### PR TITLE
관리자 기능: 좌석 선택 페이지 입장 가능 인원 조정

### DIFF
--- a/back/src/domains/booking/const/inBookingDefaultMaxSize.const.ts
+++ b/back/src/domains/booking/const/inBookingDefaultMaxSize.const.ts
@@ -1,0 +1,1 @@
+export const IN_BOOKING_DEFAULT_MAX_SIZE = 100;

--- a/back/src/domains/booking/const/inBookingPoolSize.const.ts
+++ b/back/src/domains/booking/const/inBookingPoolSize.const.ts
@@ -1,1 +1,0 @@
-export const IN_BOOKING_POOL_SIZE = 100;

--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -31,6 +31,8 @@ import { BookingAmountReqDto } from '../dto/bookingAmountReqDto';
 import { BookingAmountResDto } from '../dto/bookingAmountResDto';
 import { BookReqDto } from '../dto/bookReqDto';
 import { BookResDto } from '../dto/bookResDto';
+import { InBookingSizeReqDto } from '../dto/inBookingSizeReq.dto';
+import { InBookingSizeResDto } from '../dto/inBookingSizeRes.dto';
 import { SeatsSseDto } from '../dto/seatsSse.dto';
 import { ServerTimeDto } from '../dto/serverTime.dto';
 import { WaitingSseDto } from '../dto/waitingSse.dto';
@@ -134,5 +136,33 @@ export class BookingController {
   @Get('server-time')
   async getServerTime() {
     return await this.bookingService.getTimeMs();
+  }
+
+  @Post('in-booking-pool-size/event/:eventId')
+  @UseGuards(SessionAuthGuard(USER_STATUS.ADMIN))
+  @ApiOperation({
+    summary: 'ADMIN: 좌석 선택창 인원 설정',
+    description: '특정 이벤트의 좌석 선택창에 입장 가능한 인원 수를 설정한다.',
+  })
+  @ApiOkResponse({ description: '인원 설정 성공', type: InBookingSizeResDto })
+  @ApiUnauthorizedResponse({ description: '인증 실패' })
+  async setInBookingSessionsMaxSize(@Param('eventId') eventId: number, @Body() dto: InBookingSizeReqDto) {
+    const maxSize = dto.maxSize;
+    const setSize = await this.inBookingService.setInBookingSessionsMaxSize(eventId, maxSize);
+    return new InBookingSizeResDto(setSize);
+  }
+
+  @Post('in-booking-pool-size/all')
+  @UseGuards(SessionAuthGuard(USER_STATUS.ADMIN))
+  @ApiOperation({
+    summary: 'ADMIN: 좌석 선택창 인원 설정(ALL)',
+    description: '모든 이벤트의 좌석 선택창에 입장 가능한 인원 수를 설정한다.',
+  })
+  @ApiOkResponse({ description: '인원 설정 성공', type: InBookingSizeResDto })
+  @ApiUnauthorizedResponse({ description: '인증 실패' })
+  async setAllInBookingSessionsMaxSize(@Body() dto: InBookingSizeReqDto) {
+    const maxSize = dto.maxSize;
+    const setSize = await this.inBookingService.setAllInBookingSessionsMaxSize(maxSize);
+    return new InBookingSizeResDto(setSize);
   }
 }

--- a/back/src/domains/booking/dto/inBookingSizeReq.dto.ts
+++ b/back/src/domains/booking/dto/inBookingSizeReq.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InBookingSizeReqDto {
+  @ApiProperty({
+    name: 'maxSize',
+    type: Number,
+    example: 100,
+    description: '설정할 크기',
+  })
+  maxSize: number;
+}

--- a/back/src/domains/booking/dto/inBookingSizeRes.dto.ts
+++ b/back/src/domains/booking/dto/inBookingSizeRes.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InBookingSizeResDto {
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  @ApiProperty({
+    name: 'maxSize',
+    type: Number,
+    example: 100,
+  })
+  maxSize: number;
+}

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
 
 import { AuthService } from '../../../auth/service/auth.service';
 import { EventService } from '../../event/service/event.service';
@@ -22,13 +23,29 @@ export class BookingService {
     private readonly waitingQueueService: WaitingQueueService,
   ) {}
 
