### PR TITLE
실시간 좌석 관리에 Lua 스크립트 적용

### DIFF
--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -26,7 +26,6 @@ import { Observable } from 'rxjs';
 
 import { USER_STATUS } from '../../../auth/const/userStatus.const';
 import { SessionAuthGuard } from '../../../auth/guard/session.guard';
-import { AuthService } from '../../../auth/service/auth.service';
 import { SeatStatus } from '../const/seatStatus.enum';
 import { BookingAmountReqDto } from '../dto/bookingAmountReqDto';
 import { BookingAmountResDto } from '../dto/bookingAmountResDto';
@@ -43,7 +42,6 @@ export class BookingController {
     private readonly bookingService: BookingService,
     private readonly inBookingService: InBookingService,
     private readonly bookingSeatsService: BookingSeatsService,
-    private readonly authService: AuthService,
   ) {}
 
   @UseGuards(SessionAuthGuard())
@@ -90,16 +88,16 @@ export class BookingController {
   })
   @ApiOkResponse({ description: '좌석 점유/취소 성공' })
   @ApiUnauthorizedResponse({ description: '인증 실패' })
+  @ApiBadRequestResponse({ description: '잘못된 요청' })
   @ApiConflictResponse({ description: '이미 점유/취소된 좌석' })
   async updateSeatOccupancy(@Req() req: Request, @Body() dto: BookReqDto) {
     const sid = req.cookies['SID'];
-    const eventId = await this.authService.getUserEventTarget(sid);
 
     if (dto.expectedStatus === SeatStatus.RESERVE) {
-      const result = await this.bookingSeatsService.bookSeat(eventId, [dto.sectionIndex, dto.seatIndex]);
+      const result = await this.bookingSeatsService.bookSeat(sid, [dto.sectionIndex, dto.seatIndex]);
       return new BookResDto(result);
     } else if (dto.expectedStatus === SeatStatus.DELETE) {
-      const result = await this.bookingSeatsService.unBookSeat(eventId, [dto.sectionIndex, dto.seatIndex]);
+      const result = await this.bookingSeatsService.unBookSeat(sid, [dto.sectionIndex, dto.seatIndex]);
       return new BookResDto(result);
     }
   }

--- a/back/src/domains/booking/luaScripts/getSeatsLua.ts
+++ b/back/src/domains/booking/luaScripts/getSeatsLua.ts
@@ -1,0 +1,21 @@
+import Redis from 'ioredis';
+
+const getSeatsLua = `
+  local eventId = KEYS[1]
+  local sectionsLen = redis.call('GET', 'event:'..eventId..':sections:len')
+  
+  local result = {}
+  for i = 0, tonumber(sectionsLen)-1 do
+    local seatsLen = redis.call('GET', 'event:'..eventId..':section:'..i..':seats:len')
+    for j = 0, tonumber(seatsLen)-1 do
+      table.insert(result, redis.call('GETBIT', 'event:'..eventId..':section:'..i..':seats', j))
+    end  
+  end
+  
+  return result
+`;
+
+export async function runGetSeatsLua(redis: Redis, eventId: number): Promise<number[]> {
+  // @ts-expect-error Lua 스크립트 실행 결과 타입의 자동 추론이 불가능하여, 직접 명시하기 위함.
+  return redis.eval(getSeatsLua, 1, eventId);
+}

--- a/back/src/domains/booking/luaScripts/initSectionSeatLua.ts
+++ b/back/src/domains/booking/luaScripts/initSectionSeatLua.ts
@@ -1,0 +1,24 @@
+import Redis from 'ioredis';
+
+const initSectionSeatLua = `
+  local key = KEYS[1]
+  local lenKey = KEYS[1] .. ':len'
+  local bitString = ARGV[1]
+  local totalBits = string.len(bitString)
+  
+  redis.call('DEL', key)
+  
+  for i = 1, totalBits do
+     local bit = string.sub(bitString, i, i)
+     redis.call('SETBIT', key, i-1, bit)
+  end
+  
+  redis.call('SET', lenKey, totalBits)
+  
+  return 1
+  `;
+
+export async function runInitSectionSeatLua(redis: Redis, key: string, seatBitMap: string): Promise<number> {
+  // @ts-expect-error Lua 스크립트 실행 결과 타입의 자동 추론이 불가능하여, 직접 명시하기 위함.
+  return redis.eval(initSectionSeatLua, 1, key, seatBitMap);
+}

