### PR TITLE
getTargetEvent 조회 실패시 예외 핸들링

### DIFF
--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -71,6 +71,11 @@ export class BookingSeatsService {
 
   async bookSeat(sid: string, target: [number, number]) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new BadRequestException('좌석을 점유하려는 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const bookedSeat = await this.inBookingService.getBookedSeats(sid);
     const bookingAmount = await this.inBookingService.getBookingAmount(sid);
     const bookedAmount = bookedSeat.length;
@@ -88,6 +93,11 @@ export class BookingSeatsService {
 
   async unBookSeat(sid: string, target: [number, number]) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new BadRequestException('좌석 점유를 취소하려는 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const bookedSeat = await this.inBookingService.getBookedSeats(sid);
     const bookedAmount = bookedSeat.length;
 

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -35,6 +35,11 @@ export class BookingService {
   async onSeatsSseDisconnected(event: { sid: string }) {
     const sid = event.sid;
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      return;
+    }
+
     if (await this.openBookingService.isEventOpened(eventId)) {
       await this.collectSeatsIfNotSaved(eventId, sid);
       await this.inBookingService.emitSession(sid);
@@ -92,6 +97,11 @@ export class BookingService {
 
   async setInBookingFromEntering(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new BadRequestException('좌석 선택 상태로 이동할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const bookingAmount = await this.enterBookingService.getBookingAmount(sid);
 
     await this.enterBookingService.removeEnteringSession(sid);
@@ -113,6 +123,11 @@ export class BookingService {
 
   private async getForwarded(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new BadRequestException('permission할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const isInsertable = await this.isInsertableInBooking(eventId);
 
     if (isInsertable) {
@@ -147,6 +162,11 @@ export class BookingService {
       await this.flushBookedSeats(sid);
       return await this.inBookingService.setBookingAmount(sid, bookingAmount);
     }
+
+    const isEntering = await this.enterBookingService.isEntering(sid);
+    if (!isEntering) {
+      throw new BadRequestException('예매 수량을 설정할 수 없는 상태입니다.');
+    }
     return await this.enterBookingService.setBookingAmount(sid, bookingAmount);
   }
 
@@ -154,6 +174,11 @@ export class BookingService {
     const bookedSeats = await this.inBookingService.getBookedSeats(sid);
     if (bookedSeats.length > 0) {
       const eventId = await this.userService.getUserEventTarget(sid);
+
+      if (eventId === null) {
+        throw new BadRequestException('좌석을 회수할 세션의 대상 이벤트를 불러올 수 없습니다.');
+      }
+
       await Promise.all(bookedSeats.map((seat) => this.bookingSeatsService.updateSeatDeleted(eventId, seat)));
       await this.inBookingService.removeBookedSeats(sid);
     }

--- a/back/src/domains/booking/service/enter-booking.service.ts
+++ b/back/src/domains/booking/service/enter-booking.service.ts
@@ -44,6 +44,11 @@ export class EnterBookingService {
 
   async addEnteringSession(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new Error('입장중 상태에 추가할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const timestamp = Date.now();
     await this.redis.zadd(`entering:${eventId}`, timestamp, sid);
     return true;
@@ -51,9 +56,25 @@ export class EnterBookingService {
 
   async removeEnteringSession(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new Error('입장중 상태에서 제거할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     await this.redis.zrem(`entering:${eventId}`, sid);
     await this.removeBookingAmount(sid);
     return true;
+  }
+
+  async isEntering(sid: string) {
+    const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      return false;
+    }
+
+    const isMember = await this.redis.zscore(`entering:${eventId}`, sid);
+    return isMember !== null;
   }
 
   async getEnteringSessionCount(eventId: number) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -224,6 +224,9 @@ export class InBookingService {
 
   async addReconnectingSession(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+    if (eventId === null) {
+      return false;
+    }
     const timestamp = Date.now();
     await this.redis.zadd(`reconnecting:${eventId}`, timestamp, sid);
     return true;
@@ -231,6 +234,9 @@ export class InBookingService {
 
   async removeReconnectingSession(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+    if (eventId === null) {
+      return false;
+    }
     await this.redis.zrem(`reconnecting:${eventId}`, sid);
     return true;
   }

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -64,6 +64,11 @@ export class InBookingService {
 
   async isInBooking(sid: string) {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      return false;
+    }
+
     const session = await this.getSession(eventId, sid);
     return !!session;
   }
@@ -81,6 +86,11 @@ export class InBookingService {
 
   async setBookingAmount(sid: string, amount: number): Promise<number> {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('예매 수량을 설정할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
 
     session.bookingAmount = amount;
@@ -91,12 +101,22 @@ export class InBookingService {
 
   async getBookingAmount(sid: string): Promise<number> {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('예매 수량을 조회할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
     return session.bookingAmount;
   }
 
   async addBookedSeat(sid: string, seat: [number, number]): Promise<void> {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('점유한 좌석을 추가할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
     session.bookedSeats.push(seat);
     await this.setSession(eventId, session);
@@ -104,12 +124,22 @@ export class InBookingService {
 
   async getBookedSeats(sid: string): Promise<[number, number][]> {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      return [];
+    }
+
     const session = await this.getSession(eventId, sid);
     return session.bookedSeats;
   }
 
   async removeBookedSeat(sid: string, seat: [number, number]): Promise<void> {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('점유한 좌석을 제거할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
     session.bookedSeats = session.bookedSeats.filter((s) => s[0] !== seat[0] || s[1] !== seat[1]);
     await this.setSession(eventId, session);
@@ -117,6 +147,11 @@ export class InBookingService {
 
   async removeBookedSeats(sid: string) {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('점유한 좌석을 모두 제거할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
     session.bookedSeats = [];
     await this.setSession(eventId, session);
@@ -124,12 +159,22 @@ export class InBookingService {
 
   async getIsSaved(sid: string) {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('예약 저장 여부를 조회할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
     return session.saved;
   }
 
   async setIsSaved(sid: string, saved: boolean) {
     const eventId = await this.getTargetEventId(sid);
+
+    if (eventId === null) {
+      throw new Error('예약 저장 여부를 설정할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     const session = await this.getSession(eventId, sid);
     session.saved = saved;
     await this.setSession(eventId, session);
@@ -137,9 +182,14 @@ export class InBookingService {
 
   async emitSession(sid: string) {
     const eventId = await this.getTargetEventId(sid);
-    await this.removeInBooking(eventId, sid);
-    await this.authService.setUserStatusLogin(sid);
-    await this.userService.setUserEventTarget(sid, 0);
+
+    if (eventId === null) {
+      return;
+    } else if (eventId !== 0) {
+      await this.removeInBooking(eventId, sid);
+      await this.authService.setUserStatusLogin(sid);
+      await this.userService.setUserEventTarget(sid, 0);
+    }
   }
 
   async getInBookingSessionsMaxSize(eventId: number) {

--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -43,6 +43,11 @@ export class WaitingQueueService {
 
   async pushQueue(sid: string) {
     const eventId = await this.userService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new Error('대기큐에 추가할 세션의 대상 이벤트를 불러올 수 없습니다.');
+    }
+
     if (!this.queueSubscriptionMap.get(eventId)) {
       await this.createQueueSubscription(eventId);
     }

--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -105,6 +105,11 @@ export class ReservationService {
       const session = await this.authService.getUserSession(sid);
       const userId = session.id;
       const eventId = await this.userService.getUserEventTarget(sid);
+
+      if (eventId === null) {
+        throw new BadRequestException('예약 확정하려는 세션의 대상 이벤트를 불러올 수 없습니다.');
+      }
+
       const { bookingAmount, bookedSeats } = await this.inBookingService.getBookAmountAndBookedSeats(
         sid,
         eventId,

--- a/back/src/domains/user/service/user.service.ts
+++ b/back/src/domains/user/service/user.service.ts
@@ -150,8 +150,14 @@ export class UserService {
   }
 
   async getUserEventTarget(sid: string) {
-    const session = JSON.parse(await this.redis.get(`user:${sid}`));
-    return session.targetEvent;
+    const sessionData = await this.redis.get(`user:${sid}`);
+
+    if (!sessionData) {
+      return null;
+    }
+
+    const session = JSON.parse(sessionData);
+    return session?.targetEvent ?? null;
   }
 
   async makeGuestUser() {


### PR DESCRIPTION
## 📌 이슈 번호
- close #347

## 🚀 구현 내용
- getTargetEvent() 조회 실패시 null 반환
- getTargetEvent()를 호출하는 모든 코드에서 null 반환에 대응, 적절한 에러 메시지/코드 반환
  - getTargetEvent()의 null 반환이 정상 동작 범위일 경우에는 에러 반환 대신 적절한 대응 로직 구현

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
