### PR TITLE
WS 연결 클라이언트 최신 좌석 스냅샷 전송 및 구독 정리 개선

### DIFF
--- a/back/src/benchmark/gateway/seats.gateway.ts
+++ b/back/src/benchmark/gateway/seats.gateway.ts
@@ -27,6 +27,10 @@ interface CustomWebSocket extends WebSocket {
   eventId?: number;
 }
 
+type SeatStatusObject = {
+  seatStatus: number[][];
+};
+
 @WebSocketGateway({
   cors: {
     origin: '*',
@@ -44,6 +48,7 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private eventClients = new Map<number, Set<CustomWebSocket>>();
   private eventSubscriptions = new Map<number, Subscription>();
   private eventConnectionCounts = new Map<number, number>();
+  private latestSeatsData = new Map<number, SeatStatusObject>();
 
   constructor(
     @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
@@ -87,7 +92,6 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.clients.add(client);
 
     const { eventId, sid } = this.parseConnectionParams(req);
-    this.logger.verbose(`[SEATS-WS-CONNECTED] Event ${eventId} | SID ${sid}`);
 
     if (!this.validateEventId(eventId, client, req)) {
       return;
@@ -110,6 +114,16 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     this.addClientToEvent(client, eventId);
     this.setupEventSubscription(eventId);
+
+    const latestData = this.latestSeatsData.get(eventId);
+    if (latestData && client.readyState === WebSocket.OPEN) {
+      client.send(
+        JSON.stringify({
+          type: 'seats-update',
+          data: latestData,
+        }),
+      );
+    }
   }
 
   private parseConnectionParams(req: Request): { eventId: number; sid: string } {
@@ -149,6 +163,7 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
       const observable = this.bookingSeatsService.getSeatsObservable(eventId);
 
       const subscription = observable.subscribe(async (seatData) => {
+        this.latestSeatsData.set(eventId, seatData);
         this.broadcastToEvent(eventId, {
           type: 'seats-update',
           data: seatData,
@@ -179,6 +194,7 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
       if (currentCount <= 1) {
         this.eventConnectionCounts.delete(eventId);
         this.eventClients.delete(eventId);
+        this.latestSeatsData.delete(eventId);
 
         const subscription = this.eventSubscriptions.get(eventId);
         if (subscription) {
@@ -189,7 +205,6 @@ export class SeatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
         this.eventConnectionCounts.set(eventId, currentCount - 1);
       }
     }
-    this.logger.verbose(`[SEATS-WS-DISCONNECTED] Event ${client.eventId} | SID ${client.sid}`);
   }
 
   private broadcastToEvent(eventId: number, message: any): void {

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -30,10 +30,15 @@ type SeatStatusObject = {
   seatStatus: number[][];
 };
 
+type SeatSubscription = {
+  subject: BehaviorSubject<SeatStatusObject>;
+  interval: NodeJS.Timeout;
+};
+
 @Injectable()
 export class BookingSeatsService {
   private readonly redis: Redis | null;
-  private seatsSubscriptionMap = new Map<number, BehaviorSubject<SeatStatusObject>>();
+  private seatsSubscriptionMap = new Map<number, SeatSubscription>();
   private broadcastActivateMap = new Map<number, boolean>();
 
   constructor(
@@ -57,16 +62,18 @@ export class BookingSeatsService {
     if (this.seatsSubscriptionMap.has(eventId)) {
       throw new InternalServerErrorException('이미 해당 이벤트의 좌석 구독이 존재합니다.');
     }
-    const subscription = await this.createSeatSubscription(eventId, seats);
-    this.seatsSubscriptionMap.set(eventId, subscription);
+    const seatSubscription = await this.createSeatSubscription(eventId, seats);
+    this.seatsSubscriptionMap.set(eventId, seatSubscription);
   }
 
   async clearSeatsSubscription(eventId: number) {
-    const subscription = this.seatsSubscriptionMap.get(eventId);
-    if (subscription) {
-      subscription.complete();
+    const seatSubscription = this.seatsSubscriptionMap.get(eventId);
+    if (seatSubscription) {
+      clearInterval(seatSubscription.interval);
+      seatSubscription.subject.complete();
       this.seatsSubscriptionMap.delete(eventId);
     }
+    this.broadcastActivateMap.delete(eventId);
     const keys = await this.redis.keys(`event:${eventId}:*`);
     if (keys.length > 0) {
       await this.redis.unlink(...keys);
@@ -170,7 +177,11 @@ export class BookingSeatsService {
   }
 
   getSeatsObservable(eventId: number) {
-    return this.seatsSubscriptionMap.get(eventId).asObservable();
+    const subscription = this.seatsSubscriptionMap.get(eventId);
+    if (!subscription) {
+      throw new InternalServerErrorException('해당 이벤트의 좌석 구독이 존재하지 않습니다.');
+    }
+    return subscription.subject.asObservable();
   }
 
   subscribeSeatsSSE(eventId: number) {
@@ -195,29 +206,33 @@ export class BookingSeatsService {
     return this.broadcastActivateMap.get(eventId);
   };
 
-  private async createSeatSubscription(eventId: number, initialSeats: number[][]) {
-    const subscription = new BehaviorSubject<SeatStatusObject>({ seatStatus: initialSeats });
+  private async createSeatSubscription(eventId: number, initialSeats: number[][]): Promise<SeatSubscription> {
+    const subject = new BehaviorSubject<SeatStatusObject>({ seatStatus: initialSeats });
     let lastBroadcastTime = Date.now();
 
-    setInterval(
+    const interval = setInterval(
       async () => {
         const now = Date.now();
         const timeSinceLastBroadcast = now - lastBroadcastTime;
 
         if (timeSinceLastBroadcast >= SSE_MAXIMUM_INTERVAL || this.isBroadcastActivated(eventId)) {
-          const seats = await this.getSeats(eventId);
-          subscription.next(new SeatsSseDto(seats));
-          lastBroadcastTime = Date.now();
+          try {
+            const seats = await this.getSeats(eventId);
+            subject.next(new SeatsSseDto(seats));
+            lastBroadcastTime = Date.now();
 
-          if (this.isBroadcastActivated(eventId)) {
-            this.unActivateNextBroadcast(eventId);
+            if (this.isBroadcastActivated(eventId)) {
+              this.unActivateNextBroadcast(eventId);
+            }
+          } catch (error) {
+            this.logger.error(`좌석 브로드캐스트 실패: eventId=${eventId}`, error);
           }
         }
       },
       Math.min(SEATS_BROADCAST_INTERVAL, SSE_MAXIMUM_INTERVAL),
     );
 
-    return subscription;
+    return { subject, interval };
   }
 
   @OnEvent('logout-release-seats')


### PR DESCRIPTION
## 📌 이슈 번호
- close #353

## 🚀 구현 내용
- `latestSeatsData` Map으로 이벤트별 최신 좌석 스냅샷을 보유하고, 신규 WS 연결 시 즉시 전송
- `seatsSubscriptionMap`을 `SeatSubscription` 타입으로 변경하여 구독 정리 시 `setInterval`을 함께 해제
- 구독 조회 실패 시 명시적 예외 처리 추가

### 특이사항
- 기존 구독 맵은 `BehaviorSubject`만 보관하여 구독 정리 시 `setInterval`이 해제되지 않는 메모리 누수 문제가 있었음
- WS 신규 연결 직후 interval에 의한 자동 전파 시점까지 화면 렌더링이 지연되는 문제가 있었음

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->