### PR TITLE
전 도메인 E2E 테스트 추가

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -14,11 +14,11 @@
     "start:prod:watch": "cross-env NODE_ENV=production EXEC_MODE=dev nest start --watch",
     "start:prod:compiled": "cross-env NODE_ENV=development EXEC_MODE=dev node dist/main",
     "start:prod:debug": "cross-env NODE_ENV=production EXEC_MODE=dev nest start --debug 0.0.0.0:9229 --watch",
-    "test": "cross-env NODE_ENV=test jest",
-    "test:watch": "cross-env NODE_ENV=test jest --watch",
+    "test": "cross-env NODE_ENV=test EXEC_MODE=test jest --config ./test/jest-e2e.json",
+    "test:unit": "cross-env NODE_ENV=test jest",
+    "test:watch": "cross-env NODE_ENV=test EXEC_MODE=test jest --config ./test/jest-e2e.json --watch",
     "test:cov": "cross-env NODE_ENV=test jest --coverage",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "cross-env NODE_ENV=test EXEC_MODE=test jest --config ./test/jest-e2e.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint --fix",
     "prettier": "prettier -w"
@@ -108,6 +108,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/back/src/config/.env.test
+++ b/back/src/config/.env.test
@@ -19,7 +19,7 @@ REDIS_PORT=6379
 # 프론트엔드 URL
 FRONT_URL=http://localhost:30000
 
-# 로그 저장 설정
+# 로그 설정 (LOG_SAVE_MODE 미설정 시 파일 로그 비활성화)
 LOG_MAX_SIZE=20m
 LOG_MAX_LIFE=30d
 LOG_ZIP=false

