### PR TITLE
좌석 확정 시 선점한 좌석과 예약하는 좌석과 비교하는 로직

### DIFF
--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -151,4 +151,12 @@ export class InBookingService {
   private async getInBookingSessionsSize(eventId: number): Promise<number> {
     return this.redis.scard(this.getEventKey(eventId));
   }
+
+  async getBookAmountAndBookedSeats(sid: string, eventId: number) {
+    const session = await this.getSession(eventId, sid);
+    return {
+      bookingAmount: session.bookingAmount,
+      bookedSeats: session.bookedSeats,
+    };
+  }
 }

--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -94,7 +94,17 @@ export class ReservationService {
       const session = await this.authService.getUserSession(sid);
       const userId = session.id;
       const eventId = await this.authService.getUserEventTarget(sid);
-      const bookingAmount = await this.inBookingService.getBookingAmount(sid);
+      const { bookingAmount, bookedSeats } = await this.inBookingService.getBookAmountAndBookedSeats(
+        sid,
+        eventId,
+      );
+
+      reservationCreateDto.seats.forEach((seat) => {
+        const arr = [seat.sectionIndex, seat.seatIndex];
+        if (!bookedSeats.find((bookedSeat) => JSON.stringify(bookedSeat) === JSON.stringify(arr))) {
+          throw new BadRequestException('선점하지 않은 좌석이 포함되어 있습니다.');
+        }
+      });
 
       if (reservationCreateDto.eventId !== eventId || reservationCreateDto.seats.length !== bookingAmount) {
         throw new BadRequestException('예매 정보 또는 설정한 좌석수가 올바르지 않습니다.');


### PR DESCRIPTION
- 예매 요청으로 들어온 좌석과 redis session속 bookedSeats 좌석이 동일한지 확인하는 로직 추가 Issue Resolved: #

## 📌 이슈 번호
- close #206 

## 🚀 구현 내용
- 좌석 확정 시 좌석 선택 페이지에서 선점한 좌석과 예매 확정요청으로 보낸 좌석 데이터가 동일한지 확인하는 로직을 추가했습니다.
- 다를경우 또는 없는 좌석을 신청할 경우 예외가 발생되고 클라이언트로는 stats400에 예매가 실패했다는 응답을 보내도록 했습니다. 

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
