### PR TITLE
세션이 이미 만료된 사용자의 userStatus를 확인하는 오류 수정

### DIFF
--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -23,6 +23,7 @@ export class AuthService {
 
   async setUserStatusLogin(sid: string) {
     const session = JSON.parse(await this.redis.get(`user:${sid}`));
+    if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
     this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.LOGIN }));
@@ -30,6 +31,7 @@ export class AuthService {
 
   async setUserStatusWaiting(sid: string) {
     const session = JSON.parse(await this.redis.get(`user:${sid}`));
+    if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
     this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.WAITING }));
@@ -37,6 +39,7 @@ export class AuthService {
 
   async setUserStatusEntering(sid: string) {
     const session = JSON.parse(await this.redis.get(`user:${sid}`));
+    if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
     this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.ENTERING }));
@@ -44,6 +47,7 @@ export class AuthService {
 
   async setUserStatusSelectingSeat(sid: string) {
     const session = JSON.parse(await this.redis.get(`user:${sid}`));
+    if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
     this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.SELECTING_SEAT }));
@@ -51,6 +55,7 @@ export class AuthService {
 
   async setUserStatusReconnectingSelecting(sid: string) {
     const session = JSON.parse(await this.redis.get(`user:${sid}`));
+    if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
     await this.redis.set(
@@ -61,6 +66,7 @@ export class AuthService {
 
   async setUserStatusAdmin(sid: string) {
     const session = JSON.parse(await this.redis.get(`user:${sid}`));
+    if (!session) return;
 
     this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.ADMIN }));
   }


### PR DESCRIPTION
## 📌 이슈 번호
- close #341

## 🚀 구현 내용
- AuthService에서 'setUserStatus~~'류의 메서드에서, session 조회 결과 존재하지 않으면 userStatus를 확인하지 않고 반환하도록 수정

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
