### PR TITLE
RDB에 Section.seats 저장 타입 일치 문제

### DIFF
--- a/back/src/domains/booking/service/open-booking.service.ts
+++ b/back/src/domains/booking/service/open-booking.service.ts
@@ -41,12 +41,8 @@ export class OpenBookingService implements OnApplicationBootstrap {
     const sections = await Promise.all(
       place.sections.map((sectionId) => this.sectionRepository.selectSection(parseInt(sectionId))),
     );
-    const seats = sections.map((section) => section.seats.map((seat) => parseBooleanString(seat)));
+    const seats = sections.map((section) => section.seats);
     await this.seatsUpdateService.openReservation(eventId, seats);
     this.openedEvents.add(eventId);
   }
 }
-
-const parseBooleanString = (str: string): boolean => {
-  return str === 'true';
-};

--- a/back/src/domains/place/entity/section.entity.ts
+++ b/back/src/domains/place/entity/section.entity.ts
@@ -14,7 +14,7 @@ export class Section {
   colLen: number;
 
   @Column({ type: 'json', name: 'seats' })
-  seats: string[];
+  seats: boolean[];
 
   @ManyToOne(() => Place, (place) => place.sections, { lazy: true })
   @JoinColumn({ name: 'place_id', referencedColumnName: 'id' })


### PR DESCRIPTION
## 📌 이슈 번호
- close #183 

## 🚀 구현 내용
- RDB에 Section.seats가 `string[]`으로 저장된다 가정하고 있던 로직을 `boolean[]`으로 변경함.


<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
