### PR TITLE
로거 config 세부화

### DIFF
--- a/back/src/util/logger/logging.module.ts
+++ b/back/src/util/logger/logging.module.ts
@@ -28,6 +28,13 @@ export const FullRequestLoggingInterceptor = RequestLoggingInterceptor.instantia
     FullRequestLoggingInterceptor,
   ],
   exports: [
+    WinstonModule,
+    //-로거 사용법-
+    //중요!:
+    //import { Logger as WinstonLogger } from 'winston';
+    //의존성 주입 단계에서:
+    //@Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
+
     RequestLoggingService,
     RequestLoggingInterceptor,
     RequestLoggingMiddleware,

--- a/back/src/util/logger/service/request-logging.service.ts
+++ b/back/src/util/logger/service/request-logging.service.ts
@@ -1,7 +1,9 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Request, Response } from 'express';
 import Redis from 'ioredis';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger as WinstonLogger } from 'winston';
 
 import {
   LoggingDetailType,
@@ -11,7 +13,6 @@ import {
   CachedUserInfo,
   UserInfo,
 } from '../types/logging.types';
-import { winstonLogger } from '../winston.logger';
 
 @Injectable()
 export class RequestLoggingService {
@@ -21,7 +22,10 @@ export class RequestLoggingService {
   private readonly MAX_CACHE_SIZE = 1000;
   private readonly DEFAULT_DETAILS = Object.values(LoggingDetailType);
 
-  constructor(private readonly redisService: RedisService) {
+  constructor(
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
+    private readonly redisService: RedisService,
+  ) {
     this.redis = this.redisService.getOrThrow();
     setInterval(() => this.cleanupExpiredCache(), 5 * 60 * 1000);
   }
@@ -148,7 +152,7 @@ export class RequestLoggingService {
         return userInfo;
       }
     } catch (error) {
-      winstonLogger.warn(
+      this.logger.warn(
         `Failed to get user info for SID: ${sid} - ${error.message}`,
         'DetailedRequestLogging',
       );
@@ -221,9 +225,9 @@ export class RequestLoggingService {
     const message = parts.join(' | ');
 
     if (type === 'ERR') {
-      winstonLogger.error(message, error?.stack || logData.errorStack, logData.loggerName);
+      this.logger.error(message, error?.stack || logData.errorStack, logData.loggerName);
     } else {
-      winstonLogger.log(message, logData.loggerName);
+      this.logger.http(message, logData.loggerName);
     }
   }
 

--- a/back/src/util/logger/winston.config.ts
+++ b/back/src/util/logger/winston.config.ts
@@ -6,22 +6,28 @@ import winstonDaily from 'winston-daily-rotate-file';
 
 const logDir = path.join(__dirname, '../../../logs');
 
-const dailyOptions = (level: string) => {
+const dailyOptions = (name: string, level?: string) => {
   return {
-    level,
+    level: level || (process.env.NODE_ENV === 'prod' ? 'info' : 'silly'),
     datePattern: 'YYYY-MM-DD',
-    dirname: logDir + `/${level}`,
-    filename: `%DATE%.${level}.log`,
+    dirname: path.join(logDir, name),
+    filename: `%DATE%.${name}.log`,
     zippedArchive: true,
     maxSize: '20m',
-    maxFiles: '14d',
+    maxFiles: process.env.NODE_ENV === 'prod' ? '30d' : '9999d',
   };
 };
 
 export const winstonConfig = {
+  format: winston.format.combine(
+    winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
+    winston.format.errors({ stack: true }),
+    winston.format.json(),
+  ),
+
   transports: [
     new winston.transports.Console({
-      level: 'silly',
+      level: process.env.NODE_ENV === 'prod' ? 'warn' : 'debug',
       format: winston.format.combine(
         winston.format.timestamp(),
         winston.format.ms(),
@@ -33,8 +39,8 @@ export const winstonConfig = {
         }),
       ),
     }),
-    new winstonDaily(dailyOptions('info')),
-    new winstonDaily(dailyOptions('warn')),
-    new winstonDaily(dailyOptions('error')),
+
+    new winstonDaily(dailyOptions('critical', 'warn')),
+    new winstonDaily(dailyOptions('all')),
   ],
 };

--- a/back/src/util/logger/winston.logger.ts
+++ b/back/src/util/logger/winston.logger.ts
@@ -1,5 +1,0 @@
-import { WinstonModule } from 'nest-winston';
-
-import { winstonConfig } from './winston.config';
-
-export const winstonLogger = WinstonModule.createLogger(winstonConfig);


### PR DESCRIPTION
## 📌 이슈 번호
- close #327

## 🚀 구현 내용

- 타 모듈에 대한 로거 주입 방식 변경(nest Logger에서 WinstonLogger로)
  - http, verbose, silly 레벨 로그를 사용 가능하게 됨
- 로거 config 개선
  - .log 파일에서도 ms 타임스탬프 활성화
  - 로그 레벨별, 실행 환경별 기록 방식 설정
    -  prod:
       - 콘솔: warn까지
       - 파일: info까지
     - dev:
       - 콘솔: debug까지
       - 파일: silly까지
  - 실행 환경별 로그 파일 삭제 기한 설정
     - prod: 30일
     - dev: 무한


<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
