### PR TITLE
관리자 기능: 좌석 선택 페이지 기본 사이즈 설정

### DIFF
--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -165,4 +165,18 @@ export class BookingController {
     const setSize = await this.inBookingService.setAllInBookingSessionsMaxSize(maxSize);
     return new InBookingSizeResDto(setSize);
   }
+
+  @Post('in-booking-pool-size/default')
+  @UseGuards(SessionAuthGuard(USER_STATUS.ADMIN))
+  @ApiOperation({
+    summary: 'ADMIN: 좌석 선택창 인원 기본값 설정',
+    description: '좌석 선택창에 입장 가능한 인원 수의 기본값을 설정한다.',
+  })
+  @ApiOkResponse({ description: '기본값 설정 성공', type: InBookingSizeResDto })
+  @ApiUnauthorizedResponse({ description: '인증 실패' })
+  async setInBookingSessionsDefaultMaxSize(@Body() dto: InBookingSizeReqDto) {
+    const defaultMaxSize = dto.maxSize;
+    const setSize = await this.inBookingService.setInBookingSessionsDefaultMaxSize(defaultMaxSize);
+    return new InBookingSizeResDto(setSize);
+  }
 }

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -35,6 +35,8 @@ export class InBookingService {
 
   async setInBookingSessionsDefaultMaxSize(size: number) {
     await this.redis.set('in-booking:default-max-size', size);
+    const defaultMaxSize = parseInt(await this.redis.get('in-booking:default-max-size'));
+    return defaultMaxSize;
   }
 
   async setInBookingSessionsMaxSize(eventId: number, size: number) {


### PR DESCRIPTION
## 📌 이슈 번호
- close #217 

## 🚀 구현 내용

이벤트가 새로 오픈될 때 참조할, 좌석 선택 페이지의 기본 사이즈를 설정하는 API

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
