### PR TITLE
좌석 선택 중 이탈 시 좌석 회수

### DIFF
--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -10,6 +10,7 @@ type InBookingSession = {
   sid: string;
   bookingAmount: number;
   bookedSeats: [number, number][];
+  saved: boolean;
 };
 
 @Injectable()
@@ -61,6 +62,7 @@ export class InBookingService {
       sid,
       bookingAmount,
       bookedSeats: [],
+      saved: false,
     };
     await this.setSession(eventId, session);
     return true;
@@ -102,6 +104,19 @@ export class InBookingService {
     await this.setSession(eventId, session);
   }
 
+  async getIsSaved(sid: string) {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    return session.saved;
+  }
+
+  async setIsSaved(sid: string, saved: boolean) {
+    const eventId = await this.getTargetEventId(sid);
+    const session = await this.getSession(eventId, sid);
+    session.saved = saved;
+    await this.setSession(eventId, session);
+  }
+
   async emitSession(sid: string) {
     const eventId = await this.getTargetEventId(sid);
     await this.removeInBooking(eventId, sid);
@@ -129,7 +144,7 @@ export class InBookingService {
     return `in-booking:${eventId}:sessions`;
   }
 
-  private async setSession(eventId: number, inBookingSession: InBookingSession): Promise<void> {
+  async setSession(eventId: number, inBookingSession: InBookingSession): Promise<void> {
     const sessionKey = this.getSessionKey(eventId, inBookingSession.sid);
     const eventKey = this.getEventKey(eventId);
 
@@ -137,7 +152,7 @@ export class InBookingService {
     await this.redis.set(sessionKey, JSON.stringify(inBookingSession));
   }
 
-  private async getSession(eventId: number, sid: string): Promise<InBookingSession | null> {
+  async getSession(eventId: number, sid: string): Promise<InBookingSession | null> {
     const session = await this.redis.get(this.getSessionKey(eventId, sid));
     return session ? JSON.parse(session) : null;
   }

--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -134,6 +134,8 @@ export class ReservationService {
 
       await queryRunner.commitTransaction();
 
+      await this.inBookingService.setIsSaved(sid, true);
+
       return {
         programName: program.name,
         runningDate: event[0].runningDate,


### PR DESCRIPTION
## 📌 이슈 번호
- close #234 

## 🚀 구현 내용
- InBooking 세션에 `saved` 필드 추가
- 예매 확정 요청이 받아들여진 경우에 `saved` 필드가 `true`로 설정
- 좌석 선택 중 이탈 시, `saved`가 `true`가 아니라면 모든 `bookedSeats`를 회수

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
