### PR TITLE
예약 확정 createdAt 한국 시간 출력되도록 변경

### DIFF
--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -20,6 +20,8 @@ import { Reservation } from '../entity/reservation.entity';
 import { ReservedSeat } from '../entity/reservedSeat.entity';
 import { ReservationRepository } from '../repository/reservation.repository';
 
+const OFFSET = 1000 * 60 * 60 * 9;
+
 @Injectable()
 export class ReservationService {
   private redis: Redis;
@@ -169,7 +171,7 @@ export class ReservationService {
     program: Program,
   ) {
     const reservationData: any = {
-      createdAt: new Date(),
+      createdAt: new Date(Date.now() + OFFSET),
       amount: reservationCreateDto.seats.length,
       program: program,
       event: event[0],


### PR DESCRIPTION
Issue Resolved: #

## 📌 이슈 번호
- close #224

## 🚀 구현 내용
- 예약 내역에서 createdAt이 한국시간으로 안되는 버그가 있었는데 이를 해결했습니다.

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
