### PR TITLE
'LOG_SAVE_MODE'별 저장 방식 구체화, 오류 fix

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -13,7 +13,7 @@ $ npm install
     - (dev/release)
 
 ### 환경 변수 설정
-다음과 같은 환경 변수 파일들을 "새로" 생성하세요:
+다음과 같이 환경 변수 파일들을 **"새로"** 생성하세요:
 
 ```text
 ./
@@ -22,6 +22,7 @@ $ npm install
         └── config/
             └── .env.development
             └── .env.production
+            └── .env.sample - (생성되어 있음)(참고용)
 ```
 
 #### 기본 환경 변수 파일(NODE_ENV)
@@ -32,6 +33,9 @@ $ npm install
 
 예시: `.env.development`:
 ```env
+# 표준 시간 설정
+TZ=Asia/Seoul
+
 # 데이터베이스 설정
 DATABASE_HOST=localhost
 DATABASE_PASSWORD=0000
@@ -55,7 +59,7 @@ LOG_ZIP=true
 ```
 
 #### 실행 모드별 환경 변수 파일(EXEC_MODE)
-장소적 환경과 별개로, 동작 모드를 설정하는 환경 변수가 `.env.execMode.(모드)`에 "이미" 정의되어 있습니다.
+장소적 환경과 별개로, 동작 모드를 설정하는 환경 변수가 `.env.execMode.(모드)`에 **"이미"** 정의되어 있습니다.
 
 `.env.execMode.release`는 실제 서비스에 사용되는 설정으로, 임의로 변경하지 않는 것을 권장합니다.
 

--- a/back/README.md
+++ b/back/README.md
@@ -67,6 +67,9 @@ LOG_ZIP=true
 # 로깅 모드
 LOGGING_MODE=dev
 
+# 로그 저장 모드
+LOG_SAVE_MODE=dev
+
 # 벤치마크 모드
 BENCHMARK_MODE=true
 

--- a/back/src/config/.env.execMode.dev
+++ b/back/src/config/.env.execMode.dev
@@ -3,6 +3,9 @@
 # 로깅 모드
 LOGGING_MODE=dev
 
+# 로그 저장 모드
+LOG_SAVE_MODE=dev
+
 # 벤치마크 모드
 BENCHMARK_MODE=true
 

--- a/back/src/config/.env.execMode.release
+++ b/back/src/config/.env.execMode.release
@@ -4,6 +4,9 @@
 # 로깅 모드
 LOGGING_MODE=prod
 
+# 로그 저장 모드
+LOG_SAVE_MODE=prod
+
 # 벤치마크 모드
 BENCHMARK_MODE=false
 

--- a/back/src/config/.env.sample
+++ b/back/src/config/.env.sample
@@ -1,3 +1,6 @@
+# 표준 시간 설정
+TZ=Asia/Seoul
+
 # 데이터베이스 설정
 DATABASE_HOST=localhost
 DATABASE_PASSWORD=0000

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -9,7 +9,6 @@ import { setupSwagger } from './config/setupSwagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {});
-  process.env.TZ = 'Asia/Seoul';
   setupSwagger(app);
   app.enableCors({
     origin: [process.env.FRONT_URL ?? 'http://localhost:3000'],

--- a/back/src/util/date-util.ts
+++ b/back/src/util/date-util.ts
@@ -1,0 +1,14 @@
+const formatter = new Intl.DateTimeFormat('sv-SE', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  fractionalSecondDigits: 3,
+  hour12: false,
+});
+
+export const getLocalISOString = (date = new Date()) => {
+  return formatter.format(date).replace(' ', 'T').replace(',', '.') + 'Z';
+};

--- a/back/src/util/logger/winston.config.ts
+++ b/back/src/util/logger/winston.config.ts
@@ -4,6 +4,8 @@ import { utilities as nestWinstonModuleUtilities } from 'nest-winston';
 import * as winston from 'winston';
 import winstonDaily from 'winston-daily-rotate-file';
 
+import { getLocalISOString } from '../date-util';
+
 const logDir = path.join(__dirname, '../../../logs');
 
 const dailyOptions = (name: string, level?: string) => {
@@ -13,21 +15,35 @@ const dailyOptions = (name: string, level?: string) => {
     return {
       level: baseLevel,
       datePattern: 'YYYY-MM-DD',
-      dirname: path.join(logDir, name),
+      dirname: path.join(logDir, process.env.LOG_SAVE_MODE, name),
       filename: `%DATE%.${name}.log`,
       zippedArchive: process.env.LOG_ZIP === 'true',
       maxSize: process.env.LOG_MAX_SIZE,
       maxFiles: process.env.LOG_MAX_LIFE,
+      utc: false,
+      options: {
+        flags: 'a',
+      },
     };
   } else {
-    const timestamp = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').replace(/\..+/, '');
+    const runTimestamp = getLocalISOString()
+      .replace('T', '_')
+      .replace('Z', '')
+      .replaceAll(':', '-')
+      .split('.')[0];
+    const HMSstamp = runTimestamp.split('_')[1];
     return {
       level: baseLevel,
-      dirname: path.join(logDir, name),
-      filename: `${timestamp}-%i.${name}.log`,
+      datePattern: 'YYYY-MM-DD',
+      dirname: path.join(logDir, process.env.LOG_SAVE_MODE, name, 'start-at_' + runTimestamp),
+      filename: `%DATE%_${HMSstamp}.${name}.log`,
       zippedArchive: process.env.LOG_ZIP === 'true',
       maxSize: process.env.LOG_MAX_SIZE,
       maxFiles: process.env.LOG_MAX_LIFE,
+      utc: false,
+      options: {
+        flags: 'a',
+      },
     };
   }
 };


### PR DESCRIPTION
## 📌 이슈 번호
- close #333

## 🚀 구현 내용

### 1. 시간대 관련 개선 사항
- **TZ 환경변수 위치 변경**: 코드에서 `.env` 파일로 이동하여 실행 위치별 유연성 향상 및 설정 순서 보장
- **로컬 시간대 적용**: `getLocalISOString` 유틸 함수 구현으로 로그 파일명이 `process.env.TZ` 설정 시간대를 정확히 반영하도록 개선

### 2. LOG_SAVE_MODE별 저장 방식 구체화

#### 개발 환경 (`LOG_SAVE_MODE = 'dev'`)
- **디렉토리 분기**: 실행 시점별로 별도 디렉토리 생성하여 로그 파일 관리 및 열람 편의성 향상
- **파일명 오류 수정**: 로그 파일명 깨짐 현상 해결

#### 운영 환경 (`LOG_SAVE_MODE = 'prod'`)
- **append 모드 활성화**: 실행 시점 구분 없이 로그를 지속적으로 누적
- **통합 용량 관리**: 디렉토리를 분기하지 않아 전체 용량 관리 전략이 효율적으로 동작

### 3. 설정 파일 보완
- `execMode.env`에 누락된 `LOG_SAVE_MODE` 환경변수 추가

### 주요 변경사항
- 개발/운영 환경별 로그 저장 전략 차별화
- 시간대 설정의 유연성 및 정확성 개선
- 로그 파일 관리 편의성 향상 (개발 환경)
- 로그 영속성 및 용량 관리 최적화 (운영 환경)
<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
