### PR TITLE
대기 큐 '대기 인원'을 '~번'으로 표시하는 표기 오류 수정

### DIFF
--- a/front/src/pages/WaitingQueuePage/index.tsx
+++ b/front/src/pages/WaitingQueuePage/index.tsx
@@ -96,7 +96,7 @@ export default function WaitingQueuePage() {
       title: '대기 인원',
       content: (
         <span className="text-heading3 text-typo">
-          <span className="text-warning">{totalWaiting}</span> 번
+          <span className="text-warning">{totalWaiting}</span> 명
         </span>
       ),
     },


### PR DESCRIPTION

## 📌 이슈 번호
- close #292 

## 🚀 구현 내용

- 대기 큐 '대기 인원'을 '~번'으로 표시하는 표기 오류 수정

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
