### PR TITLE
중복 로그인 방지로직

### DIFF
--- a/back/src/auth/guard/session.guard.ts
+++ b/back/src/auth/guard/session.guard.ts
@@ -21,10 +21,10 @@ export function SessionAuthGuard(userStatus: string = USER_STATUS.LOGIN) {
 
       const sessionId = request.cookies.SID;
       const session = JSON.parse(await this.redis.get(`user:${sessionId}`));
-      this.redis.expireat(`user:${sessionId}`, Math.round(Date.now() / 1000) + EXPIRE_TIME);
       // TODO
       // userStatus, target_event를 비교하여 접근 허용 여부를 판단
       if (session && USER_LEVEL[session.userStatus] >= USER_LEVEL[userStatus]) {
+        this.redis.expireat(`user:${sessionId}`, Math.round(Date.now() / 1000) + EXPIRE_TIME);
         return true;
       } else if (!session) {
         throw new ForbiddenException('접근 권한이 없습니다.');

--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -58,7 +58,8 @@ export class AuthService {
     return session.targetEvent;
   }
 
-  async removeSession(sid: string) {
+  async removeSession(sid: string, loginId: string) {
+    this.redis.unlink(`user-id:${loginId}`);
     return this.redis.unlink(`user:${sid}`);
   }
 

--- a/back/src/domains/user/controller/user.controller.ts
+++ b/back/src/domains/user/controller/user.controller.ts
@@ -24,6 +24,8 @@ import { Request, Response } from 'express';
 
 import { USER_STATUS } from '../../../auth/const/userStatus.const';
 import { SessionAuthGuard } from '../../../auth/guard/session.guard';
+import { User } from '../../../util/user-injection/user.decorator';
+import { UserParamDto } from '../../../util/user-injection/userParamDto';
 import { USER_ROLE } from '../const/userRole';
 import { UserCreateDto } from '../dto/userCreate.dto';
 import { UserLoginDto } from '../dto/userLogin.dto';
@@ -124,9 +126,9 @@ export class UserController {
   @ApiForbiddenResponse({ description: '접근 권한이 없습니다.' })
   @UseGuards(SessionAuthGuard(USER_STATUS.LOGIN))
   @Post('logout')
-  async getUserLogout(@Req() req: Request) {
+  async getUserLogout(@Req() req: Request, @User() user: UserParamDto) {
     const sid = req.cookies['SID'];
-    return await this.userService.logoutUser(sid);
+    return await this.userService.logoutUser(sid, user);
   }
 
   @ApiOperation({ summary: '사용자 정보', description: '사용자 정보 요청을 처리한다. 사용자 ID를 불러온다.' })


### PR DESCRIPTION
## 📌 이슈 번호
- close #202 

## 🚀 구현 내용
- 기존 redis에 key는 user:${sid}  value에는 {userid, loginid, role}등을 정보를 저장하는 구조이고 중복로그인을 대처하지 못했던 문제가 있었습니다.
- 중복 로그인을 방지하기위해서 sessio에 적합한 방식을 찾다 redis에 login한 user의 id를 하나 더 저장해서 운영하는 방식을 사용했습니다.
- 로그인 시 총 두개의 key-value가redis에 등록됩니다. 
  - 하나는 위에서 설명한   key는 user:${sid}  value에는 {userid, loginid, role}등을 정보를 저장하는 key-value쌍
  - 다른 하나는 key user-id:{loginid} value는 sid 값을 가지는 key-value쌍입니다.
  - 이 두개의 쌍을 이용해서 로그인 요청시 user-id:${login요청을 보낸 유저의 loginID}가 있는지 확인 후 없다면 위에서 언급한 두개의 key-value쌍을 redis에 등록합니다.
  - 만약 로그인한 유저가 있다면 로그인 처리를 하고 이 값을 갱신하도록 합니다.
-  위과정을 통해서 중복 로그인 방지 로직을 추가했습니다. 

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
