### PR TITLE
Booking 모듈 Redis 중복 호출 제거

### DIFF
--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -109,7 +109,7 @@ export class BookingController {
     if (session.userStatus === USER_STATUS.ENTERING) {
       await this.bookingService.setInBookingFromEntering(sid);
     } else if (session.userStatus === USER_STATUS.RECONNECTING_SELECTING) {
-      await this.inBookingService.removeReconnectingSession(sid);
+      await this.inBookingService.removeReconnectingSession(eventId, sid);
       await this.authService.setUserStatusSelectingSeat(sid);
     }
 
@@ -121,7 +121,7 @@ export class BookingController {
         await this.bookingService.onSeatsSseDisconnected({ sid });
       } else {
         await this.authService.setUserStatusReconnectingSelecting(sid);
-        await this.inBookingService.addReconnectingSession(sid);
+        await this.inBookingService.addReconnectingSession(eventId, sid);
       }
     });
 

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -87,19 +87,14 @@ export class BookingSeatsService {
       throw new BadRequestException('좌석을 점유하려는 세션의 대상 이벤트를 불러올 수 없습니다.');
     }
 
-    const bookedSeat = await this.inBookingService.getBookedSeats(sid);
-    const bookingAmount = await this.inBookingService.getBookingAmount(sid);
-    const bookedAmount = bookedSeat.length;
+    await this.inBookingService.validateAndAddBookedSeat(eventId, sid, target);
 
