### PR TITLE
벤치마크용 이벤트에서는 사용자가 이탈해도 좌석 회수하지 않도록 하기

### DIFF
--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -44,6 +44,9 @@ export class BookingService {
 
   private async collectSeatsIfNotSaved(eventId: number, sid: string) {
     const inBookingSession = await this.inBookingService.getSession(eventId, sid);
+    if (process.env.BENCHMARK_MODE === 'true' && eventId === 1) {
+      return;
+    }
     if (inBookingSession && !inBookingSession.saved) {
       const bookedSeats = inBookingSession.bookedSeats;
       bookedSeats.forEach((seat) => {


### PR DESCRIPTION
## 📌 이슈 번호
- close #313 

## 🚀 구현 내용

- 벤치마크 모드가 활성화되어 있고, targetEventId가 1이라면 좌석 회수 로직 pass

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