--- a/back/src/domains/booking/luaScripts/setSectionsLenLua.ts
+++ b/back/src/domains/booking/luaScripts/setSectionsLenLua.ts
@@ -1,0 +1,19 @@
+import Redis from 'ioredis';
+
+const setSectionsLenLua = `
+  local eventId = KEYS[1]
+  local sectionsLen = KEYS[2]
+  
+  redis.call('SET', 'event:'..eventId..':sections:len', sectionsLen)
+  
+  return 'OK'
+  `;
+
+export async function runSetSectionsLenLua(
+  redis: Redis,
+  eventId: number,
+  sectionsLen: number,
+): Promise<number> {
+  // @ts-expect-error Lua 스크립트 실행 결과 타입의 자동 추론이 불가능하여, 직접 명시하기 위함.
+  return redis.eval(setSectionsLenLua, 2, eventId, sectionsLen.toString());
+}

--- a/back/src/domains/booking/luaScripts/updateSeatLua.ts
+++ b/back/src/domains/booking/luaScripts/updateSeatLua.ts
@@ -1,0 +1,30 @@
+import Redis from 'ioredis';
+
+const updateSeatLua = `
+    local key = KEYS[1]
+    local lenKey = KEYS[1] .. ':len'
+    local index = tonumber(ARGV[1])
+    local value = tonumber(ARGV[2])
+    
+    local maxLength = redis.call('GET', lenKey)
+    if index < 0 or index >= tonumber(maxLength) then
+      return nil
+    end
+    
+    local currentValue = redis.call('GETBIT', key, index)
+    if currentValue ~= value then
+      redis.call('SETBIT', key, index, value)
+      return 1
+    end
+    return 0
+  `;
+
+export async function runUpdateSeatLua(
+  redis: Redis,
+  sectionKey: string,
+  seatIndex: number,
+  value: 0 | 1,
+): Promise<number | 'nil'> {
+  // @ts-expect-error Lua 스크립트 실행 결과 타입의 자동 추론이 불가능하여, 직접 명시하기 위함.
+  return redis.eval(updateSeatLua, 1, sectionKey, seatIndex, value);
+}

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -1,63 +1,117 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { ConflictException, Injectable } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
 import { interval, Observable, switchMap } from 'rxjs';
 
+import { AuthService } from '../../../auth/service/auth.service';
 import { SeatStatus } from '../const/seatStatus.enum';
