### PR TITLE
SSE 브로드캐스트 리팩토링

### DIFF
--- a/back/src/domains/booking/const/seatsBroadcastInterval.const.ts
+++ b/back/src/domains/booking/const/seatsBroadcastInterval.const.ts
@@ -1,0 +1,1 @@
+export const SEATS_BROADCAST_INTERVAL = 500;

--- a/back/src/domains/booking/const/seatsSseRetryTime.const.ts
+++ b/back/src/domains/booking/const/seatsSseRetryTime.const.ts
@@ -1,0 +1,1 @@
+export const SEATS_SSE_RETRY_TIME = 5000;

--- a/back/src/domains/booking/luaScripts/getSeatsLua.ts
+++ b/back/src/domains/booking/luaScripts/getSeatsLua.ts
@@ -4,18 +4,20 @@ const getSeatsLua = `
   local eventId = KEYS[1]
   local sectionsLen = redis.call('GET', 'event:'..eventId..':sections:len')
   
-  local result = {}
+  local placeResult = {}
   for i = 0, tonumber(sectionsLen)-1 do
     local seatsLen = redis.call('GET', 'event:'..eventId..':section:'..i..':seats:len')
+    local sectionResult = {}
     for j = 0, tonumber(seatsLen)-1 do
-      table.insert(result, redis.call('GETBIT', 'event:'..eventId..':section:'..i..':seats', j))
-    end  
+      table.insert(sectionResult, redis.call('GETBIT', 'event:'..eventId..':section:'..i..':seats', j))
+    end
+    table.insert(placeResult, sectionResult)  
   end
   
-  return result
+  return placeResult
 `;
 
-export async function runGetSeatsLua(redis: Redis, eventId: number): Promise<number[]> {
+export async function runGetSeatsLua(redis: Redis, eventId: number): Promise<number[][]> {
   // @ts-expect-error Lua 스크립트 실행 결과 타입의 자동 추론이 불가능하여, 직접 명시하기 위함.
   return redis.eval(getSeatsLua, 1, eventId);
 }

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -111,7 +111,7 @@ export class BookingSeatsService {
 
   async getSeats(eventId: number) {
     const seatStatusBits = await runGetSeatsLua(this.redis, eventId);
-    return seatStatusBits.map((bit) => bit === 1);
+    return seatStatusBits.map((sectionBits) => sectionBits.map((bit) => bit === 1));
   }
 
   subscribeSeats(eventId: number): Observable<any> {


### PR DESCRIPTION
## 📌 이슈 번호
- close #161 

## 🚀 구현 내용

- SSE 연결마다 새 Observable 객체가 생성되지 않도록 함.
- 이벤트마다 Subject 객체가 하나씩 생성되어 이로부터 여러 클라이언트에게 브로드캐스트하는 기능 구현


<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
