### PR TITLE
벤치마크 모듈 WS Gateway 좌석 Observable pipe 구조 수정

### DIFF
--- a/back/src/benchmark/gateway/seats.gateway.ts
+++ b/back/src/benchmark/gateway/seats.gateway.ts
@@ -144,12 +144,12 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private setupEventSubscription(eventId: number): void {
     if (!this.eventSubscriptions.has(eventId)) {
-      const observable = this.bookingSeatsService.subscribeSeats(eventId);
+      const observable = this.bookingSeatsService.getSeatsObservable(eventId);
 
-      const subscription = observable.subscribe((data) => {
+      const subscription = observable.subscribe(async (seatData) => {
         this.broadcastToEvent(eventId, {
           type: 'seats-update',
-          data: data.data,
+          data: seatData,
         });
       });
 

--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -101,7 +101,7 @@ export class BookingController {
     const sid = req.cookies['SID'];
     await this.bookingService.setInBookingFromEntering(sid);
 
-    const observable = this.bookingSeatsService.subscribeSeats(eventId);
+    const observable = this.bookingSeatsService.subscribeSeatsSSE(eventId);
 
     req.on('close', () => {
       this.eventEmitter.emit('seats-sse-close', { sid });

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -155,18 +155,17 @@ export class BookingSeatsService {
     return seatStatusBits;
   }
 
-  subscribeSeats(eventId: number) {
-    return this.seatsSubscriptionMap
-      .get(eventId)
-      .asObservable()
-      .pipe(
-        map((data) => {
-          return {
-            data,
-            retry: SEATS_SSE_RETRY_TIME,
-          };
-        }),
-      );
+  getSeatsObservable(eventId: number) {
+    return this.seatsSubscriptionMap.get(eventId).asObservable();
+  }
+
+  subscribeSeatsSSE(eventId: number) {
+    return this.getSeatsObservable(eventId).pipe(
+      map((data) => ({
+        data,
+        retry: SEATS_SSE_RETRY_TIME,
+      })),
+    );
   }
 
   @OnEvent('seats-status-changed')


### PR DESCRIPTION
## 📌 이슈 번호
- close #331

## 🚀 구현 내용
- 벤치마크 모듈의 WS Gateway에서 좌석 Observable 구독 시 pipe가 아닌 Observable 자체를 가져오도록 변경
  -  기존의 pipe를 그대로 가져오는 구조는 SSE API와 WS Gateway 각각에서 부가적인 로직(로깅 등)을 삽입할 때 간섭을 유발하고 유연성을 저해하기에 수정함.
  -  SSE API는 nestJS 프레임워크의 요구사항에 따라 pipe를 운용하도록 유지하고, WS Gateway는 해당이 없어 Observable 형태로 운용하도록 함.


<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