+import { runGetSeatsLua } from '../luaScripts/getSeatsLua';
+import { runInitSectionSeatLua } from '../luaScripts/initSectionSeatLua';
+import { runSetSectionsLenLua } from '../luaScripts/setSectionsLenLua';
+import { runUpdateSeatLua } from '../luaScripts/updateSeatLua';
+
+import { InBookingService } from './in-booking.service';
 
 @Injectable()
 export class BookingSeatsService {
   private readonly redis: Redis | null;
-  constructor(private redisService: RedisService) {
+
+  constructor(
+    private redisService: RedisService,
+    private inBookingService: InBookingService,
+    private authService: AuthService,
+  ) {
     this.redis = this.redisService.getOrThrow();
   }
 
   async openReservation(eventId: number, seats: boolean[][]) {
-    await this.redis.set(`event:${eventId}:seats`, JSON.stringify(seats));
+    seats.forEach((section, sectionIndex) => {
+      const seatBitMap = section.map((seat) => (seat ? '1' : '0')).join('');
+      const key = `event:${eventId}:section:${sectionIndex}:seats`;
+      runInitSectionSeatLua(this.redis, key, seatBitMap);
+    });
+    await runSetSectionsLenLua(this.redis, eventId, seats.length);
   }
 
-  //TODO: 트랜잭션 관리 필요
-  async bookSeat(eventId: number, target: [number, number]) {
-    const [sectionIndex, seatIndex] = target;
-    const seatsData = await this.redis.get(`event:${eventId}:seats`);
-    const seats = JSON.parse(seatsData);
+  async bookSeat(sid: string, target: [number, number]) {
+    const eventId = await this.authService.getUserEventTarget(sid);
+    const bookedSeat = await this.inBookingService.getBookedSeats(sid);
+    const bookingAmount = await this.inBookingService.getBookingAmount(sid);
+    const bookedAmount = bookedSeat.length;
 
-    if (seats[sectionIndex][seatIndex] === false) {
+    if (bookingAmount <= bookedAmount) {
+      throw new BadRequestException('예약 가능한 좌석 수를 초과했습니다.');
+    }
+
+    const result = await this.updateSeatReserved(eventId, target);
+    if (result) {
+      await this.inBookingService.addBookedSeat(sid, target);
+    }
+    return result;
+  }
+
+  async unBookSeat(sid: string, target: [number, number]) {
+    const eventId = await this.authService.getUserEventTarget(sid);
+    const bookedSeat = await this.inBookingService.getBookedSeats(sid);
+    const bookedAmount = bookedSeat.length;
+
+    if (bookedAmount === 0) {
+      throw new BadRequestException('취소할 수 있는 좌석이 없습니다.');
+    }
+    if (!bookedSeat.some((seat) => seat[0] === target[0] && seat[1] === target[1])) {
+      throw new BadRequestException('예약하지 않은 좌석입니다.');
+    }
+
+    const result = await this.updateSeatDeleted(eventId, target);
+    if (result) {
+      await this.inBookingService.removeBookedSeat(sid, target);
+    }
+    return result;
+  }
+
+  async updateSeatReserved(eventId: number, target: [number, number]) {
+    const [sectionIndex, seatIndex] = target;
+    const key = `event:${eventId}:section:${sectionIndex}:seats`;
+
+    const result = await runUpdateSeatLua(this.redis, key, seatIndex, 0);
+
+    if (result === 'nil') {
+      throw new BadRequestException('좌석이 존재하지 않습니다.');
+    } else if (result === 0) {
       throw new ConflictException('이미 예약된 좌석입니다.');
+    } else {
+      return {
+        eventId,
+        sectionIndex,
+        seatIndex,
+        acceptedStatus: SeatStatus.RESERVE,
+      };
     }
-    seats[sectionIndex][seatIndex] = false;
-
-    await this.redis.set(`event:${eventId}:seats`, JSON.stringify(seats));
-    return {
-      eventId,
-      sectionIndex,
-      seatIndex,
-      acceptedStatus: SeatStatus.RESERVE,
-    };
   }
 
-  async unBookSeat(eventId: number, target: [number, number]) {
+  async updateSeatDeleted(eventId: number, target: [number, number]) {
     const [sectionIndex, seatIndex] = target;
-    const seatsData = await this.redis.get(`event:${eventId}:seats`);
-    const seats = JSON.parse(seatsData);
+    const key = `event:${eventId}:section:${sectionIndex}:seats`;
 
-    if (seats[sectionIndex][seatIndex] === true) {
+    const result = await runUpdateSeatLua(this.redis, key, seatIndex, 1);
+
+    if (result === 'nil') {
+      throw new BadRequestException('좌석이 존재하지 않습니다.');
+    } else if (result === 0) {
       throw new ConflictException('이미 취소된 좌석입니다.');
+    } else {
+      return {
+        eventId,
+        sectionIndex,
+        seatIndex,
+        acceptedStatus: SeatStatus.DELETE,
+      };
     }
-    seats[sectionIndex][seatIndex] = true;
-
-    await this.redis.set(`event:${eventId}:seats`, JSON.stringify(seats));
-    return {
-      eventId,
-      sectionIndex,
-      seatIndex,
-      acceptedStatus: SeatStatus.DELETE,
-    };
   }
 
-  async getSeats(eventId: number): Promise<boolean[][]> {
-    const seatsData = await this.redis.get(`event:${eventId}:seats`);
-    return JSON.parse(seatsData);
+  async getSeats(eventId: number) {
+    const seatStatusBits = await runGetSeatsLua(this.redis, eventId);
+    return seatStatusBits.map((bit) => bit === 1);
   }
 
   subscribeSeats(eventId: number): Observable<any> {


### PR DESCRIPTION
## 📌 이슈 번호
- close #142

## 🚀 구현 내용

- Redis 조작 로직에 Lua 스크립트 적용
  - 좌석 현황 데이터에 접근하는 로직을 모두 Lua 스크립트로 전환하여 동시성 이슈 해결
  - 좌석 현황의 수정을 부분 수정 방식으로 변경하여 성능 개선
    - 부분 수정의 성능을 극대화 할 수 있는 Bit맵 타입으로 Redis 내 저장 형태 변경(API 반환 타입은 그대로)

## 특이사항

lua 스크립트는 최후의 수단으로 사용되어야 한다. 유지 보수와 협업에 치명적이기 때문이다. 이 부분을 인지해야 한다.

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
