### PR TITLE
예매 내역 삭제 시 좌석 반납

### DIFF
--- a/back/src/domains/booking/booking.module.ts
+++ b/back/src/domains/booking/booking.module.ts
@@ -25,6 +25,6 @@ import { WaitingQueueService } from './service/waiting-queue.service';
     WaitingQueueService,
     EnterBookingService,
   ],
-  exports: [InBookingService],
+  exports: [BookingService, InBookingService],
 })
 export class BookingModule {}

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -155,6 +155,12 @@ export class BookingService {
     }
   }
 
+  async freeSeatsIfEventOpened(eventId: number, seats: [number, number][]) {
+    if (await this.openBookingService.isEventOpened(eventId)) {
+      await Promise.all(seats.map((seat) => this.bookingSeatsService.updateSeatDeleted(eventId, seat)));
+    }
+  }
+
   async getTimeMs(): Promise<ServerTimeDto> {
     try {
       return {

--- a/back/src/domains/reservation/repository/reservation.repository.ts
+++ b/back/src/domains/reservation/repository/reservation.repository.ts
@@ -18,6 +18,15 @@ export class ReservationRepository {
     });
   }
 
+  async findReservationByIdMatchedUserId(userId: number, reservationId: number) {
+    return await this.ReservationRepository.findOne({
+      where: {
+        id: reservationId,
+        user: { id: userId },
+      },
+    });
+  }
+
   async deleteReservationByIdMatchedUserId(userId: number, reservationId: number) {
     return await this.ReservationRepository.softDelete({
       id: reservationId,


### PR DESCRIPTION
## 📌 이슈 번호
- close #254

## 🚀 구현 내용

- 예매 내역 삭제 시 좌석을 반납하여, 예약이 마감되지 않은 경우에 다른 유저가 자리를 가져갈 수 있도록 함

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
