### PR TITLE
없어진 유저에 대한 상태 초기화 시 에러

### DIFF
--- a/back/src/domains/booking/service/open-booking.service.ts
+++ b/back/src/domains/booking/service/open-booking.service.ts
@@ -216,8 +216,11 @@ export class OpenBookingService implements OnApplicationBootstrap {
   }
 
   private async resetUserStatus(sid: string) {
-    await this.authService.setUserStatusLogin(sid);
-    await this.userService.setUserEventTarget(sid, 0);
+    const authSession = await this.authService.getUserSession(sid);
+    if (authSession) {
+      await this.authService.setUserStatusLogin(sid);
+      await this.userService.setUserEventTarget(sid, 0);
+    }
   }
 
   private async unlinkOpenedEvent(eventId: number) {


### PR DESCRIPTION

## 📌 이슈 번호
- close #260 

## 🚀 구현 내용

- open-booking 서비스에서 resetUserStatus를 호출할 때, 리셋할 세션이 redis에 존재하는 지 확인하고 실행되도록 변경함.

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
