### PR TITLE
✨ feat: 유저의 예매 내역 조회

### DIFF
--- a/back/src/domains/reservation/controller/reservation.controller.ts
+++ b/back/src/domains/reservation/controller/reservation.controller.ts
@@ -1,8 +1,39 @@
-import { Controller } from '@nestjs/common';
+import { ClassSerializerInterceptor, Controller, Get, UseGuards, UseInterceptors } from '@nestjs/common';
+import {
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
 
+import { USER_STATUS } from 'src/auth/const/userStatus.const';
+import { SessionAuthGuard } from 'src/auth/guard/session.guard';
+import { User } from 'src/util/user-injection/user.decorator';
+import { UserParamDto } from 'src/util/user-injection/userParamDto';
+
+import { ReservationSpecificDto } from '../dto/reservationSepecificDto';
 import { ReservationService } from '../service/reservation.service';
 
 @Controller('reservation')
+@UseInterceptors(ClassSerializerInterceptor)
 export class ReservationController {
   constructor(private readonly reservationService: ReservationService) {}
+
+  @UseGuards(SessionAuthGuard(USER_STATUS.LOGIN))
+  @Get()
+  @ApiOperation({
+    summary: '유저 예매 내역 조회',
+    description: '현재 시간 <= event 시작 시간 이후의 유저 예매 내역을 조회한다.',
+  })
+  @ApiOkResponse({ description: '예매 내역 조회 성공', type: ReservationSpecificDto, isArray: true })
+  @ApiForbiddenResponse({ description: '인증되지 않은 요청', type: Error })
+  @ApiInternalServerErrorResponse({ description: '서버 내부 에러', type: Error })
+  async findReservation(@User() user: UserParamDto) {
+    try {
+      const reservations: ReservationSpecificDto[] = await this.reservationService.findUserReservation(user);
+      return reservations;
+    } catch (error) {
+      throw error;
+    }
+  }
 }

--- a/back/src/domains/reservation/dto/reservationSepecificDto.ts
+++ b/back/src/domains/reservation/dto/reservationSepecificDto.ts
@@ -1,0 +1,24 @@
+import { Expose } from 'class-transformer';
+
+export class ReservationSpecificDto {
+  constructor({ id, programName, runningDate, placeName, seats }) {
+    this.id = id;
+    this.programName = programName;
+    this.runningDate = runningDate;
+    this.placeName = placeName;
+    this.seats = seats;
+  }
+
+  id: number;
+
+  @Expose({ name: 'program-name' })
+  programName: string;
+
+  @Expose({ name: 'running-date' })
+  runningDate: Date;
+
+  @Expose({ name: 'place-name' })
+  placeName: string;
+
+  seats: string;
+}

--- a/back/src/domains/reservation/repository/reservation.repository.ts
+++ b/back/src/domains/reservation/repository/reservation.repository.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
+
+import { Reservation } from '../entity/reservation.entity';
+
+@Injectable()
+export class ReservationRepository {
+  constructor(@InjectRepository(Reservation) private ReservationRepository: Repository<Reservation>) {}
+
+  async selectAllReservationAfterNowByUser(userId: number): Promise<Reservation[]> {
+    return await this.ReservationRepository.find({
+      where: {
+        user: { id: userId },
+        event: { runningDate: MoreThanOrEqual(new Date()) },
+      },
+    });
+  }
+}

--- a/back/src/domains/reservation/reservation.module.ts
+++ b/back/src/domains/reservation/reservation.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ReservationController } from './controller/reservation.controller';
+import { Reservation } from './entity/reservation.entity';
+import { ReservedSeat } from './entity/reservedSeat.entity';
+import { ReservationRepository } from './repository/reservation.repository';
 import { ReservationService } from './service/reservation.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Reservation, ReservedSeat])],
   controllers: [ReservationController],
-  providers: [ReservationService],
+  providers: [ReservationService, ReservationRepository],
 })
 export class ReservationModule {}

--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -1,4 +1,50 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { UserParamDto } from 'src/util/user-injection/userParamDto';
+
+import { ReservationSpecificDto } from '../dto/reservationSepecificDto';
+import { Reservation } from '../entity/reservation.entity';
+import { ReservedSeat } from '../entity/reservedSeat.entity';
+import { ReservationRepository } from '../repository/reservation.repository';
 
 @Injectable()
-export class ReservationService {}
+export class ReservationService {
+  constructor(@Inject() private readonly reservationRepository: ReservationRepository) {}
+
+  async findUserReservation({ id }: UserParamDto) {
+    const reservations: Reservation[] =
+      await this.reservationRepository.selectAllReservationAfterNowByUser(id);
+    return await this.convertReservationListToSpecificDto(reservations);
+  }
+
+  private async convertReservationListToSpecificDto(
+    reservations: Reservation[],
+  ): Promise<ReservationSpecificDto[]> {
+    return Promise.all(
+      reservations.map(async (reservation: Reservation) => {
+        const [program, event, reservedSeats] = await Promise.all([
+          reservation.program,
+          reservation.event,
+          reservation.reservedSeats,
+        ]);
+        const place = await program.place;
+
+        return new ReservationSpecificDto({
+          id: reservation.id,
+          programName: program.name,
+          runningDate: event.runningDate,
+          placeName: place.name,
+          seats: this.makeStringFormatFromReservedSeats(reservedSeats),
+        });
+      }),
+    );
+  }
+
+  private makeStringFormatFromReservedSeats(reservedSeats: ReservedSeat[]) {
+    return reservedSeats
+      .map((seat) => {
+        return `${seat.section}구역 ${seat.row}행 ${seat.col}열`;
+      })
+      .join(', ');
+  }
+}


### PR DESCRIPTION
- 유저의 예매 내역 조회
- 예매 내역은 현 시간 이후 예매 내역만을 제공

Issue Resolved: #99

## 📌 이슈 번호
- close #99 

## 🚀 구현 내용
- 유저의 예매 내역 조회
- /reservation [GET] 요청 처리
- 현 시간 이후 시작하는 이벤트에 대해서만 예매 내용 제공
<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
