### PR TITLE
✨ feat: swagger-api 인증 및 쿠키 유지

### DIFF
--- a/back/src/config/setupSwagger.ts
+++ b/back/src/config/setupSwagger.ts
@@ -6,8 +6,11 @@ export function setupSwagger(app: INestApplication): void {
     .setTitle('RealTicket API Docs')
     .setDescription('RealTicket의 API 명세시 입니다.')
     .setVersion('1.0.0')
+    .addCookieAuth('SID')
     .build();
 
   const document = SwaggerModule.createDocument(app, options);
-  SwaggerModule.setup('api-docs', app, document);
+  SwaggerModule.setup('api-docs', app, document, {
+    swaggerOptions: { persistAuthorization: true },
+  });
 }


### PR DESCRIPTION
- swagger 페이지에서 인증 기능 추가
- 인증 시에 입력한 쿠키 값을 SID로 설정해서 전송 Issue Resolved: #131

## 📌 이슈 번호
- close #131 

## 🚀 구현 내용

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->
- 사용법
- https://chestnut-sense-efd.notion.site/Swagger-API-fbf94aac52ea4afa9a0ada8016ff6a83?pvs=4
<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
