### PR TITLE
예매 확정 세션의 SSE 해제 시 즉시 정리

### DIFF
--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -115,9 +115,14 @@ export class BookingController {
 
     const observable = this.bookingSeatsService.subscribeSeatsSSE(eventId);
 
-    req.on('close', () => {
-      this.authService.setUserStatusReconnectingSelecting(sid);
-      this.inBookingService.addReconnectingSession(sid);
+    req.on('close', async () => {
+      const inBookingSession = await this.inBookingService.getSession(eventId, sid);
+      if (inBookingSession?.saved) {
+        await this.bookingService.onSeatsSseDisconnected({ sid });
+      } else {
+        await this.authService.setUserStatusReconnectingSelecting(sid);
+        await this.inBookingService.addReconnectingSession(sid);
+      }
     });
 
     return observable;


### PR DESCRIPTION
## Summary

예매 확정(saved=true) 후 SSE가 끊기면 reconnecting 풀을 거치지 않고 즉시 세션을 정리하여 슬롯을 반환한다.

### 변경 전

모든 SSE 해제가 동일하게 reconnecting 풀에 등록 → GC 타임아웃(5초) 동안 슬롯 점유:

```typescript
req.on('close', () => {
  this.authService.setUserStatusReconnectingSelecting(sid);
  this.inBookingService.addReconnectingSession(sid);
});
```

### 변경 후

`close` 핸들러에서 클로저의 `eventId`로 in-booking 세션을 직접 조회하여 `saved` 여부에 따라 분기:

```typescript
req.on('close', async () => {
  const inBookingSession = await this.inBookingService.getSession(eventId, sid);
  if (inBookingSession?.saved) {
    await this.bookingService.onSeatsSseDisconnected({ sid });
  } else {
    await this.authService.setUserStatusReconnectingSelecting(sid);
    await this.inBookingService.addReconnectingSession(sid);
  }
});
```

- 세션이 null이면 `?.saved`가 undefined → 기존 reconnecting 로직으로 자연 분기
- `getIsSaved`의 `getTargetEventId` 호출을 우회하여 에러 가능성 제거

Issue Resolved: #364