+  @OnEvent('seats-sse-close')
+  async letInNextWaiting(event: { sid: string }) {
+    const eventId = await this.authService.getUserEventTarget(event.sid);
+    if ((await this.waitingQueueService.getQueueSize(eventId)) < 1) {
+      return;
+    }
+    if (await this.inBookingService.isInsertable(eventId)) {
+      const item = await this.waitingQueueService.popQueue(eventId);
+      if (!item) {
+        return;
+      }
+      await this.authService.setUserStatusSelectingSeat(item.sid);
+    }
+  }
+
   // 함수 이름 생각하기
   async isAdmission(eventId: number, sid: string): Promise<BookingAdmissionStatusDto> {
     // eventId를 받아서 해당 이벤트가 존재하는지 확인한다.
     const event = await this.eventService.findEvent({ eventId });
     const now = new Date(Date.now() + OFFSET);
+    const isOpened = await this.openBookingService.isEventOpened(eventId);
 
-    if (!this.openBookingService.isEventOpened(eventId)) {
+    if (!isOpened) {
       throw new BadRequestException('아직 예약이 오픈되지 않았습니다.');
     } else if (now >= event.reservationCloseDate) {
       //event 시간 확인 이벤트 종료시간 이후인지

--- a/back/src/domains/booking/service/open-booking.service.ts
+++ b/back/src/domains/booking/service/open-booking.service.ts
@@ -1,28 +1,33 @@
+import { RedisService } from '@liaoliaots/nestjs-redis';
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import Redis from 'ioredis';
 
 import { Event } from '../../event/entity/event.entity';
 import { EventRepository } from '../../event/repository/event.reposiotry';
 import { SectionRepository } from '../../place/repository/section.repository';
+import { IN_BOOKING_DEFAULT_MAX_SIZE } from '../const/inBookingDefaultMaxSize.const';
 
 import { BookingSeatsService } from './booking-seats.service';
+import { InBookingService } from './in-booking.service';
 
 @Injectable()
 export class OpenBookingService implements OnApplicationBootstrap {
-  private openedEvents = new Set<number>();
+  private readonly redis: Redis | null;
 
   constructor(
+    private redisService: RedisService,
     private eventRepository: EventRepository,
     private sectionRepository: SectionRepository,
+    private inBookingService: InBookingService,
     private seatsUpdateService: BookingSeatsService,
-  ) {}
+  ) {
+    this.redis = this.redisService.getOrThrow();
+  }
 
   async onApplicationBootstrap() {
     await this.checkAndOpenReservations();
-  }
-
-  isEventOpened(eventId: number) {
-    return this.openedEvents.has(eventId);
+    await this.inBookingService.setInBookingSessionsDefaultMaxSize(IN_BOOKING_DEFAULT_MAX_SIZE);
   }
 
   @Cron(CronExpression.EVERY_HOUR)
@@ -35,14 +40,27 @@ export class OpenBookingService implements OnApplicationBootstrap {
     await Promise.all(eventsToOpen.map((event) => this.openReservation(event)));
   }
 
+  async isEventOpened(eventId: number) {
+    return (await this.redis.get(`open-booking:${eventId}:opened`)) === 'true';
+  }
+
   private async openReservation(event: Event) {
     const eventId = event.id;
     const place = await event.place;
     const sections = await Promise.all(
       place.sections.map((sectionId) => this.sectionRepository.selectSection(parseInt(sectionId))),
     );
-    const seats = sections.map((section) => section.seats);
-    await this.seatsUpdateService.openReservation(eventId, seats);
-    this.openedEvents.add(eventId);
+
+    const defaultMaxSize = await this.inBookingService.getInBookingSessionsDefaultMaxSize();
+    await this.inBookingService.setInBookingSessionsMaxSize(eventId, defaultMaxSize);
+
+    const initialSeats = sections.map((section) => section.seats);
+    await this.seatsUpdateService.openReservation(eventId, initialSeats);
+
+    await this.registerOpenedEvent(eventId);
+  }
+
+  private async registerOpenedEvent(eventId: number) {
+    await this.redis.set(`open-booking:${eventId}:opened`, 'true');
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- close #197

## 🚀 구현 내용

- 예매가 열려 있는 특정 이벤트에 대해 좌석 선택 페이지 입장 가능 인원 수를 설정하는 관리자용 API 구현
- 예매가 열려 있는 모든 이벤트에 대해 좌석 선택 페이지 입장 가능 인원 수를 설정하는 관리자용 API 구현

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
