### PR TITLE
백엔드 Mock 모드 실행 지원

### DIFF
--- a/back/src/app.module.ts
+++ b/back/src/app.module.ts
@@ -17,15 +17,19 @@ import { MockModule } from './mock/mock.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot(ormConfig),
-    RedisModule.forRoot(redisConfig),
-    ProgramModule,
-    ReservationModule,
-    PlaceModule,
-    UtilModule,
-    UserModule,
-    BookingModule,
-    EventModule,
+    ...(process.env.MOCK_MODE !== 'true'
+      ? [
+          TypeOrmModule.forRoot(ormConfig),
+          RedisModule.forRoot(redisConfig),
+          ProgramModule,
+          ReservationModule,
+          PlaceModule,
+          UtilModule,
+          UserModule,
+          BookingModule,
+          EventModule,
+        ]
+      : []),
     MockModule,
   ],
   controllers: [AppController],


### PR DESCRIPTION
## 📌 이슈 번호
- close #61 

## 🚀 구현 내용

- [x] DB 등 환경 세팅 없이 Mock APIs 실행을 위한 모드 구현

`MOCK_MODE` 환경 변수가 `true`일 때에 활성화되며, mock 모듈 외의 모듈을 app.module에서 임포트하지 않음.

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
