### PR TITLE
좌석 예매 secion_id 참조를 section_index참조하도록 변경

### DIFF
--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -176,16 +176,16 @@ export class ReservationService {
     reservationResult: Reservation,
   ) {
     const sections = reservationCreateDto.seats.map((seat) => {
-      if (!place.sections.includes(seat.sectionIndex.toString())) {
-        throw new BadRequestException(`해당 section이 존재하지 않습니다. sectionId: ${seat.sectionIndex}`);
+      if (!place.sections[seat.sectionIndex]) {
+        throw new BadRequestException(`해당 section이 존재하지 않습니다. sectionIndex: ${seat.sectionIndex}`);
       }
-      return seat.sectionIndex;
+      return Number.parseInt(place.sections[seat.sectionIndex]);
     });
 
     const sectionInfo = await queryRunner.manager.find(Section, { where: { id: In(sections) } });
 
-    const reservedSeatsInfo: any = reservationCreateDto.seats.map((seat) => {
-      const section = sectionInfo.find((section) => section.id === seat.sectionIndex);
+    const reservedSeatsInfo: any = reservationCreateDto.seats.map((seat, index) => {
+      const section = sectionInfo.find((section) => section.id === sections[index]);
       if (seat.seatIndex >= section.seats.length || seat.seatIndex < 0) {
         throw new BadRequestException(
           `해당 section의 seat이 존재하지 않습니다. seatIndex: ${seat.seatIndex}`,


### PR DESCRIPTION
- 예약 확정 요청에서 secionid를 참조하던 부분을 secionIndex를 참조하도록 변경 Issue Resolved: #

## 📌 이슈 번호
- close #200

## 🚀 구현 내용
- 예매 확정 요청에서 보내주는 secionIndex를 sectionId를 참조하는것으로 착각했습니다. 이부분을 수정해서 secionIndex를 참조하도록 변경했습니다.

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