-    if (bookingAmount <= bookedAmount) {
-      throw new BadRequestException('예약 가능한 좌석 수를 초과했습니다.');
+    try {
+      return await this.updateSeatReserved(eventId, target);
+    } catch (error) {
+      await this.inBookingService.removeBookedSeat(eventId, sid, target);
+      throw error;
     }
-
-    const result = await this.updateSeatReserved(eventId, target);
-    if (result) {
-      await this.inBookingService.addBookedSeat(sid, target);
-    }
-    return result;
   }
 
   async unBookSeat(sid: string, target: [number, number]) {
@@ -109,21 +104,14 @@ export class BookingSeatsService {
       throw new BadRequestException('좌석 점유를 취소하려는 세션의 대상 이벤트를 불러올 수 없습니다.');
     }
 
-    const bookedSeat = await this.inBookingService.getBookedSeats(sid);
-    const bookedAmount = bookedSeat.length;
+    await this.inBookingService.validateAndRemoveBookedSeat(eventId, sid, target);
 
-    if (bookedAmount === 0) {
-      throw new BadRequestException('취소할 수 있는 좌석이 없습니다.');
+    try {
+      return await this.updateSeatDeleted(eventId, target);
+    } catch (error) {
+      await this.inBookingService.addBookedSeat(eventId, sid, target);
+      throw error;
     }
-    if (!bookedSeat.some((seat) => seat[0] === target[0] && seat[1] === target[1])) {
-      throw new BadRequestException('예약하지 않은 좌석입니다.');
-    }
-
-    const result = await this.updateSeatDeleted(eventId, target);
-    if (result) {
-      await this.inBookingService.removeBookedSeat(sid, target);
-    }
-    return result;
   }
 
   async updateSeatReserved(eventId: number, target: [number, number]) {

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -34,7 +34,7 @@ export class BookingService {
 
     if (await this.openBookingService.isEventOpened(eventId)) {
       await this.collectSeatsIfNotSaved(eventId, sid);
-      await this.inBookingService.emitSession(sid);
+      await this.inBookingService.emitSession(eventId, sid);
       await this.letInNextWaiting(eventId);
     }
   }
@@ -82,7 +82,7 @@ export class BookingService {
       if (!item) {
         break;
       }
-      await this.enterBookingService.addEnteringSession(item.sid);
+      await this.enterBookingService.addEnteringSession(eventId, item.sid);
       await this.authService.setUserStatusEntering(item.sid);
     }
   }
@@ -96,7 +96,7 @@ export class BookingService {
 
     const bookingAmount = await this.enterBookingService.getBookingAmount(sid);
 
-    await this.enterBookingService.removeEnteringSession(sid);
+    await this.enterBookingService.removeEnteringSession(eventId, sid);
     await this.inBookingService.insertInBooking(eventId, sid, bookingAmount);
     await this.authService.setUserStatusSelectingSeat(sid);
   }
@@ -110,20 +110,14 @@ export class BookingService {
 
     await this.authService.setUserEventTarget(sid, eventId);
 
-    return await this.getForwarded(sid);
+    return await this.getForwarded(eventId, sid);
   }
 
-  private async getForwarded(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-
-    if (eventId === null) {
-      throw new BadRequestException('permission할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  private async getForwarded(eventId: number, sid: string) {
     const isInsertable = await this.isInsertableInBooking(eventId);
 
     if (isInsertable) {
-      await this.enterBookingService.addEnteringSession(sid);
+      await this.enterBookingService.addEnteringSession(eventId, sid);
       await this.authService.setUserStatusEntering(sid);
       return {
         waitingStatus: false,
@@ -132,7 +126,7 @@ export class BookingService {
     }
 
     await this.authService.setUserStatusWaiting(sid);
-    const userOrder = await this.waitingQueueService.pushQueue(sid);
+    const userOrder = await this.waitingQueueService.pushQueue(eventId, sid);
     return {
       waitingStatus: true,
       enteringStatus: false,
@@ -149,31 +143,32 @@ export class BookingService {
   }
 
   async setBookingAmount(sid: string, bookingAmount: number) {
-    const isInBooking = await this.inBookingService.isInBooking(sid);
-    if (isInBooking) {
-      await this.flushBookedSeats(sid);
-      return await this.inBookingService.setBookingAmount(sid, bookingAmount);
+    const eventId = await this.authService.getUserEventTarget(sid);
+
+    if (eventId === null) {
+      throw new BadRequestException('예매 수량을 설정할 세션의 대상 이벤트를 불러올 수 없습니다.');
     }
 
-    const isEntering = await this.enterBookingService.isEntering(sid);
+    const isInBooking = await this.inBookingService.isInBooking(eventId, sid);
+    if (isInBooking) {
+      const { flushedSeats } = await this.inBookingService.flushAndSetBookingAmount(
+        eventId,
+        sid,
+        bookingAmount,
+      );
+      if (flushedSeats.length > 0) {
+        await Promise.all(
+          flushedSeats.map((seat) => this.bookingSeatsService.updateSeatDeleted(eventId, seat)),
+        );
+      }
+      return bookingAmount;
+    }
+
+    const isEntering = await this.enterBookingService.isEntering(eventId, sid);
     if (!isEntering) {
       throw new BadRequestException('예매 수량을 설정할 수 없는 상태입니다.');
     }
     return await this.enterBookingService.setBookingAmount(sid, bookingAmount);
-  }
-
-  private async flushBookedSeats(sid: string) {
-    const bookedSeats = await this.inBookingService.getBookedSeats(sid);
-    if (bookedSeats.length > 0) {
-      const eventId = await this.authService.getUserEventTarget(sid);
-
-      if (eventId === null) {
-        throw new BadRequestException('좌석을 회수할 세션의 대상 이벤트를 불러올 수 없습니다.');
-      }
-
-      await Promise.all(bookedSeats.map((seat) => this.bookingSeatsService.updateSeatDeleted(eventId, seat)));
-      await this.inBookingService.removeBookedSeats(sid);
-    }
   }
 
   async freeSeatsIfEventOpened(eventId: number, seats: [number, number][]) {

--- a/back/src/domains/booking/service/enter-booking.service.ts
+++ b/back/src/domains/booking/service/enter-booking.service.ts
@@ -40,37 +40,19 @@ export class EnterBookingService {
     }
   }
 
-  async addEnteringSession(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-
-    if (eventId === null) {
-      throw new Error('입장중 상태에 추가할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async addEnteringSession(eventId: number, sid: string) {
     const timestamp = Date.now();
     await this.redis.zadd(`entering:${eventId}`, timestamp, sid);
     return true;
   }
 
-  async removeEnteringSession(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-
-    if (eventId === null) {
-      throw new Error('입장중 상태에서 제거할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async removeEnteringSession(eventId: number, sid: string) {
     await this.redis.zrem(`entering:${eventId}`, sid);
     await this.removeBookingAmount(sid);
     return true;
   }
 
-  async isEntering(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-
-    if (eventId === null) {
-      return false;
-    }
-
+  async isEntering(eventId: number, sid: string) {
     const isMember = await this.redis.zscore(`entering:${eventId}`, sid);
     return isMember !== null;
   }
@@ -81,7 +63,7 @@ export class EnterBookingService {
 
   async setBookingAmount(sid: string, bookingAmount: number) {
     await this.redis.set(`entering:${sid}:temp-booking-amount`, bookingAmount);
-    return parseInt(await this.redis.get(`entering:${sid}:temp-booking-amount`));
+    return bookingAmount;
   }
 
   async getBookingAmount(sid: string) {
@@ -89,7 +71,7 @@ export class EnterBookingService {
     if (!bookingAmountData) {
       return 0;
     }
-    return parseInt(await this.redis.get(`entering:${sid}:temp-booking-amount`));
+    return parseInt(bookingAmountData);
   }
 
   async removeBookingAmount(sid: string) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -1,5 +1,5 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import Redis from 'ioredis';
@@ -43,14 +43,13 @@ export class InBookingService {
 
   async setInBookingSessionsDefaultMaxSize(size: number) {
     await this.redis.set('in-booking:default-max-size', size);
-    const defaultMaxSize = parseInt(await this.redis.get('in-booking:default-max-size'));
-    return defaultMaxSize;
+    return size;
   }
 
   async setInBookingSessionsMaxSize(eventId: number, size: number) {
     await this.redis.set(`in-booking:${eventId}:max-size`, size);
     this.eventEmitter.emit('in-booking-max-size-changed', { eventId });
-    return parseInt(await this.redis.get(`in-booking:${eventId}:max-size`));
+    return size;
   }
 
   async setAllInBookingSessionsMaxSize(size: number) {
@@ -59,17 +58,10 @@ export class InBookingService {
 
     this.eventEmitter.emit('all-in-booking-max-size-changed');
 
-    const lastKey = keys[keys.length - 1];
-    return parseInt(await this.redis.get(lastKey));
+    return size;
   }
 
-  async isInBooking(sid: string) {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      return false;
-    }
-
+  async isInBooking(eventId: number, sid: string) {
     const session = await this.getSession(eventId, sid);
     return !!session;
   }
@@ -85,13 +77,7 @@ export class InBookingService {
     return true;
   }
 
-  async setBookingAmount(sid: string, amount: number): Promise<number> {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('예매 수량을 설정할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async setBookingAmount(eventId: number, sid: string, amount: number): Promise<number> {
     const session = await this.getSession(eventId, sid);
 
     session.bookingAmount = amount;
@@ -100,93 +86,50 @@ export class InBookingService {
     return amount;
   }
 
-  async getBookingAmount(sid: string): Promise<number> {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('예매 수량을 조회할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async getBookingAmount(eventId: number, sid: string): Promise<number> {
     const session = await this.getSession(eventId, sid);
     return session.bookingAmount;
   }
 
-  async addBookedSeat(sid: string, seat: [number, number]): Promise<void> {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('점유한 좌석을 추가할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async addBookedSeat(eventId: number, sid: string, seat: [number, number]): Promise<void> {
     const session = await this.getSession(eventId, sid);
     session.bookedSeats.push(seat);
     await this.setSession(eventId, session);
   }
 
-  async getBookedSeats(sid: string): Promise<[number, number][]> {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
+  async getBookedSeats(eventId: number, sid: string): Promise<[number, number][]> {
+    const session = await this.getSession(eventId, sid);
+    if (!session) {
       return [];
     }
-
-    const session = await this.getSession(eventId, sid);
     return session.bookedSeats;
   }
 
-  async removeBookedSeat(sid: string, seat: [number, number]): Promise<void> {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('점유한 좌석을 제거할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async removeBookedSeat(eventId: number, sid: string, seat: [number, number]): Promise<void> {
     const session = await this.getSession(eventId, sid);
     session.bookedSeats = session.bookedSeats.filter((s) => s[0] !== seat[0] || s[1] !== seat[1]);
     await this.setSession(eventId, session);
   }
 
-  async removeBookedSeats(sid: string) {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('점유한 좌석을 모두 제거할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async removeBookedSeats(eventId: number, sid: string) {
     const session = await this.getSession(eventId, sid);
     session.bookedSeats = [];
     await this.setSession(eventId, session);
   }
 
-  async getIsSaved(sid: string) {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('예약 저장 여부를 조회할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async getIsSaved(eventId: number, sid: string) {
     const session = await this.getSession(eventId, sid);
     return session.saved;
   }
 
-  async setIsSaved(sid: string, saved: boolean) {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      throw new Error('예약 저장 여부를 설정할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async setIsSaved(eventId: number, sid: string, saved: boolean) {
     const session = await this.getSession(eventId, sid);
     session.saved = saved;
     await this.setSession(eventId, session);
   }
 
-  async emitSession(sid: string) {
-    const eventId = await this.getTargetEventId(sid);
-
-    if (eventId === null) {
-      return;
-    } else if (eventId !== 0) {
+  async emitSession(eventId: number, sid: string) {
+    if (eventId !== 0) {
       await this.removeInBooking(eventId, sid);
       await this.authService.setUserStatusLogin(sid);
       await this.authService.setUserEventTarget(sid, 0);
@@ -199,10 +142,6 @@ export class InBookingService {
 
   async getInBookingSessionCount(eventId: number): Promise<number> {
     return this.redis.scard(this.getEventKey(eventId));
-  }
-
-  private getTargetEventId(sid: string) {
-    return this.authService.getUserEventTarget(sid);
   }
 
   private getSessionKey(eventId: number, sid: string) {
@@ -242,6 +181,46 @@ export class InBookingService {
     };
   }
 
+  async validateAndAddBookedSeat(eventId: number, sid: string, target: [number, number]): Promise<void> {
+    const session = await this.getSession(eventId, sid);
+    if (!session) {
+      throw new BadRequestException('좌석 선택 세션이 존재하지 않습니다.');
+    }
+    if (session.bookingAmount <= session.bookedSeats.length) {
+      throw new BadRequestException('예약 가능한 좌석 수를 초과했습니다.');
+    }
+    session.bookedSeats.push(target);
+    await this.setSession(eventId, session);
+  }
+
+  async validateAndRemoveBookedSeat(eventId: number, sid: string, target: [number, number]): Promise<void> {
+    const session = await this.getSession(eventId, sid);
+    if (!session || session.bookedSeats.length === 0) {
+      throw new BadRequestException('취소할 수 있는 좌석이 없습니다.');
+    }
+    if (!session.bookedSeats.some((seat) => seat[0] === target[0] && seat[1] === target[1])) {
+      throw new BadRequestException('예약하지 않은 좌석입니다.');
+    }
+    session.bookedSeats = session.bookedSeats.filter((s) => s[0] !== target[0] || s[1] !== target[1]);
+    await this.setSession(eventId, session);
+  }
+
+  async flushAndSetBookingAmount(
+    eventId: number,
+    sid: string,
+    amount: number,
+  ): Promise<{ flushedSeats: [number, number][] }> {
+    const session = await this.getSession(eventId, sid);
+    if (!session) {
+      return { flushedSeats: [] };
+    }
+    const flushedSeats = [...session.bookedSeats];
+    session.bookedSeats = [];
+    session.bookingAmount = amount;
+    await this.setSession(eventId, session);
+    return { flushedSeats };
+  }
+
   async getAllInBookingSids(eventId: number) {
     return this.redis.smembers(this.getEventKey(eventId));
   }
@@ -273,21 +252,13 @@ export class InBookingService {
     }
   }
 
-  async addReconnectingSession(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-    if (eventId === null) {
-      return false;
-    }
+  async addReconnectingSession(eventId: number, sid: string) {
     const timestamp = Date.now();
     await this.redis.zadd(`reconnecting:${eventId}`, timestamp, sid);
     return true;
   }
 
-  async removeReconnectingSession(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-    if (eventId === null) {
-      return false;
-    }
+  async removeReconnectingSession(eventId: number, sid: string) {
     await this.redis.zrem(`reconnecting:${eventId}`, sid);
     return true;
   }

--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -4,7 +4,6 @@ import Redis from 'ioredis';
 import { BehaviorSubject } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { AuthService } from '../../../auth/service/auth.service';
 import { SSE_MAXIMUM_INTERVAL } from '../const/sseMaximumInterval';
 import { WAITING_BROADCAST_INTERVAL } from '../const/waitingBroadcastInterval.const';
 import { DEFAULT_WAITING_THROUGHPUT_RATE } from '../const/watingThroughputRate.const';
@@ -21,10 +20,7 @@ export class WaitingQueueService {
   private readonly redis: Redis | null;
   private queueSubscriptionMap = new Map<number, BehaviorSubject<WaitingSituation>>();
 
-  constructor(
-    private redisService: RedisService,
-    private authService: AuthService,
-  ) {
+  constructor(private redisService: RedisService) {
     this.redis = this.redisService.getOrThrow();
   }
 
@@ -39,13 +35,7 @@ export class WaitingQueueService {
       );
   }
 
-  async pushQueue(sid: string) {
-    const eventId = await this.authService.getUserEventTarget(sid);
-
-    if (eventId === null) {
-      throw new Error('대기큐에 추가할 세션의 대상 이벤트를 불러올 수 없습니다.');
-    }
-
+  async pushQueue(eventId: number, sid: string) {
     if (!this.queueSubscriptionMap.get(eventId)) {
       await this.createQueueSubscription(eventId);
     }

--- a/back/src/domains/reservation/service/reservation.service.ts
+++ b/back/src/domains/reservation/service/reservation.service.ts
@@ -144,7 +144,7 @@ export class ReservationService {
 
       await queryRunner.commitTransaction();
 
-      await this.inBookingService.setIsSaved(sid, true);
+      await this.inBookingService.setIsSaved(eventId, sid, true);
 
       return {
         programName: program.name,

--- a/back/test/helpers/e2e-setup.ts
+++ b/back/test/helpers/e2e-setup.ts
@@ -282,8 +282,9 @@ export async function transitionToSelectingSeat(app: INestApplication, sid: stri
 export async function simulateSseDisconnect(app: INestApplication, sid: string) {
   const authService = app.get(AuthService);
   const inBookingService = app.get(InBookingService);
+  const eventId = await authService.getUserEventTarget(sid);
   await authService.setUserStatusReconnectingSelecting(sid);
-  await inBookingService.addReconnectingSession(sid);
+  await inBookingService.addReconnectingSession(eventId, sid);
 }
 
 /**
@@ -296,8 +297,10 @@ export async function simulateSseDisconnect(app: INestApplication, sid: string) 
  * 4. 대기열 다음 유저 입장
  */
 export async function simulateSseCloseTimeout(app: INestApplication, sid: string) {
+  const authService = app.get(AuthService);
   const inBookingService = app.get(InBookingService);
-  await inBookingService.removeReconnectingSession(sid);
+  const eventId = await authService.getUserEventTarget(sid);
+  await inBookingService.removeReconnectingSession(eventId, sid);
 
   const bookingService = app.get(BookingService);
   await bookingService.onSeatsSseDisconnected({ sid });


### PR DESCRIPTION
## Summary

- Booking 하위 서비스들이 `sid`만 받아 내부에서 매번 `getUserEventTarget(sid)`를 호출하던 구조를, 상위 호출자가 이미 알고 있는 `eventId`를 파라미터로 전달하도록 변경
- SET 직후 동일 키 GET하던 버그 4건 수정
- 복합 메서드(`validateAndAddBookedSeat`, `flushAndSetBookingAmount` 등) 도입으로 `getSession` 중복까지 제거
- `WaitingQueueService`에서 `eventId`를 얻기 위해 `AuthService` 에 불필요히 의존하던 것 제거

**Redis 호출 절감**: `bookSeat` 7→3, `setBookingAmount` 7→3, `isAdmission` 3~4→1

## 변경 파일

| 파일 | 변경 |
|------|------|
| `in-booking.service.ts` | 12개 메서드 eventId 파라미터화, SET→GET 버그 3건 수정, 복합 메서드 3개 추가 |
| `enter-booking.service.ts` | 3개 메서드 eventId 파라미터화, SET→GET 버그 1건 수정 |
| `waiting-queue.service.ts` | `pushQueue` eventId 파라미터화, AuthService 의존성 제거 |
| `booking.service.ts` | 모든 호출자 업데이트, `getForwarded` 중복 호출 제거 |
| `booking-seats.service.ts` | `bookSeat`/`unBookSeat` 복합 메서드 적용 |
| `booking.controller.ts` | SSE 핸들러 eventId 전달 |
| `reservation.service.ts` | `setIsSaved` eventId 전달 |
| `e2e-setup.ts` | 테스트 헬퍼 시그니처 업데이트 |

## Test plan

- [x] `npm run build` 통과
- [x] `npm run test` 93개 테스트 전부 통과
- [x] lint-staged (ESLint + Prettier) 통과

Issue Resolved: #366