### PR TITLE
좌석 선택 페이지 기본 최대 인원 수 설정 문제

### DIFF
--- a/back/src/domains/booking/service/open-booking.service.ts
+++ b/back/src/domains/booking/service/open-booking.service.ts
@@ -26,8 +26,8 @@ export class OpenBookingService implements OnApplicationBootstrap {
   }
 
   async onApplicationBootstrap() {
-    await this.checkAndOpenReservations();
     await this.inBookingService.setInBookingSessionsDefaultMaxSize(IN_BOOKING_DEFAULT_MAX_SIZE);
+    await this.checkAndOpenReservations();
   }
 
   @Cron(CronExpression.EVERY_HOUR)


### PR DESCRIPTION
## 📌 이슈 번호
- close #214 

## 🚀 구현 내용

- 이벤트의 좌석 선택 페이지 입장 인원 수 설정 로직보다, 좌석 선택 페이지 기본 최대 인원 수 설정이 먼저 행해지도록 순서 변경

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
