### PR TITLE
서버가 클라이언트의 SSE 재연결 시도를 기다리는 로직 추가

### DIFF
--- a/back/src/domains/booking/const/seatsSseRetryTime.const.ts
+++ b/back/src/domains/booking/const/seatsSseRetryTime.const.ts
@@ -1,1 +1,3 @@
-export const SEATS_SSE_RETRY_TIME = 5000;
+export const SEATS_SSE_RETRY_INTERVAL = 1000;
+
+export const SEATS_SSE_RETRY_TIMEOUT = 5000;

--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -13,6 +13,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -26,6 +27,7 @@ import { Request } from 'express';
 
 import { USER_STATUS } from '../../../auth/const/userStatus.const';
 import { SessionAuthGuard } from '../../../auth/guard/session.guard';
+import { SEATS_SSE_RETRY_TIMEOUT } from '../const/seatsSseRetryTime.const';
 import { SeatStatus } from '../const/seatStatus.enum';
 import { BookingAmountReqDto } from '../dto/bookingAmountReq.dto';
 import { BookingAmountResDto } from '../dto/bookingAmountRes.dto';
@@ -51,6 +53,7 @@ export class BookingController {
     private readonly bookingSeatsService: BookingSeatsService,
     private readonly waitingQueueService: WaitingQueueService,
     private readonly openBookingService: OpenBookingService,
+    private readonly schedulerRegistry: SchedulerRegistry,
   ) {}
 
   @UseGuards(SessionAuthGuard())
@@ -99,12 +102,22 @@ export class BookingController {
   @ApiUnauthorizedResponse({ description: '인증 실패' })
   async getReservationStatusByEventId(@Param('eventId') eventId: number, @Req() req: Request) {
     const sid = req.cookies['SID'];
+
+    if (this.schedulerRegistry.doesExist('timeout', `sse-closing-${sid}`)) {
+      this.schedulerRegistry.deleteTimeout(`sse-closing-${sid}`);
+    }
+
     await this.bookingService.setInBookingFromEntering(sid);
 
     const observable = this.bookingSeatsService.subscribeSeatsSSE(eventId);
 
     req.on('close', () => {
-      this.eventEmitter.emit('seats-sse-close', { sid });
+      this.schedulerRegistry.addTimeout(
+        `sse-closing-${sid}`,
+        setTimeout(() => {
+          this.eventEmitter.emit('seats-sse-close', { sid });
+        }, SEATS_SSE_RETRY_TIMEOUT),
+      );
     });
 
     return observable;

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -12,7 +12,7 @@ import { map } from 'rxjs/operators';
 
 import { UserService } from '../../user/service/user.service';
 import { SEATS_BROADCAST_INTERVAL } from '../const/seatsBroadcastInterval.const';
-import { SEATS_SSE_RETRY_TIME } from '../const/seatsSseRetryTime.const';
+import { SEATS_SSE_RETRY_INTERVAL } from '../const/seatsSseRetryTime.const';
 import { SeatStatus } from '../const/seatStatus.enum';
 import { SSE_MAXIMUM_INTERVAL } from '../const/sseMaximumInterval';
 import { SeatsSseDto } from '../dto/seatsSse.dto';
@@ -163,7 +163,7 @@ export class BookingSeatsService {
     return this.getSeatsObservable(eventId).pipe(
       map((data) => ({
         data,
-        retry: SEATS_SSE_RETRY_TIME,
+        retry: SEATS_SSE_RETRY_INTERVAL,
       })),
     );
   }


### PR DESCRIPTION
Issue Resolved: #337

## 📌 이슈 번호
- close #337 

## 🚀 구현 내용

- 기존 `SEATS_SSE_RETRY_TIME`를 `SEATS_SSE_RETRY_INTERVAL`(재연결 시도 주기), `SEATS_SSE_RETRY_TIMEOUT`(재연결 가능 타임아웃)으로 분리
- SSE 연결 종료 시 `SEATS_SSE_RETRY_TIMEOUT` 만큼의 타임아웃을 설정(ScheduleRegistry 활용), 타임아웃까지는 세션을 정리하지 않도록 함


<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
