### PR TITLE
좌석 선택 페이지 입장 인원 관리

### DIFF
--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -37,6 +37,11 @@ export class AuthService {
     this.redis.set(sid, JSON.stringify({ ...session, target_event: eventId }));
   }
 
+  async getUserEventTarget(sid: string) {
+    const session = JSON.parse(await this.redis.get(sid));
+    return session.target_event;
+  }
+
   async removeSession(sid: string) {
     return this.redis.unlink(sid);
   }

--- a/back/src/domains/booking/booking.module.ts
+++ b/back/src/domains/booking/booking.module.ts
@@ -5,9 +5,10 @@ import { AuthModule } from '../../auth/auth.module';
 import { EventModule } from '../event/event.module'; // Import EventModule
 
 import { BookingService } from './service/booking.service';
+import { InBookingService } from './service/in-booking.service';
 
 @Module({
   imports: [EventModule, AuthModule],
-  providers: [BookingService],
+  providers: [BookingService, InBookingService],
 })
 export class BookingModule {}

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -1,0 +1,101 @@
+import { RedisService } from '@liaoliaots/nestjs-redis';
+import { Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+
+import { AuthService } from '../../../auth/service/auth.service';
+
+type InBookingSession = {
+  sid: string;
+  bookingAmount: number;
+  bookedSeats: [number, number][];
+};
+
+@Injectable()
+export class InBookingService {
+  private readonly redis: Redis | null;
+  constructor(
+    private readonly authService: AuthService,
+    private redisService: RedisService,
+  ) {
+    this.redis = this.redisService.getOrThrow();
+  }
+
+  async insertInBooking(sid: string): Promise<boolean> {
+    const eventId = await this.getTargetEventId(sid);
+    const session: InBookingSession = {
+      sid,
+      bookingAmount: 0,
+      bookedSeats: [],
+    };
+    await this.setSession(eventId, session);
+    return true;
+  }
+
+  async removeInBooking(sid: string): Promise<void> {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    if (session) {
+      await this.redis.del(this.getSessionKey(eventId, sid));
+      await this.redis.srem(this.getEventKey(eventId), sid);
+    }
+  }
+
+  async setBookingAmount(sid: string, amount: number): Promise<void> {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+
+    session.bookingAmount = amount;
+    await this.setSession(eventId, session);
+  }
+
+  async getBookingAmount(sid: string): Promise<number> {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    return session.bookingAmount;
+  }
+
+  async addBookedSeat(sid: string, seat: [number, number]): Promise<void> {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    session.bookedSeats.push(seat);
+    await this.setSession(eventId, session);
+  }
+
+  async getBookedSeats(sid: string): Promise<[number, number][]> {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    return session.bookedSeats;
+  }
+
+  async removeBookedSeat(sid: string, seat: [number, number]): Promise<void> {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    session.bookedSeats = session.bookedSeats.filter((s) => s[0] !== seat[0] || s[1] !== seat[1]);
+    await this.setSession(eventId, session);
+  }
+
+  private getTargetEventId(sid: string) {
+    return this.authService.getUserEventTarget(sid);
+  }
+
+  private getSessionKey(eventId: number, sid: string) {
+    return `in-booking:${eventId}:session:${sid}`;
+  }
+
+  private getEventKey(eventId: number) {
+    return `in-booking:${eventId}:sessions`;
+  }
+
+  private async setSession(eventId: number, inBookingSession: InBookingSession): Promise<void> {
+    const sessionKey = this.getSessionKey(eventId, inBookingSession.sid);
+    const eventKey = this.getEventKey(eventId);
+
+    await this.redis.sadd(eventKey, inBookingSession.sid);
+    await this.redis.set(sessionKey, JSON.stringify(inBookingSession));
+  }
+
+  private async getSession(eventId: number, sid: string): Promise<InBookingSession | null> {
+    const session = await this.redis.get(this.getSessionKey(eventId, sid));
+    return session ? JSON.parse(session) : null;
+  }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- close #42 

## 🚀 구현 내용

- 좌석 선택 페이지에 들어온 인원을 관리하는 in-booking 서비스 별도 구현
- 좌석 선택 페이지 입장 인원을 Redis에서 관리
- 좌석 선택 페이지 입장/퇴장 메소드 구현
- 예매 예정 매수 설정 메소드 구현
- 선택한 좌석 기록/삭제 메소드 구현
- 기존 booking 서비스의 좌석 선택 페이지 입장 시도 메소드와 연결
- auth 서비스에 `target-event`를 조회하는 메소드 추가

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
