### PR TITLE
Feat/#35 entity creation

### DIFF
--- a/back/src/event/entity/event.entity.ts
+++ b/back/src/event/entity/event.entity.ts
@@ -1,0 +1,33 @@
+import { Place } from 'src/place/entity/place.entity';
+import { Program } from 'src/program/entities/program.entity';
+import { Reservation } from 'src/reservation/entity/reservation.entity';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
+
+@Entity({ name: 'Event' })
+export class Event {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'timestamp', name: 'running_date' })
+  runningDate: Date;
+
+  @Column({ type: 'timestamp', name: 'reservation_open_date' })
+  reservationOpenDate: Date;
+
+  @Column({ type: 'timestamp', name: 'reservation_close_date' })
+  reservationCloseDate: Date;
+
+  @Column({ type : 'json', name: 'seat_status' })
+  seatStatus: number[][];
+
+  @ManyToOne(() => Program, (program) => program.events, { lazy: true })
+  @JoinColumn({ name: 'program_id', referencedColumnName: 'id' })
+  program: Promise<Program>;
+
+  @ManyToOne(() => Place, (place) => place.events, { lazy: true })
+  @JoinColumn({ name: 'place_id', referencedColumnName: 'id' })
+  place: Promise<Place>;
+
+  @OneToMany(() => Reservation, (reservation) => reservation.event, { lazy: true })
+  reservations: Promise<Reservation[]>;
+}

--- a/back/src/event/event.controller.spec.ts
+++ b/back/src/event/event.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventController } from './event.controller';
+import { EventService } from './event.service';
+
+describe('EventController', () => {
+  let controller: EventController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventController],
+      providers: [EventService],
+    }).compile();
+
+    controller = module.get<EventController>(EventController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/back/src/event/event.controller.ts
+++ b/back/src/event/event.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { EventService } from './event.service';
+
+@Controller('event')
+export class EventController {
+  constructor(private readonly eventService: EventService) {}
+}

--- a/back/src/event/event.module.ts
+++ b/back/src/event/event.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EventService } from './event.service';
+import { EventController } from './event.controller';
+
+@Module({
+  controllers: [EventController],
+  providers: [EventService],
+})
+export class EventModule {}

--- a/back/src/event/event.service.spec.ts
+++ b/back/src/event/event.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventService } from './event.service';
+
+describe('EventService', () => {
+  let service: EventService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EventService],
+    }).compile();
+
+    service = module.get<EventService>(EventService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/back/src/event/event.service.ts
+++ b/back/src/event/event.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EventService {}

--- a/back/src/place/entity/place.entity.ts
+++ b/back/src/place/entity/place.entity.ts
@@ -1,0 +1,36 @@
+import { Event } from 'src/event/entity/event.entity';
+import { Program } from 'src/program/entities/program.entity';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+
+@Entity({ name: 'Place' })
+export class Place {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, name: 'name' })
+  name: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'address' })
+  address: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true, name: 'overview_svg' })
+  overviewSvg: string;
+
+  @Column({ type: 'int', name: 'overview_height' })
+  overviewHeight: number;
+
+  @Column({ type: 'int', name: 'overview_width' })
+  overviewWidth: number;
+
+  @Column({ type: 'json', name: 'sections' })
+  sections: string[];
+
+  @Column({ type: 'text', name: 'overview_points' })
+  overviewPoints: string;
+
+  @OneToMany(() => Program, (program) => program.place, { lazy: true })
+  programs: Promise<Program[]>;
+
+  @OneToMany(() => Event, (event) => event.place, { lazy: true })
+  events: Promise<Event[]>;
+}

--- a/back/src/place/entity/section.entity.ts
+++ b/back/src/place/entity/section.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Place } from './place.entity';
+
+@Entity({ name: 'Section' })
+export class Section {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, name: 'name' })
+  name: string;
+
+  @Column({ type: 'int', name: 'col_len' })
+  colLen: number;
+
+  @Column({ type: 'json', name: 'seats' })
+  seats: string[];
+
+  @ManyToOne(() => Place, (place) => place.sections, { lazy: true })
+  @JoinColumn({ name: 'place_id', referencedColumnName: 'id' })
+  place: Promise<Place>;
+}

--- a/back/src/program/entities/program.entity.ts
+++ b/back/src/program/entities/program.entity.ts
@@ -1,1 +1,38 @@
-export class Program {}
+import { Event } from 'src/event/entity/event.entity';
+import { Place } from 'src/place/entity/place.entity';
+import { Reservation } from 'src/reservation/entity/reservation.entity';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
+
+@Entity({ name: 'Program' })
+export class Program {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, name: 'name' })
+  name: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'profile_url' })
+  profileUrl: string;
+
+  @Column({ type: 'int', name: 'running_time' })
+  runningTime: number;
+
+  @Column({ type: 'varchar', length: 255, name: 'genre' })
+  genre: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'actors' })
+  actors: string;
+
+  @Column({ type: 'int', name: 'price' })
+  price: number;
+
+  @ManyToOne(() => Place, (place) => place.programs, { lazy: true })
+  @JoinColumn({ name: 'place_id', referencedColumnName: 'id' })
+  place: Promise<Place>;
+
+  @OneToMany(() => Event, (event) => event.program, { lazy: true })
+  events: Promise<Event[]>;
+  
+  @OneToMany(() => Reservation, (reservation) => reservation.program, { lazy: true })
+  reservations: Promise<Reservation[]>;
+}

--- a/back/src/reservation/entity/reservation.entity.ts
+++ b/back/src/reservation/entity/reservation.entity.ts
@@ -1,0 +1,34 @@
+import { Event } from "src/event/entity/event.entity";
+import { Program } from "src/program/entities/program.entity";
+import { User } from "src/user/entity/user.entity";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity({ name : 'Reservation' })
+export class Reservation {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'timestamp', name: 'created_at' })
+  createdAt: Date;  
+
+  @Column({ type: 'timestamp', name: 'deleted_at', nullable : true })
+  deletedAt: Date;  
+
+  @Column({ type: 'int', name: 'amount' })
+  amount: number;  
+
+  @Column({ type: 'json', name : 'seats' })
+  seats: string[];  
+
+  @ManyToOne(() => Program, (program) => program.reservations, { lazy : true })
+  @JoinColumn({ name: 'program_id', referencedColumnName: 'id' })
+  program: Promise<Program>;  
+
+  @ManyToOne(() => Event, (event) => event.reservations, { lazy : true })
+  @JoinColumn({ name: 'event_id', referencedColumnName: 'id' })
+  event: Promise<Event>;  
+
+  @ManyToOne(() => User, (user) => user.reservations, { lazy : true })
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: Promise<User>;
+}

--- a/back/src/user/entity/user.entity.ts
+++ b/back/src/user/entity/user.entity.ts
@@ -1,0 +1,17 @@
+import { Reservation } from "src/reservation/entity/reservation.entity";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity({ name : 'User' })
+export class User {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, name: 'login_id',})
+  loginId: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'login_password' })
+  loginPassword: string;
+
+  @OneToMany(() => Reservation, (reservation) => reservation.user, { lazy : true })
+  reservations: Promise<Reservation[]>;
+}


### PR DESCRIPTION
## 📌 이슈 번호
- close #35 

## 🚀 구현 내용
- DB설계에 따라 도메인 엔티티 클래스 생성
- typeorm을 통한 매핑
- 
<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->
https://www.notion.so/TypeOrm-3afe7a39c14a43f09ef9d07b66ca3659?pvs=4
<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
