### PR TITLE
SSE 연결에서 하트비트 메시지 송신

### DIFF
--- a/back/src/domains/booking/const/sseMaximumInterval.ts
+++ b/back/src/domains/booking/const/sseMaximumInterval.ts
@@ -1,0 +1,1 @@
+export const SSE_MAXIMUM_INTERVAL = 30000;

--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 
 import { AuthService } from '../../../auth/service/auth.service';
 import { UserService } from '../../user/service/user.service';
+import { SSE_MAXIMUM_INTERVAL } from '../const/sseMaximumInterval';
 import { WAITING_BROADCAST_INTERVAL } from '../const/waitingBroadcastInterval.const';
 import { DEFAULT_WAITING_THROUGHPUT_RATE } from '../const/watingThroughputRate.const';
 import { WaitingSseDto } from '../dto/waitingSse.dto';
@@ -80,7 +81,7 @@ export class WaitingQueueService {
             DEFAULT_WAITING_THROUGHPUT_RATE,
           ),
         ),
-      WAITING_BROADCAST_INTERVAL,
+      Math.min(WAITING_BROADCAST_INTERVAL, SSE_MAXIMUM_INTERVAL),
     );
 
     this.queueSubscriptionMap.set(eventId, subscription);


### PR DESCRIPTION
## 📌 이슈 번호
- close #269 

## 🚀 구현 내용

- 최대 SSE 발행 주기를 설정하는 상수 구현
- 모든 SSE가 '최대 SSE 발행 주기'를 넘는 주기를 갖지 않도록 적용
- 좌석 현황 SSE의 경우, '최대 SSE 발행 주기'마다 변경 사항이 없더라도 좌석 현황을 발행하도록 변경

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