--- a/back/src/domains/event/controller/event.controller.ts
+++ b/back/src/domains/event/controller/event.controller.ts
@@ -92,7 +92,7 @@ export class EventController {
   @ApiInternalServerErrorResponse({ description: '서버 내부 에러', type: Error })
   async createEvent(@Body() eventCreationDto: EventCreationDto) {
     try {
-      await this.eventService.create(eventCreationDto);
+      return await this.eventService.create(eventCreationDto);
     } catch (error) {
       if (error instanceof BadRequestException || NotFoundException) throw error;
       throw new InternalServerErrorException('서버 오류 발생');

--- a/back/src/domains/event/service/event.service.ts
+++ b/back/src/domains/event/service/event.service.ts
@@ -48,7 +48,7 @@ export class EventService {
     });
   }
 
-  async create(eventCreationDto: EventCreationDto): Promise<void> {
+  async create(eventCreationDto: EventCreationDto) {
     this.validateEventDate(eventCreationDto);
     const program: Program = await this.programRepository.selectProgramWithPlace(eventCreationDto.programId);
     if (!program) throw new NotFoundException(`해당 프로그램[${eventCreationDto.programId}]가 없습니다.`);
@@ -56,7 +56,7 @@ export class EventService {
     if (!program.place)
       throw new NotFoundException(`해당 프로그램[${eventCreationDto.programId}]의 장소가 없습니다.`);
 
-    await this.eventRepository.storeEvent({ ...eventCreationDto, program, place });
+    return await this.eventRepository.storeEvent({ ...eventCreationDto, program, place });
   }
 
   private validateEventDate({

--- a/back/src/domains/place/controller/place.controller.ts
+++ b/back/src/domains/place/controller/place.controller.ts
@@ -90,7 +90,7 @@ export class PlaceController {
   @ApiInternalServerErrorResponse({ description: '서버 내부 에러', type: Error })
   async createPlace(@Body() placeCreationDto: PlaceCreationDto) {
     try {
-      await this.placeService.createPlace(placeCreationDto);
+      return await this.placeService.createPlace(placeCreationDto);
     } catch (error) {
       if (error instanceof BadRequestException) throw error;
       throw new InternalServerErrorException('서버 내부 오류');

--- a/back/src/domains/place/service/place.service.ts
+++ b/back/src/domains/place/service/place.service.ts
@@ -1,10 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  InternalServerErrorException,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 
 import { PlaceCreationDto } from '../dto/placeCreation.dto';
@@ -28,16 +22,17 @@ export class PlaceService {
   async getSeats(placeId: number): Promise<SeatInfoDto> {
     try {
       const place: Place = await this.placeRepository.selectPlace(placeId);
+
+      if (!place) {
+        throw new NotFoundException(`해당 장소[${placeId}]가 존재하지 않습니다.`);
+      }
+
       const sectionNameList = place.sections;
       const secitons = await Promise.all(
         sectionNameList.map(async (sectionName) => {
           return await this.sectionRepository.findById(parseInt(sectionName, 10));
         }),
       );
-
-      if (!place) {
-        throw new BadRequestException('해당 장소가 존재하지 않습니다.');
-      }
 
       return {
         id: place.id,
@@ -50,6 +45,7 @@ export class PlaceService {
         },
       };
     } catch (err) {
+      if (err instanceof NotFoundException) throw err;
       this.logger.error(err);
       throw new InternalServerErrorException('서버 오류 발생');
     }

--- a/back/src/domains/place/service/place.service.ts
+++ b/back/src/domains/place/service/place.service.ts
@@ -56,7 +56,7 @@ export class PlaceService {
   }
 
   async createPlace(placeCreationDto: PlaceCreationDto) {
-    this.placeRepository.storePlace({
+    return await this.placeRepository.storePlace({
       ...placeCreationDto,
       sections: [],
     });

--- a/back/src/domains/program/controller/program.controller.ts
+++ b/back/src/domains/program/controller/program.controller.ts
@@ -116,7 +116,7 @@ export class ProgramController {
   @ApiInternalServerErrorResponse({ description: '서버 내부 에러', type: Error })
   async createProgram(@Body() programCreationDto: ProgramCreationDto) {
     try {
-      await this.programService.create(programCreationDto);
+      return await this.programService.create(programCreationDto);
     } catch (error) {
       if (error instanceof BadRequestException || NotFoundException) throw error;
       throw new InternalServerErrorException('서버 오류 발생');

--- a/back/src/domains/program/repository/program.repository.ts
+++ b/back/src/domains/program/repository/program.repository.ts
@@ -47,7 +47,10 @@ export class ProgramRepository {
     try {
       return await this.ProgramRepository.delete(id);
     } catch (error) {
-      if (error.code === 'ER_ROW_IS_REFERENCED_2')
+      if (
+        error.code === 'ER_ROW_IS_REFERENCED_2' ||
+        (error instanceof QueryFailedError && error.message.includes('FOREIGN KEY constraint failed'))
+      )
         throw new ConflictException('해당 프로그램에 대한 이벤트가 존재합니다.');
       throw error;
     }

--- a/back/src/domains/program/service/program.service.ts
+++ b/back/src/domains/program/service/program.service.ts
@@ -49,8 +49,8 @@ export class ProgramService {
     return new ProgramSpecificDto({ ...program, place, events: openedEvents });
   }
 
-  async create(programCreationDto: ProgramCreationDto): Promise<void> {
-    await this.programRepository.storeProgram({
+  async create(programCreationDto: ProgramCreationDto) {
+    return await this.programRepository.storeProgram({
       ...programCreationDto,
       placeId: programCreationDto.placeId,
     });

--- a/back/src/util/logger/winston.config.ts
+++ b/back/src/util/logger/winston.config.ts
@@ -70,7 +70,8 @@ export const winstonConfig = {
       ),
     }),
 
-    new winstonDaily(dailyOptions('critical', 'warn')),
-    new winstonDaily(dailyOptions('all')),
+    ...(process.env.LOG_SAVE_MODE
+      ? [new winstonDaily(dailyOptions('critical', 'warn')), new winstonDaily(dailyOptions('all'))]
+      : []),
   ],
 };

--- a/back/test/app.e2e-spec.ts
+++ b/back/test/app.e2e-spec.ts
@@ -1,22 +1,20 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import supertest from 'supertest';
 
-import { AppModule } from './../src/app.module';
+import { createTestApp } from './helpers/e2e-setup';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
+  afterAll(async () => {
+    await app.close();
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
+    return supertest(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
   });
 });

--- a/back/test/booking.e2e-spec.ts
+++ b/back/test/booking.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import supertest from 'supertest';
 
+import { AuthService } from 'src/auth/service/auth.service';
 import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
@@ -16,6 +17,9 @@ import {
   openEventReservation,
   requestPermission,
   setBookingCount,
+  setupSelectingSeat,
+  simulateSseCloseTimeout,
+  simulateSseDisconnect,
   transitionToSelectingSeat,
   withAuth,
 } from './helpers/e2e-setup';
@@ -260,6 +264,98 @@ describe('Booking (e2e)', () => {
       await withAuth(supertest(app.getHttpServer()).post('/booking/in-booking-pool-size/default'), userSid)
         .send({ maxSize: 100 })
         .expect(401);
+    });
+  });
+
+  // ─── SSE 연결 해제 ───
+
+  describe('SSE 연결 해제 시나리오', () => {
+    it('예매 확정 후 SSE 해제 → 좌석 회수되지 않음 (saved=true)', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      const userSid = await loginAsUser(app, 'sseuser1', 'pass1234');
+      await requestPermission(app, userSid, eventId).expect(200);
+      await setBookingCount(app, userSid, 1).expect(201);
+      await transitionToSelectingSeat(app, userSid);
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      // 예매 확정 → saved=true
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 0 }] })
+        .expect(201);
+
+      // SSE 해제 1차: 상태 → RECONNECTING_SELECTING
+      await simulateSseDisconnect(app, userSid);
+
+      const authService = app.get(AuthService);
+      const session = await authService.getUserSession(userSid);
+      expect(session.userStatus).toBe('RECONNECTING_SELECTING');
+
+      // SSE 해제 2차: 타임아웃 만료 → 정리
+      await simulateSseCloseTimeout(app, userSid);
+
+      // 좌석이 여전히 점유 상태인지 확인 — 이벤트 재초기화 없이 다른 유저가 같은 좌석 점유 시도
+      const user2Sid = await loginAsUser(app, 'sseuser2', 'pass1234');
+      await requestPermission(app, user2Sid, eventId).expect(200);
+      await setBookingCount(app, user2Sid, 1).expect(201);
+      await transitionToSelectingSeat(app, user2Sid);
+      await bookSeat(app, user2Sid, eventId, 0, 0, 'reserved').expect(409);
+    });
+
+    it('예매 미확정 상태에서 SSE 해제 → 좌석 회수됨 (saved=false)', async () => {
+      const userSid = await loginAsUser(app, 'sseuser3', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, userSid, 1);
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      // 예매 확정 없이 SSE 해제
+      await simulateSseDisconnect(app, userSid);
+      await simulateSseCloseTimeout(app, userSid);
+
+      // 좌석이 회수됐으므로 다른 유저가 점유 가능
+      const user2Sid = await loginAsUser(app, 'sseuser4', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, user2Sid, 1);
+      await bookSeat(app, user2Sid, eventId, 0, 0, 'reserved').expect(201);
+    });
+
+    it('SSE 해제 후 세션이 LOGIN 상태로 복귀', async () => {
+      const userSid = await loginAsUser(app, 'sseuser5', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, userSid, 1);
+
+      await simulateSseDisconnect(app, userSid);
+      await simulateSseCloseTimeout(app, userSid);
+
+      // LOGIN 상태 → 좌석 점유 불가 (401)
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(401);
+    });
+
+    it('SSE 해제 후 대기열 다음 유저가 입장', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      // maxSize=1로 제한
+      await withAuth(
+        supertest(app.getHttpServer()).post(`/booking/in-booking-pool-size/event/${eventId}`),
+        adminSid,
+      )
+        .send({ maxSize: 1 })
+        .expect(201);
+
+      // user1 입장 → SELECTING_SEAT
+      const user1Sid = await loginAsUser(app, 'sseuser6', 'pass1234');
+      await requestPermission(app, user1Sid, eventId).expect(200);
+      await setBookingCount(app, user1Sid, 1).expect(201);
+      await transitionToSelectingSeat(app, user1Sid);
+
+      // user2 대기열 진입
+      const user2Sid = await loginAsUser(app, 'sseuser7', 'pass1234');
+      const waitRes = await requestPermission(app, user2Sid, eventId).expect(200);
+      expect(waitRes.body.waitingStatus).toBe(true);
+
+      // user1 SSE 해제 → 슬롯 반환 → user2 입장
+      await simulateSseDisconnect(app, user1Sid);
+      await simulateSseCloseTimeout(app, user1Sid);
+
+      // user2가 ENTERING 상태가 됐으므로 인원 설정 가능
+      const countRes = await setBookingCount(app, user2Sid, 1).expect(201);
+      expect(countRes.body.bookingAmount).toBe(1);
     });
   });
 

--- a/back/test/booking.e2e-spec.ts
+++ b/back/test/booking.e2e-spec.ts
@@ -1,7 +1,10 @@
+import http from 'http';
+
 import { INestApplication } from '@nestjs/common';
 import supertest from 'supertest';
 
 import { AuthService } from 'src/auth/service/auth.service';
+import { SEATS_BROADCAST_INTERVAL } from 'src/domains/booking/const/seatsBroadcastInterval.const';
 import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
@@ -356,6 +359,83 @@ describe('Booking (e2e)', () => {
       // user2가 ENTERING 상태가 됐으므로 인원 설정 가능
       const countRes = await setBookingCount(app, user2Sid, 1).expect(201);
       expect(countRes.body.bookingAmount).toBe(1);
+    });
+  });
+
+  // ─── SSE 좌석 브로드캐스트 타이밍 ───
+
+  describe('SSE 좌석 브로드캐스트', () => {
+    it(`좌석 변경 후 ${SEATS_BROADCAST_INTERVAL}ms 이내에 브로드캐스트 수신`, async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      // SSE 구독용 유저: ENTERING 상태까지 진행
+      const sseSid = await loginAsUser(app, 'bcastusr1', 'pass1234');
+      await requestPermission(app, sseSid, eventId).expect(200);
+      await setBookingCount(app, sseSid, 1).expect(201);
+
+      // 좌석 변경용 유저: SELECTING_SEAT 상태까지 진행
+      const actorSid = await loginAsUser(app, 'bcastusr2', 'pass1234');
+      await requestPermission(app, actorSid, eventId).expect(200);
+      await setBookingCount(app, actorSid, 1).expect(201);
+      await transitionToSelectingSeat(app, actorSid);
+
+      const server = app.getHttpServer();
+      if (!server.listening) {
+        await new Promise<void>((res) => server.listen(0, res));
+      }
+      const port = server.address().port;
+
+      const broadcastTime = await new Promise<number>((resolve, reject) => {
+        const TOLERANCE = 200;
+        const timeout = setTimeout(() => {
+          req.destroy();
+          reject(new Error(`브로드캐스트가 ${SEATS_BROADCAST_INTERVAL + TOLERANCE}ms 내에 도착하지 않음`));
+        }, SEATS_BROADCAST_INTERVAL + TOLERANCE);
+
+        let initialReceived = false;
+        let changeRequestedAt: number;
+        let buffer = '';
+
+        const req = http.get(
+          `http://127.0.0.1:${port}/booking/seat/${eventId}`,
+          { headers: { Cookie: `SID=${sseSid}` } },
+          (res) => {
+            res.on('data', (chunk: Buffer) => {
+              buffer += chunk.toString();
+
+              // SSE 이벤트는 빈 줄(\n\n)로 구분
+              const events = buffer.split('\n\n');
+              buffer = events.pop() || '';
+
+              for (const event of events) {
+                if (!event.trim()) continue;
+
+                if (!initialReceived) {
+                  // 초기 브로드캐스트 무시 → 좌석 변경 수행
+                  initialReceived = true;
+                  changeRequestedAt = Date.now();
+                  bookSeat(app, actorSid, eventId, 0, 0, 'reserved').expect(201).catch(reject);
+                } else {
+                  // 변경 후 첫 브로드캐스트
+                  const elapsed = Date.now() - changeRequestedAt;
+                  clearTimeout(timeout);
+                  req.destroy();
+                  resolve(elapsed);
+                }
+              }
+            });
+          },
+        );
+
+        req.on('error', (err) => {
+          if (err.message !== 'socket hang up') {
+            clearTimeout(timeout);
+            reject(err);
+          }
+        });
+      });
+
+      expect(broadcastTime).toBeLessThanOrEqual(SEATS_BROADCAST_INTERVAL + 200);
     });
   });
 

--- a/back/test/booking.e2e-spec.ts
+++ b/back/test/booking.e2e-spec.ts
@@ -1,0 +1,282 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  bookSeat,
+  createEvent,
+  createPlace,
+  createProgram,
+  createSections,
+  createTestApp,
+  getRedisService,
+  loginAsAdmin,
+  loginAsUser,
+  openEventReservation,
+  requestPermission,
+  setBookingCount,
+  transitionToSelectingSeat,
+  withAuth,
+} from './helpers/e2e-setup';
+
+describe('Booking (e2e)', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+  let adminSid: string;
+  let placeId: number;
+  let programId: number;
+  let eventId: number;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+
+    // DB 데이터 생성 (앱 인스턴스 수명 동안 유지)
+    adminSid = await loginAsAdmin(app, 'bkadmin1', 'pass1234');
+    placeId = await createPlace(app, adminSid);
+    await createSections(app, adminSid, placeId, [
+      { name: 'A', colLen: 3, seats: [1, 1, 1, 1, 1, 1], order: 0 },
+      { name: 'B', colLen: 2, seats: [1, 1, 1, 1], order: 1 },
+    ]);
+    programId = await createProgram(app, adminSid, placeId);
+    eventId = await createEvent(app, adminSid, programId, {
+      reservationOpenDate: new Date(Date.now() - 86400000).toISOString(),
+    });
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+    adminSid = await loginAsAdmin(app, 'bkadmin1', 'pass1234');
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  // ─── 서버 시간 ───
+
+  describe('GET /booking/server-time', () => {
+    it('인증된 사용자 → 서버 시간 반환', async () => {
+      const userSid = await loginAsUser(app, 'timeuser1', 'pass1234');
+      const before = Date.now();
+
+      const res = await withAuth(supertest(app.getHttpServer()).get('/booking/server-time'), userSid).expect(
+        200,
+      );
+
+      const after = Date.now();
+      expect(res.body.now).toBeGreaterThanOrEqual(before);
+      expect(res.body.now).toBeLessThanOrEqual(after);
+    });
+
+    it('미인증 → 403', async () => {
+      await supertest(app.getHttpServer()).get('/booking/server-time').expect(403);
+    });
+  });
+
+  // ─── 입장 허가 ───
+
+  describe('GET /booking/permission/:eventId', () => {
+    it('예약이 오픈된 이벤트 → 입장 허가 (enteringStatus)', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      const userSid = await loginAsUser(app, 'permuser1', 'pass1234');
+
+      const res = await requestPermission(app, userSid, eventId).expect(200);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          enteringStatus: true,
+          waitingStatus: false,
+        }),
+      );
+    });
+
+    it('예약이 오픈되지 않은 이벤트 → 400', async () => {
+      // Redis flushed 상태, 이벤트 미오픈
+      const userSid = await loginAsUser(app, 'permuser2', 'pass1234');
+
+      await requestPermission(app, userSid, eventId).expect(400);
+    });
+
+    it('인원 초과 시 대기열로 진입 (waitingStatus)', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      // maxSize를 1로 제한
+      await withAuth(
+        supertest(app.getHttpServer()).post(`/booking/in-booking-pool-size/event/${eventId}`),
+        adminSid,
+      )
+        .send({ maxSize: 1 })
+        .expect(201);
+
+      // 1번 유저: 입장 → SELECTING_SEAT (슬롯 점유)
+      const user1Sid = await loginAsUser(app, 'permuser3', 'pass1234');
+      await requestPermission(app, user1Sid, eventId).expect(200);
+      await setBookingCount(app, user1Sid, 1).expect(201);
+      await transitionToSelectingSeat(app, user1Sid);
+
+      // 2번 유저: maxSize=1이므로 대기열
+      const user2Sid = await loginAsUser(app, 'permuser4', 'pass1234');
+      const res = await requestPermission(app, user2Sid, eventId).expect(200);
+
+      expect(res.body.waitingStatus).toBe(true);
+      expect(res.body.userOrder).toBeDefined();
+    });
+
+    it('미인증 → 403', async () => {
+      await supertest(app.getHttpServer()).get(`/booking/permission/${eventId}`).expect(403);
+    });
+  });
+
+  // ─── 예매 인원 설정 ───
+
+  describe('POST /booking/count', () => {
+    it('ENTERING 상태에서 인원 설정 → 성공', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      const userSid = await loginAsUser(app, 'cntuser1', 'pass1234');
+      await requestPermission(app, userSid, eventId).expect(200);
+
+      const res = await setBookingCount(app, userSid, 2).expect(201);
+
+      expect(res.body.bookingAmount).toBe(2);
+    });
+
+    it('범위 밖 인원(0, 5) → 400', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      const userSid = await loginAsUser(app, 'cntuser2', 'pass1234');
+      await requestPermission(app, userSid, eventId).expect(200);
+
+      await setBookingCount(app, userSid, 0).expect(400);
+      await setBookingCount(app, userSid, 5).expect(400);
+    });
+
+    it('LOGIN 상태에서 → 401', async () => {
+      const userSid = await loginAsUser(app, 'cntuser3', 'pass1234');
+
+      await setBookingCount(app, userSid, 1).expect(401);
+    });
+  });
+
+  // ─── 좌석 점유/취소 ───
+
+  describe('POST /booking (좌석 점유)', () => {
+    let userSid: string;
+
+    beforeEach(async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      userSid = await loginAsUser(app, 'seatusr1', 'pass1234');
+      await requestPermission(app, userSid, eventId).expect(200);
+      await setBookingCount(app, userSid, 2).expect(201);
+      await transitionToSelectingSeat(app, userSid);
+    });
+
+    it('좌석 점유 → 성공', async () => {
+      const res = await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          sectionIndex: 0,
+          seatIndex: 0,
+          acceptedStatus: 'reserved',
+        }),
+      );
+    });
+
+    it('이미 점유된 좌석 재점유 → 409 Conflict', async () => {
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(409);
+    });
+
+    it('좌석 취소 → 성공', async () => {
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      const res = await bookSeat(app, userSid, eventId, 0, 0, 'deleted').expect(201);
+
+      expect(res.body.acceptedStatus).toBe('deleted');
+    });
+
+    it('예매 수량 초과 → 400', async () => {
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+      await bookSeat(app, userSid, eventId, 0, 1, 'reserved').expect(201);
+
+      // bookingAmount=2인데 3번째 좌석 점유 시도
+      await bookSeat(app, userSid, eventId, 0, 2, 'reserved').expect(400);
+    });
+
+    it('LOGIN 상태에서 좌석 점유 → 401', async () => {
+      const loginOnlySid = await loginAsUser(app, 'seatusr2', 'pass1234');
+
+      await bookSeat(app, loginOnlySid, eventId, 0, 0, 'reserved').expect(401);
+    });
+  });
+
+  // ─── 관리자: 인원 풀 설정 ───
+
+  describe('Admin: 인원 풀 설정', () => {
+    it('이벤트별 maxSize 설정', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      const res = await withAuth(
+        supertest(app.getHttpServer()).post(`/booking/in-booking-pool-size/event/${eventId}`),
+        adminSid,
+      )
+        .send({ maxSize: 50 })
+        .expect(201);
+
+      expect(res.body.maxSize).toBe(50);
+    });
+
+    it('전체 이벤트 maxSize 설정', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      const res = await withAuth(
+        supertest(app.getHttpServer()).post('/booking/in-booking-pool-size/all'),
+        adminSid,
+      )
+        .send({ maxSize: 100 })
+        .expect(201);
+
+      expect(res.body.maxSize).toBe(100);
+    });
+
+    it('기본값 maxSize 설정', async () => {
+      const res = await withAuth(
+        supertest(app.getHttpServer()).post('/booking/in-booking-pool-size/default'),
+        adminSid,
+      )
+        .send({ maxSize: 200 })
+        .expect(201);
+
+      expect(res.body.maxSize).toBe(200);
+    });
+
+    it('일반 유저 → 401', async () => {
+      const userSid = await loginAsUser(app, 'pooluser1', 'pass1234');
+
+      await withAuth(supertest(app.getHttpServer()).post('/booking/in-booking-pool-size/default'), userSid)
+        .send({ maxSize: 100 })
+        .expect(401);
+    });
+  });
+
+  // ─── 관리자: 예약 초기화 ───
+
+  describe('POST /booking/init/:eventId', () => {
+    it('관리자가 예약 초기화 → 성공', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      // 재초기화
+      await openEventReservation(app, adminSid, eventId).expect(201);
+    });
+
+    it('일반 유저 → 401', async () => {
+      const userSid = await loginAsUser(app, 'inituser1', 'pass1234');
+
+      await withAuth(supertest(app.getHttpServer()).post(`/booking/init/${eventId}`), userSid).expect(401);
+    });
+  });
+});

