### PR TITLE
📝 docs: 커밋 탬플릿 추가

### DIFF
--- a/.commit-template.txt
+++ b/.commit-template.txt
@@ -1,0 +1,30 @@
+# '#'을 지워서 사용:
+#✨ feat:
+#🐛 fix:
+#♻️ refactor:
+#💄 style:
+#📝 docs:
+#✅ test:
+#💩 chore:
+
+# Body Message
+# 여러 줄의 메시지를 작성할 땐 "-"로 구분 (한 줄은 72자 이내)
+
+# Issue Tracker Number or URL
+Issue Resolved: #
+
+# --- COMMIT END ---
+# Type can be
+#  ✨ feat    : new feature
+#  🐛 fix     : bug fix
+#  ♻️ refactor: refactoring production code
+#  💄 style   : 코드 의미에 영향을 주지 않는 변경사항 (형식 지정, 세미콜론 누락 등)
+#  📝 docs    : 문서의 추가, 수정, 삭제
+#  ✅ test    : 테스트 추가, 수정, 삭제
+#  💩 chore   : 기타 변경사항 (빌드 부분 혹은 패키지 매니저 수정사항)
+# ------------------
+# Remember me ~
+#   제목 첫 글자를 대문자로
+#   제목 끝에 마침표 금지
+#   본문은 "어떻게" 보다 "무엇을", "왜" 를 설명한다.
+# ------------------


### PR DESCRIPTION
Issue Resolved: #26

## 📌 이슈 번호
- close #26 

## 🚀 구현 내용

커밋 탬플릿 문서 추가
- 로컬에서 `git config --local commit.template ".commit-template.txt"` 명령 필요

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
