### PR TITLE
🐛 fix: 예매 가능 시간이 지난 이벤트는 서빙하지 않도록 수정

### DIFF
--- a/back/src/domains/program/service/program.service.ts
+++ b/back/src/domains/program/service/program.service.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 
+import { Event } from 'src/domains/event/entity/event.entity';
+
 import { PlaceMainPageDto } from '../dto/placeMainPage.dto';
 import { ProgramCreationDto } from '../dto/programCreation.dto';
 import { ProgramIdDto } from '../dto/programId.dto';
@@ -39,9 +41,12 @@ export class ProgramService {
   }
 
   private async convertProgramToSpecificDto(program: Program): Promise<ProgramSpecificDto> {
+    const now = new Date();
     const [place, events] = await Promise.all([program.place, program.events]);
-
-    return new ProgramSpecificDto({ ...program, place, events });
+    const openedEvents: Event[] = events.filter((event) => {
+      return event.reservationCloseDate >= now;
+    });
+    return new ProgramSpecificDto({ ...program, place, events: openedEvents });
   }
 
   async create(programCreationDto: ProgramCreationDto): Promise<void> {


### PR DESCRIPTION

## 📌 이슈 번호
- close #287 

## 🚀 구현 내용
- 예매 가능 시간이 지난 이벤트는 프로그램 조회시 제공하지 않음 Issue Resolved: #287

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
