### PR TITLE
관리자 기능: 이벤트 오픈 스케줄 리프레시

### DIFF
--- a/back/src/domains/booking/service/open-booking.service.ts
+++ b/back/src/domains/booking/service/open-booking.service.ts
@@ -33,7 +33,7 @@ export class OpenBookingService implements OnApplicationBootstrap {
   }
 
   @Cron(CronExpression.EVERY_HOUR)
-  private async checkAndOpenReservations() {
+  async checkAndOpenReservations() {
     const events = await this.eventRepository.selectEvents();
     const openedEventIds = new Set(await this.getOpenedEventIds());
     const eventsToOpen = events.filter((event) => {
@@ -49,7 +49,7 @@ export class OpenBookingService implements OnApplicationBootstrap {
 
   async getOpenedEventIds() {
     const keys = await this.redis.keys('open-booking:*:opened');
-    const eventIds = keys.map((key) => parseInt(key.split(':')[2]));
+    const eventIds = keys.map((key) => parseInt(key.split(':')[1]));
     return eventIds;
   }
 


### PR DESCRIPTION

## 📌 이슈 번호
- close #211 

## 🚀 구현 내용

- 관리자 계정용 API: 오픈 대상에 해당하는 이벤트를 다시 탐색하여 오픈한다.


<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