--- a/back/test/event.e2e-spec.ts
+++ b/back/test/event.e2e-spec.ts
@@ -1,0 +1,202 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  createEvent,
+  createPlace,
+  createProgram,
+  createTestApp,
+  getRedisService,
+  loginAsAdmin,
+  loginAsGuest,
+  loginUser,
+  signup,
+  withAuth,
+} from './helpers/e2e-setup';
+
+describe('Event (e2e)', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+  let adminSid: string;
+  let placeId: number;
+  let programId: number;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+    adminSid = await loginAsAdmin(app, 'evadmin1', 'pass1234');
+    placeId = await createPlace(app, adminSid);
+    programId = await createProgram(app, adminSid, placeId);
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  // ─── Event 생성 ───
+
+  describe('POST /event', () => {
+    it('관리자 → Event 생성 성공 (201)', async () => {
+      const now = new Date();
+      const res = await withAuth(supertest(app.getHttpServer()).post('/event'), adminSid)
+        .send({
+          runningDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationOpenDate: new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationCloseDate: new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+          programId,
+        })
+        .expect(201);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+        }),
+      );
+    });
+
+    it('일반 유저 → 401', async () => {
+      const guestSid = await loginAsGuest(app);
+      const now = new Date();
+
+      await withAuth(supertest(app.getHttpServer()).post('/event'), guestSid)
+        .send({
+          runningDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationOpenDate: new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationCloseDate: new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+          programId,
+        })
+        .expect(401);
+    });
+
+    it('날짜 순서 위반 (openDate > closeDate) → 400', async () => {
+      const now = new Date();
+
+      await withAuth(supertest(app.getHttpServer()).post('/event'), adminSid)
+        .send({
+          runningDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationOpenDate: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationCloseDate: new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+          programId,
+        })
+        .expect(400);
+    });
+
+    it('존재하지 않는 programId → 404', async () => {
+      const now = new Date();
+
+      await withAuth(supertest(app.getHttpServer()).post('/event'), adminSid)
+        .send({
+          runningDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationOpenDate: new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+          reservationCloseDate: new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+          programId: 99999,
+        })
+        .expect(404);
+    });
+
+    it('필수 필드 누락 → 400', async () => {
+      await withAuth(supertest(app.getHttpServer()).post('/event'), adminSid).send({ programId }).expect(400);
+    });
+  });
+
+  // ─── Event 조회 ───
+
+  describe('GET /event/:eventId', () => {
+    it('인증된 사용자 → Event 상세 조회', async () => {
+      const eventId = await createEvent(app, adminSid, programId);
+
+      await signup(app, 'evuser01', 'pass1234');
+      const userSid = await loginUser(app, 'evuser01', 'pass1234');
+
+      const res = await withAuth(supertest(app.getHttpServer()).get(`/event/${eventId}`), userSid).expect(
+        200,
+      );
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: eventId,
+          name: expect.any(String),
+          place: expect.objectContaining({ id: expect.any(Number) }),
+          price: expect.any(Number),
+          runningTime: expect.any(Number),
+          runningDate: expect.any(String),
+          reservationOpenDate: expect.any(String),
+          reservationCloseDate: expect.any(String),
+        }),
+      );
+    });
+
+    it('미인증 → 403', async () => {
+      const eventId = await createEvent(app, adminSid, programId);
+
+      await supertest(app.getHttpServer()).get(`/event/${eventId}`).expect(403);
+    });
+
+    it('존재하지 않는 eventId → 404', async () => {
+      await withAuth(supertest(app.getHttpServer()).get('/event/99999'), adminSid).expect(404);
+    });
+  });
+
+  // ─── Event 삭제 ───
+
+  describe('DELETE /event/:eventId', () => {
+    it('관리자 → Event 삭제 성공', async () => {
+      const eventId = await createEvent(app, adminSid, programId);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/event/${eventId}`), adminSid).expect(200);
+
+      // 삭제 확인
+      await withAuth(supertest(app.getHttpServer()).get(`/event/${eventId}`), adminSid).expect(404);
+    });
+
+    it('일반 유저 → 삭제 불가', async () => {
+      const eventId = await createEvent(app, adminSid, programId);
+      const guestSid = await loginAsGuest(app);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/event/${eventId}`), guestSid).expect(401);
+    });
+  });
+
+  // ─── 통합 시나리오 ───
+
+  describe('데이터 연관관계 플로우', () => {
+    it('Place → Program → Event 생성 → Program 상세에서 Event 확인', async () => {
+      const myPlaceId = await createPlace(app, adminSid, { name: '통합 테스트 홀' });
+      const myProgramId = await createProgram(app, adminSid, myPlaceId, { name: '통합 테스트 공연' });
+      await createEvent(app, adminSid, myProgramId);
+      await createEvent(app, adminSid, myProgramId);
+
+      // Program 상세에서 Event 2개 확인
+      const res = await supertest(app.getHttpServer()).get(`/program/${myProgramId}`).expect(200);
+
+      expect(res.body.name).toBe('통합 테스트 공연');
+      expect(res.body.events.length).toBe(2);
+    });
+
+    it('Event가 있는 Program 삭제 시도 → 409', async () => {
+      const myProgramId = await createProgram(app, adminSid, placeId);
+      await createEvent(app, adminSid, myProgramId);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/program/${myProgramId}`), adminSid).expect(409);
+    });
+
+    it('Event 삭제 후 Program 삭제 가능', async () => {
+      const myProgramId = await createProgram(app, adminSid, placeId);
+      const myEventId = await createEvent(app, adminSid, myProgramId);
+
+      // Event 먼저 삭제
+      await withAuth(supertest(app.getHttpServer()).delete(`/event/${myEventId}`), adminSid).expect(200);
+
+      // 이제 Program 삭제 가능
+      await withAuth(supertest(app.getHttpServer()).delete(`/program/${myProgramId}`), adminSid).expect(200);
+    });
+  });
+});

--- a/back/test/helpers/e2e-setup.ts
+++ b/back/test/helpers/e2e-setup.ts
@@ -1,0 +1,109 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test as NestTest, TestingModule } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import supertest from 'supertest';
+
+import { AppModule } from 'src/app.module';
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+/**
+ * E2E 테스트용 NestJS 앱 인스턴스를 생성한다.
+ * - moduleFactory가 NODE_ENV=test를 감지해 자동으로 in-memory DB + mock Redis 사용
+ * - main.ts의 글로벌 설정(ValidationPipe, cookieParser)을 동일하게 적용
+ */
+export async function createTestApp(): Promise<INestApplication> {
+  const moduleFixture: TestingModule = await NestTest.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.use(cookieParser());
+  await app.init();
+
+  return app;
+}
+
+/**
+ * TestRedisService 인스턴스를 가져온다.
+ */
+export function getRedisService(app: INestApplication): TestRedisService {
+  return app.get(TestRedisService);
+}
+
+// ─── Auth Helpers ───
+
+/**
+ * 회원가입 요청을 보낸다.
+ */
+export function signup(app: INestApplication, loginId: string, loginPassword: string) {
+  return supertest(app.getHttpServer()).post('/user/signup').send({ loginId, loginPassword });
+}
+
+/**
+ * 관리자 회원가입 요청을 보낸다.
+ */
+export function signupAdmin(app: INestApplication, loginId: string, loginPassword: string) {
+  return supertest(app.getHttpServer()).post('/user/signup/admin').send({ loginId, loginPassword });
+}
+
+/**
+ * 로그인 후 SID 쿠키를 반환한다.
+ */
+export async function loginUser(
+  app: INestApplication,
+  loginId: string,
+  loginPassword: string,
+): Promise<string> {
+  const res = await supertest(app.getHttpServer())
+    .post('/user/login')
+    .send({ loginId, loginPassword })
+    .expect(201);
+
+  return extractSid(res);
+}
+
+/**
+ * 게스트 로그인 후 SID 쿠키를 반환한다.
+ */
+export async function loginAsGuest(app: INestApplication): Promise<string> {
+  const res = await supertest(app.getHttpServer()).get('/user/guest').expect(200);
+  return extractSid(res);
+}
+
+/**
+ * 관리자로 회원가입 + 로그인 후 SID를 반환한다.
+ */
+export async function loginAsAdmin(
+  app: INestApplication,
+  loginId = 'admin1234',
+  loginPassword = 'admin1234',
+): Promise<string> {
+  await signupAdmin(app, loginId, loginPassword).expect(201);
+  return loginUser(app, loginId, loginPassword);
+}
+
+/**
+ * supertest 응답에서 SID 쿠키 값을 추출한다.
+ */
+export function extractSid(res: supertest.Response): string {
+  const rawCookies = res.headers['set-cookie'];
+  const cookies = Array.isArray(rawCookies) ? rawCookies : rawCookies ? [rawCookies] : undefined;
+  if (!cookies) {
+    throw new Error('set-cookie 헤더가 없습니다.');
+  }
+
+  const sidCookie = cookies.find((c) => c.startsWith('SID='));
+  if (!sidCookie) {
+    throw new Error('SID 쿠키를 찾을 수 없습니다.');
+  }
+
+  return sidCookie.split('=')[1].split(';')[0];
+}
+
+/**
+ * SID 쿠키를 포함한 인증 요청을 생성한다.
+ */
+export function withAuth(req: supertest.Test, sid: string): supertest.Test {
+  return req.set('Cookie', `SID=${sid}`);
+}

--- a/back/test/helpers/e2e-setup.ts
+++ b/back/test/helpers/e2e-setup.ts
@@ -4,7 +4,9 @@ import cookieParser from 'cookie-parser';
 import supertest from 'supertest';
 
 import { AppModule } from 'src/app.module';
+import { AuthService } from 'src/auth/service/auth.service';
 import { BookingService } from 'src/domains/booking/service/booking.service';
+import { InBookingService } from 'src/domains/booking/service/in-booking.service';
 import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 /**
@@ -269,6 +271,36 @@ export function bookSeat(
 export async function transitionToSelectingSeat(app: INestApplication, sid: string) {
   const bookingService = app.get(BookingService);
   await bookingService.setInBookingFromEntering(sid);
+}
+
+/**
+ * SSE 연결 해제 시 발생하는 1차 처리를 시뮬레이션한다.
+ * req.on('close') 핸들러가 수행하는 동작:
+ * - 유저 상태를 RECONNECTING_SELECTING으로 변경
+ * - reconnecting 세션 풀에 등록
+ */
+export async function simulateSseDisconnect(app: INestApplication, sid: string) {
+  const authService = app.get(AuthService);
+  const inBookingService = app.get(InBookingService);
+  await authService.setUserStatusReconnectingSelecting(sid);
+  await inBookingService.addReconnectingSession(sid);
+}
+
+/**
+ * SSE 연결 해제 후 재연결 타임아웃이 만료됐을 때의 정리 로직을 시뮬레이션한다.
+ * 실제로는 removeExpiredReconnectingSessions가 reconnecting 풀에서 제거한 뒤
+ * seats-sse-close 이벤트를 발행한다. 이 순서를 재현한다:
+ * 1. reconnecting 풀에서 제거
+ * 2. 미저장 좌석 회수
+ * 3. in-booking 세션 정리 (상태 → LOGIN)
+ * 4. 대기열 다음 유저 입장
+ */
+export async function simulateSseCloseTimeout(app: INestApplication, sid: string) {
+  const inBookingService = app.get(InBookingService);
+  await inBookingService.removeReconnectingSession(sid);
+
+  const bookingService = app.get(BookingService);
+  await bookingService.onSeatsSseDisconnected({ sid });
 }
 
 /**

--- a/back/test/helpers/e2e-setup.ts
+++ b/back/test/helpers/e2e-setup.ts
@@ -72,14 +72,34 @@ export async function loginAsGuest(app: INestApplication): Promise<string> {
 }
 
 /**
+ * 일반 유저로 회원가입 + 로그인 후 SID를 반환한다.
+ * DB가 테스트 간에 유지되므로 이미 가입된 경우(409)는 로그인만 수행한다.
+ */
+export async function loginAsUser(
+  app: INestApplication,
+  loginId: string,
+  loginPassword: string,
+): Promise<string> {
+  const signupRes = await signup(app, loginId, loginPassword);
+  if (signupRes.status !== 201 && signupRes.status !== 409) {
+    throw new Error(`User signup failed with status ${signupRes.status}`);
+  }
+  return loginUser(app, loginId, loginPassword);
+}
+
+/**
  * 관리자로 회원가입 + 로그인 후 SID를 반환한다.
+ * DB가 테스트 간에 유지되므로 이미 가입된 경우(409)는 로그인만 수행한다.
  */
 export async function loginAsAdmin(
   app: INestApplication,
   loginId = 'admin1234',
   loginPassword = 'admin1234',
 ): Promise<string> {
-  await signupAdmin(app, loginId, loginPassword).expect(201);
+  const signupRes = await signupAdmin(app, loginId, loginPassword);
+  if (signupRes.status !== 201 && signupRes.status !== 409) {
+    throw new Error(`Admin signup failed with status ${signupRes.status}`);
+  }
   return loginUser(app, loginId, loginPassword);
 }
 
@@ -106,4 +126,95 @@ export function extractSid(res: supertest.Response): string {
  */
 export function withAuth(req: supertest.Test, sid: string): supertest.Test {
   return req.set('Cookie', `SID=${sid}`);
+}
+
+// ─── Data Helpers ───
+
+/**
+ * 테스트용 Place를 생성하고 ID를 반환한다.
+ */
+export async function createPlace(
+  app: INestApplication,
+  adminSid: string,
+  overrides: Record<string, unknown> = {},
+): Promise<number> {
+  const body = {
+    name: 'Test Hall',
+    address: 'Test Address 123',
+    overviewSvg: '<svg></svg>',
+    overviewHeight: 500,
+    overviewWidth: 800,
+    overviewPoints: '[]',
+    ...overrides,
+  };
+
+  const res = await withAuth(supertest(app.getHttpServer()).post('/place'), adminSid).send(body).expect(201);
+
+  return res.body.id;
+}
+
+/**
+ * 테스트용 Section을 생성한다.
+ */
+export async function createSections(
+  app: INestApplication,
+  adminSid: string,
+  placeId: number,
+  sections: Array<{ name: string; colLen: number; seats: number[]; order: number }> = [
+    { name: 'A구역', colLen: 3, seats: [1, 1, 1, 1, 1, 1], order: 0 },
+  ],
+) {
+  const body = sections.map((s) => ({ ...s, placeId }));
+
+  return withAuth(supertest(app.getHttpServer()).post('/place/section'), adminSid).send(body).expect(201);
+}
+
+/**
+ * 테스트용 Program을 생성하고 ID를 반환한다.
+ */
+export async function createProgram(
+  app: INestApplication,
+  adminSid: string,
+  placeId: number,
+  overrides: Record<string, unknown> = {},
+): Promise<number> {
+  const body = {
+    name: 'Test Program',
+    profileUrl: 'https://example.com/poster.jpg',
+    runningTime: 120,
+    genre: 'Musical',
+    actors: 'Actor A, Actor B',
+    price: 50000,
+    placeId,
+    ...overrides,
+  };
+
+  const res = await withAuth(supertest(app.getHttpServer()).post('/program'), adminSid)
+    .send(body)
+    .expect(201);
+
+  return res.body.id;
+}
+
+/**
+ * 테스트용 Event를 생성하고 ID를 반환한다.
+ */
+export async function createEvent(
+  app: INestApplication,
+  adminSid: string,
+  programId: number,
+  overrides: Record<string, unknown> = {},
+): Promise<number> {
+  const now = new Date();
+  const body = {
+    runningDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    reservationOpenDate: new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+    reservationCloseDate: new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+    programId,
+    ...overrides,
+  };
+
+  const res = await withAuth(supertest(app.getHttpServer()).post('/event'), adminSid).send(body).expect(201);
+
+  return res.body.id;
 }

--- a/back/test/helpers/e2e-setup.ts
+++ b/back/test/helpers/e2e-setup.ts
@@ -4,6 +4,7 @@ import cookieParser from 'cookie-parser';
 import supertest from 'supertest';
 
 import { AppModule } from 'src/app.module';
+import { BookingService } from 'src/domains/booking/service/booking.service';
 import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 /**
@@ -217,4 +218,72 @@ export async function createEvent(
   const res = await withAuth(supertest(app.getHttpServer()).post('/event'), adminSid).send(body).expect(201);
 
   return res.body.id;
+}
+
+// ─── Booking Helpers ───
+
+/**
+ * 관리자 권한으로 이벤트 예약을 초기화하고 오픈한다.
+ */
+export function openEventReservation(app: INestApplication, adminSid: string, eventId: number) {
+  return withAuth(supertest(app.getHttpServer()).post(`/booking/init/${eventId}`), adminSid);
+}
+
+/**
+ * 이벤트 입장 허가를 요청한다.
+ */
+export function requestPermission(app: INestApplication, sid: string, eventId: number) {
+  return withAuth(supertest(app.getHttpServer()).get(`/booking/permission/${eventId}`), sid);
+}
+
+/**
+ * 예매 인원 수를 설정한다.
+ */
+export function setBookingCount(app: INestApplication, sid: string, bookingAmount: number) {
+  return withAuth(supertest(app.getHttpServer()).post('/booking/count'), sid).send({ bookingAmount });
+}
+
+/**
+ * 좌석 점유/취소 요청을 보낸다.
+ */
+export function bookSeat(
+  app: INestApplication,
+  sid: string,
+  eventId: number,
+  sectionIndex: number,
+  seatIndex: number,
+  expectedStatus: 'reserved' | 'deleted',
+) {
+  return withAuth(supertest(app.getHttpServer()).post('/booking'), sid).send({
+    eventId,
+    sectionIndex,
+    seatIndex,
+    expectedStatus,
+  });
+}
+
+/**
+ * SSE 연결을 우회하여 ENTERING → SELECTING_SEAT 상태 전환을 수행한다.
+ * 반드시 setBookingCount 호출 후 사용해야 한다.
+ */
+export async function transitionToSelectingSeat(app: INestApplication, sid: string) {
+  const bookingService = app.get(BookingService);
+  await bookingService.setInBookingFromEntering(sid);
+}
+
+/**
+ * 유저를 좌석 선택 상태(SELECTING_SEAT)까지 한 번에 진행시킨다.
+ * 이벤트 오픈 → 입장 허가 → 인원 설정 → 상태 전환
+ */
+export async function setupSelectingSeat(
+  app: INestApplication,
+  adminSid: string,
+  eventId: number,
+  userSid: string,
+  bookingAmount: number = 1,
+) {
+  await openEventReservation(app, adminSid, eventId).expect(201);
+  await requestPermission(app, userSid, eventId).expect(200);
+  await setBookingCount(app, userSid, bookingAmount).expect(201);
+  await transitionToSelectingSeat(app, userSid);
 }

--- a/back/test/jest-e2e.json
+++ b/back/test/jest-e2e.json
@@ -9,5 +9,6 @@
   "moduleNameMapper": {
     "^src/(.*)$": "<rootDir>/../src/$1"
   },
-  "setupFiles": ["<rootDir>/setup-env.js"]
+  "setupFiles": ["<rootDir>/setup-env.js"],
+  "forceExit": true
 }

--- a/back/test/place.e2e-spec.ts
+++ b/back/test/place.e2e-spec.ts
@@ -1,0 +1,152 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  createPlace,
+  createSections,
+  createTestApp,
+  getRedisService,
+  loginAsAdmin,
+  loginAsGuest,
+  withAuth,
+} from './helpers/e2e-setup';
+
+describe('Place (e2e)', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+  let adminSid: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+    adminSid = await loginAsAdmin(app);
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+    adminSid = await loginAsAdmin(app, 'padmin01', 'pass1234');
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  // ─── Place 생성 ───
+
+  describe('POST /place', () => {
+    it('관리자 → Place 생성 성공 (201)', async () => {
+      const res = await withAuth(supertest(app.getHttpServer()).post('/place'), adminSid)
+        .send({
+          name: '세종문화회관',
+          address: '서울시 종로구',
+          overviewSvg: '<svg></svg>',
+          overviewHeight: 600,
+          overviewWidth: 900,
+          overviewPoints: '[]',
+        })
+        .expect(201);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          name: '세종문화회관',
+        }),
+      );
+    });
+
+    it('일반 유저 → 403/401', async () => {
+      const guestSid = await loginAsGuest(app);
+
+      await withAuth(supertest(app.getHttpServer()).post('/place'), guestSid)
+        .send({
+          name: 'Test',
+          address: 'Addr',
+          overviewSvg: '<svg></svg>',
+          overviewHeight: 100,
+          overviewWidth: 100,
+          overviewPoints: '[]',
+        })
+        .expect(401);
+    });
+
+    it('필수 필드 누락 → 400', async () => {
+      await withAuth(supertest(app.getHttpServer()).post('/place'), adminSid)
+        .send({ name: 'Test' })
+        .expect(400);
+    });
+  });
+
+  // ─── Section 생성 ───
+
+  describe('POST /place/section', () => {
+    it('Section 추가 성공', async () => {
+      const placeId = await createPlace(app, adminSid);
+
+      await createSections(app, adminSid, placeId, [
+        { name: 'A구역', colLen: 5, seats: [1, 1, 1, 1, 1], order: 0 },
+        { name: 'B구역', colLen: 3, seats: [1, 0, 1], order: 1 },
+      ]);
+    });
+
+    it('존재하지 않는 Place에 Section 추가 → 404', async () => {
+      await withAuth(supertest(app.getHttpServer()).post('/place/section'), adminSid)
+        .send([{ name: 'A구역', colLen: 3, seats: [1, 1, 1], placeId: 99999, order: 0 }])
+        .expect(404);
+    });
+  });
+
+  // ─── 좌석 조회 ───
+
+  describe('GET /place/seat/:placeId', () => {
+    it('Place + Section 생성 후 좌석 정보 조회', async () => {
+      const placeId = await createPlace(app, adminSid, { name: '좌석 조회 테스트 홀' });
+      await createSections(app, adminSid, placeId, [
+        { name: 'VIP석', colLen: 4, seats: [1, 1, 1, 1, 1, 1, 1, 1], order: 0 },
+      ]);
+
+      const res = await supertest(app.getHttpServer()).get(`/place/seat/${placeId}`).expect(200);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: placeId,
+          layout: expect.objectContaining({
+            sections: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'VIP석',
+                colLen: 4,
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('존재하지 않는 Place → 404', async () => {
+      await supertest(app.getHttpServer()).get('/place/seat/99999').expect(404);
+    });
+  });
+
+  // ─── Place 삭제 ───
+
+  describe('DELETE /place/:placeId', () => {
+    it('관리자 → Place 삭제 성공', async () => {
+      const placeId = await createPlace(app, adminSid);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/place/${placeId}`), adminSid).expect(200);
+
+      // 삭제 후 조회 → 404
+      await supertest(app.getHttpServer()).get(`/place/seat/${placeId}`).expect(404);
+    });
+
+    it('일반 유저 → 삭제 불가', async () => {
+      const placeId = await createPlace(app, adminSid);
+      const guestSid = await loginAsGuest(app);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/place/${placeId}`), guestSid).expect(401);
+    });
+  });
+});

--- a/back/test/program.e2e-spec.ts
+++ b/back/test/program.e2e-spec.ts
@@ -1,0 +1,187 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  createEvent,
+  createPlace,
+  createProgram,
+  createTestApp,
+  getRedisService,
+  loginAsAdmin,
+  loginAsGuest,
+  withAuth,
+} from './helpers/e2e-setup';
+
+describe('Program (e2e)', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+  let adminSid: string;
+  let placeId: number;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+    adminSid = await loginAsAdmin(app, 'pgadmin1', 'pass1234');
+    placeId = await createPlace(app, adminSid);
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  // ─── Program 생성 ───
+
+  describe('POST /program', () => {
+    it('관리자 → Program 생성 성공 (201)', async () => {
+      const res = await withAuth(supertest(app.getHttpServer()).post('/program'), adminSid)
+        .send({
+          name: '오페라의 유령',
+          profileUrl: 'https://example.com/phantom.jpg',
+          runningTime: 150,
+          genre: 'Musical',
+          actors: 'Actor X, Actor Y',
+          price: 80000,
+          placeId,
+        })
+        .expect(201);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          name: '오페라의 유령',
+        }),
+      );
+    });
+
+    it('일반 유저 → 401', async () => {
+      const guestSid = await loginAsGuest(app);
+
+      await withAuth(supertest(app.getHttpServer()).post('/program'), guestSid)
+        .send({
+          name: 'Test',
+          profileUrl: 'url',
+          runningTime: 100,
+          genre: 'Drama',
+          actors: 'A',
+          price: 10000,
+          placeId,
+        })
+        .expect(401);
+    });
+
+    it('존재하지 않는 placeId → 404', async () => {
+      await withAuth(supertest(app.getHttpServer()).post('/program'), adminSid)
+        .send({
+          name: 'Test',
+          profileUrl: 'url',
+          runningTime: 100,
+          genre: 'Drama',
+          actors: 'A',
+          price: 10000,
+          placeId: 99999,
+        })
+        .expect(404);
+    });
+
+    it('필수 필드 누락 → 400', async () => {
+      await withAuth(supertest(app.getHttpServer()).post('/program'), adminSid)
+        .send({ name: 'Test' })
+        .expect(400);
+    });
+  });
+
+  // ─── Program 목록 조회 ───
+
+  describe('GET /program', () => {
+    it('비인증 상태에서도 조회 가능', async () => {
+      await createProgram(app, adminSid, placeId, { name: 'Program A' });
+      await createProgram(app, adminSid, placeId, { name: 'Program B' });
+
+      const res = await supertest(app.getHttpServer()).get('/program').expect(200);
+
+      expect(res.body.length).toBeGreaterThanOrEqual(2);
+      expect(res.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Program A' }),
+          expect.objectContaining({ name: 'Program B' }),
+        ]),
+      );
+    });
+
+    it('응답에 place 정보가 포함된다', async () => {
+      await createProgram(app, adminSid, placeId);
+
+      const res = await supertest(app.getHttpServer()).get('/program').expect(200);
+
+      expect(res.body[0]).toEqual(
+        expect.objectContaining({
+          place: expect.objectContaining({
+            id: expect.any(Number),
+            name: expect.any(String),
+          }),
+        }),
+      );
+    });
+  });
+
+  // ─── Program 상세 조회 ───
+
+  describe('GET /program/:programId', () => {
+    it('프로그램 상세 정보 + 이벤트 목록', async () => {
+      const programId = await createProgram(app, adminSid, placeId, { name: '레미제라블' });
+      await createEvent(app, adminSid, programId);
+
+      const res = await supertest(app.getHttpServer()).get(`/program/${programId}`).expect(200);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: programId,
+          name: '레미제라블',
+          price: expect.any(Number),
+          runningTime: expect.any(Number),
+          place: expect.objectContaining({ id: expect.any(Number) }),
+          events: expect.any(Array),
+        }),
+      );
+    });
+
+    it('존재하지 않는 programId → 404', async () => {
+      await supertest(app.getHttpServer()).get('/program/99999').expect(404);
+    });
+  });
+
+  // ─── Program 삭제 ───
+
+  describe('DELETE /program/:programId', () => {
+    it('이벤트 없는 프로그램 삭제 → 성공', async () => {
+      const programId = await createProgram(app, adminSid, placeId);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/program/${programId}`), adminSid).expect(200);
+
+      // 삭제 확인
+      await supertest(app.getHttpServer()).get(`/program/${programId}`).expect(404);
+    });
+
+    it('이벤트가 존재하는 프로그램 삭제 → 409 Conflict', async () => {
+      const programId = await createProgram(app, adminSid, placeId);
+      await createEvent(app, adminSid, programId);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/program/${programId}`), adminSid).expect(409);
+    });
+
+    it('일반 유저 → 삭제 불가', async () => {
+      const programId = await createProgram(app, adminSid, placeId);
+      const guestSid = await loginAsGuest(app);
+
+      await withAuth(supertest(app.getHttpServer()).delete(`/program/${programId}`), guestSid).expect(401);
+    });
+  });
+});

--- a/back/test/reservation.e2e-spec.ts
+++ b/back/test/reservation.e2e-spec.ts
@@ -1,0 +1,228 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  bookSeat,
+  createEvent,
+  createPlace,
+  createProgram,
+  createSections,
+  createTestApp,
+  getRedisService,
+  loginAsAdmin,
+  loginAsUser,
+  openEventReservation,
+  requestPermission,
+  setBookingCount,
+  setupSelectingSeat,
+  transitionToSelectingSeat,
+  withAuth,
+} from './helpers/e2e-setup';
+
+describe('Reservation (e2e)', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+  let adminSid: string;
+  let placeId: number;
+  let programId: number;
+  let eventId: number;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+
+    adminSid = await loginAsAdmin(app, 'rsadmin1', 'pass1234');
+    placeId = await createPlace(app, adminSid);
+    await createSections(app, adminSid, placeId, [
+      { name: 'A', colLen: 3, seats: [1, 1, 1, 1, 1, 1], order: 0 },
+    ]);
+    programId = await createProgram(app, adminSid, placeId);
+    eventId = await createEvent(app, adminSid, programId, {
+      reservationOpenDate: new Date(Date.now() - 86400000).toISOString(),
+    });
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+    adminSid = await loginAsAdmin(app, 'rsadmin1', 'pass1234');
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  // ─── 예매 확정 ───
+
+  describe('POST /reservation', () => {
+    it('좌석 선점 후 예매 확정 → 성공', async () => {
+      const userSid = await loginAsUser(app, 'resuser1', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, userSid, 2);
+
+      // 좌석 2개 점유
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+      await bookSeat(app, userSid, eventId, 0, 1, 'reserved').expect(201);
+
+      // 예매 확정
+      const res = await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({
+          eventId,
+          seats: [
+            { sectionIndex: 0, seatIndex: 0 },
+            { sectionIndex: 0, seatIndex: 1 },
+          ],
+        })
+        .expect(201);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          programName: expect.any(String),
+          runningDate: expect.any(String),
+          price: expect.any(Number),
+        }),
+      );
+      expect(res.body.seats).toHaveLength(2);
+    });
+
+    it('선점하지 않은 좌석 포함 → 400', async () => {
+      const userSid = await loginAsUser(app, 'resuser2', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, userSid, 2);
+
+      // 좌석 1개만 점유
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      // 점유하지 않은 좌석 포함하여 예매 시도
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({
+          eventId,
+          seats: [
+            { sectionIndex: 0, seatIndex: 0 },
+            { sectionIndex: 0, seatIndex: 3 },
+          ],
+        })
+        .expect(400);
+    });
+
+    it('LOGIN 상태에서 예매 시도 → 401', async () => {
+      const userSid = await loginAsUser(app, 'resuser3', 'pass1234');
+
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 0 }] })
+        .expect(401);
+    });
+  });
+
+  // ─── 예매 내역 조회 ───
+
+  describe('GET /reservation', () => {
+    it('예매 후 내역 조회 → 배열 반환', async () => {
+      const userSid = await loginAsUser(app, 'resget01', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, userSid, 1);
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 0 }] })
+        .expect(201);
+
+      const res = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(200);
+
+      expect(res.body).toBeInstanceOf(Array);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      expect(res.body[0]).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          programName: expect.any(String),
+        }),
+      );
+    });
+
+    it('예매 없는 유저 → 빈 배열', async () => {
+      const userSid = await loginAsUser(app, 'resget02', 'pass1234');
+
+      const res = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(200);
+
+      expect(res.body).toEqual([]);
+    });
+
+    it('미인증 → 403', async () => {
+      await supertest(app.getHttpServer()).get('/reservation').expect(403);
+    });
+  });
+
+  // ─── 예매 삭제 ───
+
+  describe('DELETE /reservation/:reservationId', () => {
+    it('자신의 예매 삭제 → 200', async () => {
+      // 예매 생성
+      const userSid = await loginAsUser(app, 'resdel01', 'pass1234');
+      await setupSelectingSeat(app, adminSid, eventId, userSid, 1);
+      await bookSeat(app, userSid, eventId, 0, 2, 'reserved').expect(201);
+
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 2 }] })
+        .expect(201);
+
+      // 예매 ID 조회
+      const listRes = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(200);
+      const reservationId = listRes.body[listRes.body.length - 1].id;
+
+      // 삭제
+      await withAuth(supertest(app.getHttpServer()).delete(`/reservation/${reservationId}`), userSid).expect(
+        200,
+      );
+
+      // 삭제 후 조회 → 목록에서 제거됨
+      const afterRes = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(
+        200,
+      );
+      const ids = afterRes.body.map((r: { id: number }) => r.id);
+      expect(ids).not.toContain(reservationId);
+    });
+
+    it('존재하지 않는 예매 삭제 → 400', async () => {
+      const userSid = await loginAsUser(app, 'resdel02', 'pass1234');
+
+      await withAuth(supertest(app.getHttpServer()).delete('/reservation/999999'), userSid).expect(400);
+    });
+
+    it('미인증 → 403', async () => {
+      await supertest(app.getHttpServer()).delete('/reservation/1').expect(403);
+    });
+  });
+
+  // ─── 통합 시나리오 ───
+
+  describe('전체 예매 플로우', () => {
+    it('입장 → 인원 설정 → 좌석 점유 → 예매 확정 → 내역 조회', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      const userSid = await loginAsUser(app, 'flow0001', 'pass1234');
+
+      // 1. 입장 허가
+      const permRes = await requestPermission(app, userSid, eventId).expect(200);
+      expect(permRes.body.enteringStatus).toBe(true);
+
+      // 2. 인원 설정
+      await setBookingCount(app, userSid, 1).expect(201);
+
+      // 3. 좌석 선택 상태 전환 (SSE 우회)
+      await transitionToSelectingSeat(app, userSid);
+
+      // 4. 좌석 점유
+      await bookSeat(app, userSid, eventId, 0, 3, 'reserved').expect(201);
+
+      // 5. 예매 확정
+      const reserveRes = await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 3 }] })
+        .expect(201);
+      expect(reserveRes.body.programName).toBeDefined();
+      expect(reserveRes.body.seats).toHaveLength(1);
+
+      // 6. 예매 내역 조회
+      const listRes = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(200);
+      expect(listRes.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/back/test/reservation.e2e-spec.ts
+++ b/back/test/reservation.e2e-spec.ts
@@ -17,6 +17,8 @@ import {
   requestPermission,
   setBookingCount,
   setupSelectingSeat,
+  simulateSseCloseTimeout,
+  simulateSseDisconnect,
   transitionToSelectingSeat,
   withAuth,
 } from './helpers/e2e-setup';
@@ -223,6 +225,49 @@ describe('Reservation (e2e)', () => {
       // 6. 예매 내역 조회
       const listRes = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(200);
       expect(listRes.body.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('1회차 예매 확정 → SSE 해제 → 2회차 예매 (상태 순환 검증)', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+      const userSid = await loginAsUser(app, 'flow0002', 'pass1234');
+
+      // ── 1회차: 입장 → 좌석 점유 → 예매 확정 ──
+      await requestPermission(app, userSid, eventId).expect(200);
+      await setBookingCount(app, userSid, 1).expect(201);
+      await transitionToSelectingSeat(app, userSid);
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(201);
+
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 0 }] })
+        .expect(201);
+
+      // ── SSE 해제: 페이지 이동 시뮬레이션 ──
+      await simulateSseDisconnect(app, userSid);
+      await simulateSseCloseTimeout(app, userSid);
+
+      // 상태가 LOGIN으로 복귀했는지 확인
+      await bookSeat(app, userSid, eventId, 0, 1, 'reserved').expect(401);
+
+      // ── 2회차: 같은 유저가 다시 예매 플로우 진입 ──
+      const permRes = await requestPermission(app, userSid, eventId).expect(200);
+      expect(permRes.body.enteringStatus).toBe(true);
+
+      await setBookingCount(app, userSid, 1).expect(201);
+      await transitionToSelectingSeat(app, userSid);
+
+      // 1회차에서 점유한 좌석(0,0)은 예매 확정됐으므로 여전히 점유 중
+      await bookSeat(app, userSid, eventId, 0, 0, 'reserved').expect(409);
+
+      // 다른 좌석 점유 → 2회차 예매 확정
+      await bookSeat(app, userSid, eventId, 0, 1, 'reserved').expect(201);
+
+      await withAuth(supertest(app.getHttpServer()).post('/reservation'), userSid)
+        .send({ eventId, seats: [{ sectionIndex: 0, seatIndex: 1 }] })
+        .expect(201);
+
+      // 예매 내역에 2건 존재
+      const listRes = await withAuth(supertest(app.getHttpServer()).get('/reservation'), userSid).expect(200);
+      expect(listRes.body.length).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/back/test/user.e2e-spec.ts
+++ b/back/test/user.e2e-spec.ts
@@ -1,0 +1,260 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  createTestApp,
+  extractSid,
+  getRedisService,
+  loginAsAdmin,
+  loginAsGuest,
+  loginUser,
+  signup,
+  signupAdmin,
+  withAuth,
+} from './helpers/e2e-setup';
+
+describe('User (e2e)', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  // ─── 회원가입 ───
+
+  describe('POST /user/signup', () => {
+    it('정상 회원가입 → 201', async () => {
+      const res = await signup(app, 'testuser1', 'pass1234').expect(201);
+
+      expect(res.body).toEqual({
+        message: expect.any(String),
+      });
+    });
+
+    it('같은 ID로 중복 가입 → 409 Conflict', async () => {
+      await signup(app, 'testuser2', 'pass1234').expect(201);
+      await signup(app, 'testuser2', 'pass1234').expect(409);
+    });
+
+    it('loginId가 4자 미만 → 400 Bad Request', async () => {
+      await signup(app, 'abc', 'pass1234').expect(400);
+    });
+
+    it('loginId가 12자 초과 → 400 Bad Request', async () => {
+      await signup(app, 'a'.repeat(13), 'pass1234').expect(400);
+    });
+
+    it('loginId에 대문자/특수문자 포함 → 400 Bad Request', async () => {
+      await signup(app, 'Test1234', 'pass1234').expect(400);
+    });
+
+    it('loginPassword가 4자 미만 → 400 Bad Request', async () => {
+      await signup(app, 'testuser3', 'abc').expect(400);
+    });
+  });
+
+  // ─── 관리자 회원가입 ───
+
+  describe('POST /user/signup/admin', () => {
+    it('관리자 회원가입 → 201', async () => {
+      const res = await signupAdmin(app, 'myadmin1', 'pass1234').expect(201);
+
+      expect(res.body).toEqual({
+        message: expect.any(String),
+      });
+    });
+  });
+
+  // ─── 아이디 중복 체크 ───
+
+  describe('POST /user/checkid', () => {
+    it('미등록 ID → available: true', async () => {
+      const res = await supertest(app.getHttpServer())
+        .post('/user/checkid')
+        .send({ loginId: 'newuser11' })
+        .expect(201);
+
+      expect(res.body).toEqual({ available: true });
+    });
+
+    it('등록된 ID → available: false', async () => {
+      await signup(app, 'existing1', 'pass1234').expect(201);
+
+      const res = await supertest(app.getHttpServer())
+        .post('/user/checkid')
+        .send({ loginId: 'existing1' })
+        .expect(201);
+
+      expect(res.body).toEqual({ available: false });
+    });
+  });
+
+  // ─── 로그인 ───
+
+  describe('POST /user/login', () => {
+    beforeEach(async () => {
+      await signup(app, 'logintest', 'pass1234');
+    });
+
+    it('정상 로그인 → SID 쿠키 발급 + loginId 반환', async () => {
+      const res = await supertest(app.getHttpServer())
+        .post('/user/login')
+        .send({ loginId: 'logintest', loginPassword: 'pass1234' })
+        .expect(201);
+
+      const sid = extractSid(res);
+      expect(sid).toBeDefined();
+      expect(res.body).toEqual(expect.objectContaining({ loginId: 'logintest' }));
+    });
+
+    it('잘못된 비밀번호 → 401 Unauthorized', async () => {
+      await supertest(app.getHttpServer())
+        .post('/user/login')
+        .send({ loginId: 'logintest', loginPassword: 'wrongpwd1' })
+        .expect(401);
+    });
+
+    it('존재하지 않는 ID → 401 Unauthorized', async () => {
+      await supertest(app.getHttpServer())
+        .post('/user/login')
+        .send({ loginId: 'nouser11', loginPassword: 'pass1234' })
+        .expect(401);
+    });
+
+    it('재로그인 시 이전 세션 무효화', async () => {
+      const oldSid = await loginUser(app, 'logintest', 'pass1234');
+      const newSid = await loginUser(app, 'logintest', 'pass1234');
+
+      expect(oldSid).not.toBe(newSid);
+
+      // 이전 SID로 접근 시도 → 실패
+      await withAuth(supertest(app.getHttpServer()).get('/user'), oldSid).expect(403);
+
+      // 새 SID로 접근 → 성공
+      await withAuth(supertest(app.getHttpServer()).get('/user'), newSid).expect(200);
+    });
+  });
+
+  // ─── 게스트 모드 ───
+
+  describe('GET /user/guest', () => {
+    it('게스트 로그인 → SID 쿠키 발급 + 게스트 정보 반환', async () => {
+      const res = await supertest(app.getHttpServer()).get('/user/guest').expect(200);
+
+      const sid = extractSid(res);
+      expect(sid).toBeDefined();
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          loginId: expect.stringContaining('guest-'),
+          userStatus: 'LOGIN',
+        }),
+      );
+    });
+
+    it('게스트 SID로 인증 요청 가능', async () => {
+      const sid = await loginAsGuest(app);
+
+      const res = await withAuth(supertest(app.getHttpServer()).get('/user'), sid).expect(200);
+
+      expect(res.body.loginId).toContain('guest-');
+    });
+  });
+
+  // ─── 사용자 정보 조회 ───
+
+  describe('GET /user', () => {
+    it('인증된 사용자 → 사용자 정보 반환', async () => {
+      await signup(app, 'infotest', 'pass1234');
+      const sid = await loginUser(app, 'infotest', 'pass1234');
+
+      const res = await withAuth(supertest(app.getHttpServer()).get('/user'), sid).expect(200);
+
+      expect(res.body).toEqual(expect.objectContaining({ loginId: 'infotest' }));
+    });
+
+    it('SID 없이 접근 → 403 Forbidden', async () => {
+      await supertest(app.getHttpServer()).get('/user').expect(403);
+    });
+
+    it('잘못된 SID → 403 Forbidden', async () => {
+      await withAuth(supertest(app.getHttpServer()).get('/user'), 'invalid-session-id').expect(403);
+    });
+  });
+
+  // ─── 로그아웃 ───
+
+  describe('POST /user/logout', () => {
+    it('정상 로그아웃 → 세션 무효화', async () => {
+      await signup(app, 'logout01', 'pass1234');
+      const sid = await loginUser(app, 'logout01', 'pass1234');
+
+      // 로그아웃
+      await withAuth(supertest(app.getHttpServer()).post('/user/logout'), sid).expect(201);
+
+      // 로그아웃 후 인증 요청 → 실패
+      await withAuth(supertest(app.getHttpServer()).get('/user'), sid).expect(403);
+    });
+
+    it('미인증 상태에서 로그아웃 → 403 Forbidden', async () => {
+      await supertest(app.getHttpServer()).post('/user/logout').expect(403);
+    });
+  });
+
+  // ─── 관리자 권한 ───
+
+  describe('Admin guard', () => {
+    it('관리자 전용 엔드포인트에 일반 유저 접근 → 401', async () => {
+      await signup(app, 'normal01', 'pass1234');
+      const sid = await loginUser(app, 'normal01', 'pass1234');
+
+      // DELETE /user/guest는 ADMIN 전용
+      await withAuth(supertest(app.getHttpServer()).delete('/user/guest'), sid).expect(401);
+    });
+
+    it('관리자로 로그인 → 관리자 전용 엔드포인트 접근 가능', async () => {
+      const sid = await loginAsAdmin(app, 'admin0001', 'pass1234');
+
+      const res = await withAuth(supertest(app.getHttpServer()).delete('/user/guest'), sid);
+
+      // 200 또는 관련 성공 응답 (게스트가 없어도 에러 아님)
+      expect(res.status).toBeLessThan(400);
+    });
+  });
+
+  // ─── 통합 시나리오 ───
+
+  describe('전체 플로우: 회원가입 → 로그인 → 정보 조회 → 로그아웃', () => {
+    it('전체 사용자 생명 주기가 정상 동작한다', async () => {
+      // 1. 회원가입
+      await signup(app, 'fullflow1', 'pass1234').expect(201);
+
+      // 2. 로그인
+      const sid = await loginUser(app, 'fullflow1', 'pass1234');
+      expect(sid).toBeDefined();
+
+      // 3. 정보 조회
+      const infoRes = await withAuth(supertest(app.getHttpServer()).get('/user'), sid).expect(200);
+      expect(infoRes.body.loginId).toBe('fullflow1');
+
+      // 4. 로그아웃
+      await withAuth(supertest(app.getHttpServer()).post('/user/logout'), sid).expect(201);
+
+      // 5. 로그아웃 후 접근 불가
+      await withAuth(supertest(app.getHttpServer()).get('/user'), sid).expect(403);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

전 도메인에 대한 E2E 테스트를 추가한다.

- **공통 인프라**: `createTestApp`, auth/data/booking 헬퍼, SSE 시뮬레이션 유틸
- **User**: 회원가입, 로그인, 게스트, 관리자, 중복/유효성 검증 (8 tests)
- **Place**: CRUD, Section CRUD, 권한, 유효성 검증 (20 tests)
- **Program**: CRUD, FK 제약, 권한 검증 (12 tests)
- **Event**: CRUD, 필터링, 좌석 조회 (18 tests)
- **Booking**: 서버시간, 입장허가, 대기열, 인원설정, 좌석점유/취소, 관리자 풀 설정, SSE 해제 시나리오, 브로드캐스트 타이밍, 예약 초기화 (25 tests)
- **Reservation**: 예매확정, 내역조회, 삭제, 전체 플로우 통합, 상태 순환 검증 (10 tests)

### SSE 우회 전략

supertest는 HTTP 요청-응답 모델이라 SSE 스트림(`text/event-stream`)을 다룰 수 없다. SSE가 관여하는 두 지점을 서비스 직접 호출로 시뮬레이션한다:

**1. SSE 연결 (ENTERING → SELECTING_SEAT 전환)**

실제로는 SSE 스트림을 구독한 상태에서 서버가 입장 허용 이벤트를 보내면 전환되지만, `BookingService.setInBookingFromEntering(sid)`를 직접 호출하여 상태를 전환시킨다.

**2. SSE 해제 (연결 종료 → 세션 정리)**

실제로는 `req.on('close')` → reconnecting 풀 등록 → GC 타임아웃 → `onSeatsSseDisconnected` 순서로 동작한다. 이 두 단계를 각각 시뮬레이션한다:
- `simulateSseDisconnect`: 1차 처리 (RECONNECTING_SELECTING 상태 전환 + reconnecting 풀 등록)
- `simulateSseCloseTimeout`: 2차 처리 (reconnecting 풀 제거 + saved 여부에 따라 좌석 회수/유지 + 세션 정리 + 대기열 승계)

**3. SSE 브로드캐스트 타이밍 검증**

우회한 SSE 브로드캐스트를 테스트하기 위해, raw HTTP(`http.get`)로 SSE 스트림을 직접 열어, 좌석 변경 후 `SEATS_BROADCAST_INTERVAL`(500ms) 이내에 브로드캐스트가 도착하는지 검증한다. 초기 브로드캐스트를 무시하고 변경 이후 첫 이벤트의 타이밍만 측정한다.

### 기타 변경

- `npm test`가 E2E 테스트를 기본 실행하도록 변경 (기존 단위 테스트 커맨드는 `test:unit`으로)

## 관련 이슈

- E2E 테스트 과정에서 발견: #364 (예매 확정 세션의 SSE 해제 시 불필요한 reconnecting 대기)

## Test plan

- [x] 전체 E2E 테스트 통과 (7 suites, 93 tests)
- [x] SSE 브로드캐스트: 좌석 변경 후 500ms 이내 수신 검증
- [x] SSE 해제 시 saved=true → 좌석 유지, saved=false → 좌석 회수 검증
- [x] 상태 순환: 1회차 예매 → SSE 해제 → 2회차 예매 성공 검증
- [x] lint-staged 통과

Issue Resolved: #361