### PR TITLE
FE - API 프록시, 포트 개방 설정 수정

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -13,11 +13,17 @@ RUN npm run build
 
 # Use nginx image for production stage
 FROM nginx:stable-alpine
+
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY --from=build /app/dist/ .
+
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.conf /etc/nginx/conf.d/
+ARG API_SERVER_URL
+# proxy_pass 주입
+RUN sed -i 's|proxy_pass .*|proxy_pass '"${API_SERVER_URL}"';|g' /etc/nginx/conf.d/nginx.conf
+
 EXPOSE 80
 
 # Run nginx in the foreground

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,21 +1,18 @@
 FROM node:20 AS build
 WORKDIR /app
-COPY package*.json ./ 
+COPY package*.json ./
 # Install dependencies
 RUN npm install --legacy-peer-deps
 
 COPY . .
-ARG VITE_ENVIRONMENT
-ARG VITE_API_URL
 
-# Vite가 빌드 시점에 사용할 수 있도록 환경 변수 생성
-RUN echo "VITE_ENVIRONMENT=${VITE_ENVIRONMENT}" >> .env && \
-echo "VITE_API_URL=${VITE_API_URL}" >> .env
+# API 프록싱 활성화
+RUN echo "VITE_API_PROXYING=true" >> .env
 
 RUN npm run build
 
 # Use nginx image for production stage
-FROM nginx:stable-alpine 
+FROM nginx:stable-alpine
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY --from=build /app/dist/ .

--- a/front/nginx/nginx.conf
+++ b/front/nginx/nginx.conf
@@ -8,4 +8,22 @@ server {
         index index.html index.htm;          # 기본 파일
         try_files $uri $uri/ /index.html;    # SPA 라우팅 처리
     }
+
+    # API 요청을 백엔드로 프록시
+    location /api {
+
+        # 백엔드 컨테이너 이름
+        # docker-compose 에선 'localhost'로 접근 불가
+        proxy_pass http://nest:8080;
+
+        rewrite ^/api(/.*)$ $1 break;  # /api/ 제거
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host $server_name;
+    }
 }

--- a/front/nginx/nginx.conf
+++ b/front/nginx/nginx.conf
@@ -12,9 +12,8 @@ server {
     # API 요청을 백엔드로 프록시
     location /api {
 
-        # 백엔드 컨테이너 이름
-        # docker-compose 에선 'localhost'로 접근 불가
-        proxy_pass http://nest:8080;
+        # 백엔드 URL, front 도커파일에서 설정
+        proxy_pass ;
 
         rewrite ^/api(/.*)$ $1 break;  # /api/ 제거
         proxy_http_version 1.1;

--- a/front/package.json
+++ b/front/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 80",
+    "dev": "vite --port 30000",
     "build": "tsc -b && vite build",
-    "start": "vite preview --port 80 --host",
+    "start": "vite preview --port 30000 --host",
     "lint": "eslint --fix",
     "prettier": "prettier -w",
     "tsc": "tsc -b",

--- a/front/src/api/axios.ts
+++ b/front/src/api/axios.ts
@@ -6,10 +6,12 @@ import router from '@/routes/index.tsx';
 import axios, { AxiosError, isAxiosError } from 'axios';
 
 //TODO 타입 정의
-const isDevelopEnvironment = import.meta.env.VITE_ENVIRONMENT === 'dev';
-// const isDevelopEnvironment = true;
+const isApiProxying = !!import.meta.env.VITE_API_PROXYING;
+const proxyingUrl = window.location.origin + '/api';
+const apiServerUrl = import.meta.env.VITE_BE_URL ? import.meta.env.VITE_BE_URL : 'http://localhost:8080';
 
-export const BASE_URL = import.meta.env.VITE_API_URL + (isDevelopEnvironment ? '' : '/api');
+export const BASE_URL = isApiProxying ? proxyingUrl : apiServerUrl;
+
 type ErrorData = {
   error: string;
   message: string;


### PR DESCRIPTION
## 📌 이슈 번호
- close #300

## 🚀 구현 내용
- FE 서버 [dev, start] 실행에서 포트 '30000'으로 변경
- API 프록시의 작동 조건인 VITE_API_PROXYING 환경 변수를 도입
- FE 서버가 자신의 주소를 동적으로 알아내도록 변경
- 도커 이미지 빌드 시점에 arg로 API 서버 주소를 주입 가능하게 함.(하단 주의사항 참고)


<!--## 주의 사항: 관련 내용, 블로그, 링크 -->
이제 FE의 docker 이미지를 빌드할 때, `--build-arg API_SERVER_URL=http://localhost:8080`과 같이 arg 설정을 필수적으로 넣어야 함.