### PR TITLE
대기 큐: 대기자가 없을 때 headOrder null반환 문제

### DIFF
--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -90,6 +90,10 @@ export class WaitingQueueService {
   private async getHeadOrder(eventId: number) {
     const headItem = await this.redis.lindex(`waiting-queue:${eventId}`, 0);
     const headOrder = headItem ? JSON.parse(headItem).order : null;
+    if (!headOrder) {
+      const recentHeadOrder = parseInt(await this.redis.get(`waiting-queue:${eventId}:order`));
+      return recentHeadOrder + 1;
+    }
     return headOrder;
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- close #231 

## 🚀 구현 내용

- head 대기자를 불러왔을 때 결과가 없다면 '다음 발급될 번호표 순서'를 대신 반환하여 해결

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
