### PR TITLE
Lua 스크립트 내 좌석 비트맵 청크 단위 조회로 성능 개선

### DIFF
--- a/back/src/domains/booking/luaScripts/getSeatsLua.ts
+++ b/back/src/domains/booking/luaScripts/getSeatsLua.ts
@@ -2,20 +2,36 @@ import Redis from 'ioredis';
 
 const getSeatsLua = `
   local eventId = KEYS[1]
-  local sectionsLen = redis.call('GET', 'event:'..eventId..':sections:len')
+  local sectionsLen = tonumber(redis.call('GET', 'event:'..eventId..':sections:len'))
+  if not sectionsLen then return nil end
   
   local placeResult = {}
-  for i = 0, tonumber(sectionsLen)-1 do
-    local seatsLen = redis.call('GET', 'event:'..eventId..':section:'..i..':seats:len')
-    local sectionResult = {}
-    for j = 0, tonumber(seatsLen)-1 do
-      local seat = redis.call('GETBIT', 'event:'..eventId..':section:'..i..':seats', j)
-      if not (seat == 0 or seat == 1) then
-        return nil
+  local bitMasks = {128, 64, 32, 16, 8, 4, 2, 1}
+  
+  for i = 0, sectionsLen - 1 do
+      local sectionKey = 'event:'..eventId..':section:'..i..':seats'
+      local seatsLen = tonumber(redis.call('GET', sectionKey..':len'))
+      if not seatsLen then return nil end
+      
+      local byteLen = math.ceil(seatsLen / 8)
+      local rawBytes = redis.call('GETRANGE', sectionKey, 0, byteLen - 1)
+      
+      local sectionResult = {}
+      local resultIndex = 1
+      
+      for byteIndex = 1, byteLen do
+          local byte = string.byte(rawBytes, byteIndex) or 0
+          
+          for bitPos = 1, 8 do
+              if resultIndex > seatsLen then break end
+              sectionResult[resultIndex] = math.floor(byte / bitMasks[bitPos]) % 2
+              resultIndex = resultIndex + 1
+          end
+          
+          if resultIndex > seatsLen then break end
       end
-      table.insert(sectionResult, seat)
-    end
-    table.insert(placeResult, sectionResult)  
+      
+      table.insert(placeResult, sectionResult)
   end
   
   return placeResult


### PR DESCRIPTION
## 📌 이슈 번호
- close #354

## 🚀 구현 내용
- Lua 스크립트 내 좌석 상태 조회 방식을 `GETBIT` 단건 조회에서 `GETRANGE` + 비트 마스크 분해 방식으로 변경

### 특이사항
- 기존 방식은 `GETBIT`으로 좌석 비트를 하나씩 조회하여 좌석 수만큼 Redis 명령이 발생하는 성능 병목이 있었음
- `GETRANGE`로 바이트 청크를 한 번에 읽고 비트 마스크로 분해하는 방식으로 변경하여 Redis 명령 호출 횟수를 대폭 줄임

<!--## 📘 참고 사항: 관련 내용, 블로그, 링크 -->

<!--## ❓ 궁금한 내용-->

<!--## 🤝 리뷰 요청: 리뷰어들에게 요청하는 내용-->