### PR TITLE
로그아웃 요청 시 InBooking 세션 정리가 선행되도록 변경

### DIFF
--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -2,13 +2,16 @@ import { RedisService } from '@liaoliaots/nestjs-redis';
 import {
   BadRequestException,
   ConflictException,
+  Inject,
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import Redis from 'ioredis';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { BehaviorSubject } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { Logger as WinstonLogger } from 'winston';
 
 import { UserService } from '../../user/service/user.service';
 import { SEATS_BROADCAST_INTERVAL } from '../const/seatsBroadcastInterval.const';
@@ -38,6 +41,7 @@ export class BookingSeatsService {
     private inBookingService: InBookingService,
     private eventEmitter: EventEmitter2,
     private readonly userService: UserService,
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
   ) {
     this.redis = this.redisService.getOrThrow();
   }
@@ -214,5 +218,24 @@ export class BookingSeatsService {
     );
 
     return subscription;
+  }
+
+  @OnEvent('logout-release-seats')
+  async handleLogoutReleaseSeats(payload: { sid: string; eventId: number; bookedSeats: [number, number][] }) {
+    try {
+      const { sid, eventId, bookedSeats } = payload;
+
+      for (const seat of bookedSeats) {
+        try {
+          await this.updateSeatDeleted(eventId, seat);
+        } catch (error) {
+          this.logger.warn(
+            `(로그아웃) 좌석 방출 실패: [${seat[0]}, ${seat[1]}], SID: ${sid}, ${error.message}`,
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error(`(로그아웃) 좌석 방출 실패: ${error.message}`, error.stack);
+    }
   }
 }

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -1,8 +1,10 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { Injectable } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import Redis from 'ioredis';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger as WinstonLogger } from 'winston';
 
 import { AuthService } from '../../../auth/service/auth.service';
 import { UserService } from '../../user/service/user.service';
@@ -28,6 +30,7 @@ export class InBookingService {
     private readonly userService: UserService,
     private eventEmitter: EventEmitter2,
     private readonly schedulerRegistry: SchedulerRegistry,
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
   ) {
     this.redis = this.redisService.getOrThrow();
   }
@@ -320,6 +323,41 @@ export class InBookingService {
     const keys = await this.redis.keys(`reconnecting:${eventId}:*`);
     if (keys.length > 0) {
       await this.redis.unlink(...keys);
+    }
+  }
+
+  @OnEvent('logout-start')
+  async handleLogoutStart(payload: { sid: string; sessionData: string }) {
+    try {
+      const { sid, sessionData } = payload;
+
+      const userSession = JSON.parse(sessionData);
+      const eventId = userSession?.targetEvent;
+
+      if (!eventId || eventId === 0) {
+        return;
+      }
+
+      const inBookingSession = await this.getSession(eventId, sid);
+
+      if (!inBookingSession) {
+        return;
+      }
+
+      const bookedSeats = inBookingSession.bookedSeats;
+
+      if (bookedSeats && bookedSeats.length > 0) {
+        this.eventEmitter.emit('logout-release-seats', {
+          sid,
+          eventId,
+          bookedSeats,
+        });
+      }
+
+      await this.removeInBooking(eventId, sid);
+      await this.redis.zrem(`reconnecting:${eventId}`, sid);
+    } catch (error) {
+      this.logger.error(`(로그아웃) InBooking 세션 정리 실패: ${error.message}`, error.stack);
     }
   }
 }

--- a/back/src/domains/user/service/user.service.ts
+++ b/back/src/domains/user/service/user.service.ts
@@ -4,14 +4,16 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
-  Logger,
   UnauthorizedException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Cron } from '@nestjs/schedule';
 import * as bcrypt from 'bcryptjs';
 import Redis from 'ioredis';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { DataSource, In } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
+import { Logger as WinstonLogger } from 'winston';
 
 import { USER_STATUS } from '../../../auth/const/userStatus.const';
 import { AuthService } from '../../../auth/service/auth.service';
@@ -27,7 +29,6 @@ import { UserRepository } from '../repository/user.repository';
 
 @Injectable()
 export class UserService {
-  private readonly logger = new Logger(UserService.name);
   private readonly redis: Redis;
 
   constructor(
@@ -35,6 +36,8 @@ export class UserService {
     @Inject() private readonly redisService: RedisService,
     @Inject() private readonly authService: AuthService,
     @Inject() private readonly dataSource: DataSource,
+    @Inject() private readonly eventEmitter: EventEmitter2,
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
   ) {
     this.redis = this.redisService.getOrThrow();
   }
@@ -134,7 +137,14 @@ export class UserService {
 
   async logoutUser(sid: string, { loginId }: UserParamDto) {
     try {
-      if ((await this.authService.removeSession(sid, loginId)) > 0) {
+      const sessionData = await this.redis.get(`user:${sid}`);
+      if (sessionData) {
+        this.eventEmitter.emit('logout-start', { sid, sessionData });
+        if ((await this.authService.removeSession(sid, loginId)) > 0) {
+          return { message: '로그아웃 되었습니다.' };
+        }
+      } else {
+        this.logger.warn(`세션이 존재하지 않는 사용자 로그아웃 시도: SID=${sid}, loginId=${loginId}`);
         return { message: '로그아웃 되었습니다.' };
       }
     } catch (err) {

--- a/back/src/domains/user/user.module.ts
+++ b/back/src/domains/user/user.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '../../auth/auth.module';
+import { EventModule } from '../event/event.module';
 
 import { UserController } from './controller/user.controller';
 import { User } from './entity/user.entity';
@@ -10,7 +11,7 @@ import { UserRepository } from './repository/user.repository';
 import { UserService } from './service/user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), AuthModule],
+  imports: [TypeOrmModule.forFeature([User]), AuthModule, EventModule],
   providers: [UserService, UserRepository],
   controllers: [UserController],
   exports: [UserService, UserRepository],


### PR DESCRIPTION
## 📌 이슈 번호
- close #349

## 🚀 구현 내용
- 로그아웃 요청 시 sid, 세션 데이터와 함께 로그아웃 이벤트 발행
- 로그아웃 이벤트를 구독하여 InBooking 세션 풀에서 세션을 정리하는 로직 구현

### 특이사항
- 현재 좌석 선택 중 로그아웃을 하면, 후대응하는 방식으로 해당 세션을 조회하고 점유중이던 좌석을 방출하도록 하고 있음. 그러나 로그아웃 시 세션의 정보가 사라져 후대응 로직이 진행될 수 없는 모순이 발견됨. 따라서 로그아웃 요청 시 선행적으로 세션에 대한 정리가 이뤄지도록 변경해야 함.
- 이벤트 발행 방식을 적용한 이유는 Auth 모듈과 타 모듈의 순환 참조 문제 방지를 위함.
- Entering(입장중) 세션 정리는 불필요(로그아웃된 세션에 대해 알아서 스킵됨)
- Waiting(대기큐) 세션 정리는 #304 이슈 해결 뒤에 따라서 구현되어야 함. 현재 상태로도 치명도는 낮음.

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->
