### PR TITLE
@Sse 제거, 커스텀 SseBroadcaster로 SSE 브로드캐스트 최적화

### DIFF
--- a/back/src/domains/booking/controller/booking.controller.ts
+++ b/back/src/domains/booking/controller/booking.controller.ts
@@ -7,7 +7,7 @@ import {
   ParseIntPipe,
   Post,
   Req,
-  Sse,
+  Res,
   UseGuards,
   UsePipes,
   ValidationPipe,
@@ -22,7 +22,7 @@ import {
   ApiOperation,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 
 import { USER_STATUS } from '../../../auth/const/userStatus.const';
 import { SessionAuthGuard } from '../../../auth/guard/session.guard';
@@ -65,7 +65,7 @@ export class BookingController {
     return await this.bookingService.isAdmission(eventId, sid);
   }
 
-  @Sse('re-permission/:eventId')
+  @Get('re-permission/:eventId')
   @UseGuards(SessionAuthGuard(USER_STATUS.WAITING))
   @ApiOperation({
     summary: '대기큐 현황 SSE',
@@ -73,8 +73,13 @@ export class BookingController {
   })
   @ApiOkResponse({ description: 'SSE 연결 성공', type: WaitingSseDto })
   @ApiUnauthorizedResponse({ description: '인증 실패' })
-  async subscribeWaitingQueue(@Param('eventId') eventId: number) {
-    return this.waitingQueueService.subscribeQueue(eventId);
+  async subscribeWaitingQueue(@Param('eventId') eventId: number, @Req() req: Request, @Res() res: Response) {
+    const sid = req.cookies['SID'];
+    this.waitingQueueService.addSseClient(eventId, res, sid);
+
+    req.on('close', () => {
+      this.waitingQueueService.removeSseClient(eventId, res);
+    });
   }
 
   @Post('count')
@@ -91,7 +96,7 @@ export class BookingController {
     return new BookingAmountResDto(result);
   }
 
-  @Sse('seat/:eventId')
+  @Get('seat/:eventId')
   @UseGuards(
     SessionAuthGuard([USER_STATUS.ENTERING, USER_STATUS.SELECTING_SEAT, USER_STATUS.RECONNECTING_SELECTING]),
   )
@@ -101,7 +106,11 @@ export class BookingController {
   })
   @ApiOkResponse({ description: 'SSE 연결 성공', type: SeatsSseDto })
   @ApiUnauthorizedResponse({ description: '인증 실패' })
-  async getReservationStatusByEventId(@Param('eventId') eventId: number, @Req() req: Request) {
+  async getReservationStatusByEventId(
+    @Param('eventId') eventId: number,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
     const sid = req.cookies['SID'];
 
     const session = await this.authService.getUserSession(sid);
@@ -113,9 +122,11 @@ export class BookingController {
       await this.authService.setUserStatusSelectingSeat(sid);
     }
 
-    const observable = this.bookingSeatsService.subscribeSeatsSSE(eventId);
+    this.bookingSeatsService.addSseClient(eventId, res, sid);
 
     req.on('close', async () => {
+      this.bookingSeatsService.removeSseClient(eventId, res);
+
       const inBookingSession = await this.inBookingService.getSession(eventId, sid);
       if (inBookingSession?.saved) {
         await this.bookingService.onSeatsSseDisconnected({ sid });
@@ -124,8 +135,6 @@ export class BookingController {
         await this.inBookingService.addReconnectingSession(eventId, sid);
       }
     });
-
-    return observable;
   }
 
   @Post('')

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -7,10 +7,10 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { Response } from 'express';
 import Redis from 'ioredis';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { Logger as WinstonLogger } from 'winston';
 
 import { AuthService } from '../../../auth/service/auth.service';
@@ -23,6 +23,7 @@ import { runGetSeatsLua } from '../luaScripts/getSeatsLua';
 import { runInitSectionSeatLua } from '../luaScripts/initSectionSeatLua';
 import { runSetSectionsLenLua } from '../luaScripts/setSectionsLenLua';
 import { runUpdateSeatLua } from '../luaScripts/updateSeatLua';
+import { SseBroadcaster } from '../sse/sse-broadcaster';
 
 import { InBookingService } from './in-booking.service';
 
@@ -40,6 +41,7 @@ export class BookingSeatsService {
   private readonly redis: Redis | null;
   private seatsSubscriptionMap = new Map<number, SeatSubscription>();
   private broadcastActivateMap = new Map<number, boolean>();
+  private readonly sseBroadcaster: SseBroadcaster<SeatStatusObject>;
 
   constructor(
     private redisService: RedisService,
@@ -49,6 +51,7 @@ export class BookingSeatsService {
     @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
   ) {
     this.redis = this.redisService.getOrThrow();
+    this.sseBroadcaster = new SseBroadcaster('seats', this.logger, { retryMs: SEATS_SSE_RETRY_INTERVAL });
   }
 
   async openReservation(eventId: number, seats: number[][]) {
@@ -64,9 +67,11 @@ export class BookingSeatsService {
     }
     const seatSubscription = await this.createSeatSubscription(eventId, seats);
     this.seatsSubscriptionMap.set(eventId, seatSubscription);
+    this.sseBroadcaster.startBroadcast(eventId, seatSubscription.subject.asObservable());
   }
 
   async clearSeatsSubscription(eventId: number) {
+    this.sseBroadcaster.stopBroadcast(eventId);
     const seatSubscription = this.seatsSubscriptionMap.get(eventId);
     if (seatSubscription) {
       clearInterval(seatSubscription.interval);
@@ -172,13 +177,12 @@ export class BookingSeatsService {
     return subscription.subject.asObservable();
   }
 
-  subscribeSeatsSSE(eventId: number) {
-    return this.getSeatsObservable(eventId).pipe(
-      map((data) => ({
-        data,
-        retry: SEATS_SSE_RETRY_INTERVAL,
-      })),
-    );
+  addSseClient(eventId: number, res: Response, sid: string): void {
+    this.sseBroadcaster.addClient(eventId, res, sid);
+  }
+
+  removeSseClient(eventId: number, res: Response): void {
+    this.sseBroadcaster.removeClient(eventId, res);
   }
 
   @OnEvent('seats-status-changed')

--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -1,13 +1,16 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { Response } from 'express';
 import Redis from 'ioredis';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Logger as WinstonLogger } from 'winston';
 
 import { SSE_MAXIMUM_INTERVAL } from '../const/sseMaximumInterval';
 import { WAITING_BROADCAST_INTERVAL } from '../const/waitingBroadcastInterval.const';
 import { DEFAULT_WAITING_THROUGHPUT_RATE } from '../const/watingThroughputRate.const';
 import { WaitingSseDto } from '../dto/waitingSse.dto';
+import { SseBroadcaster } from '../sse/sse-broadcaster';
 
 type WaitingSituation = {
   headOrder: number;
@@ -15,28 +18,35 @@ type WaitingSituation = {
   throughputRate: number;
 };
 
+type QueueSubscription = {
+  subject: BehaviorSubject<WaitingSituation>;
+  interval: NodeJS.Timeout;
+};
+
 @Injectable()
 export class WaitingQueueService {
   private readonly redis: Redis | null;
-  private queueSubscriptionMap = new Map<number, BehaviorSubject<WaitingSituation>>();
+  private queueSubscriptionMap = new Map<number, QueueSubscription>();
+  private readonly sseBroadcaster: SseBroadcaster<WaitingSituation>;
 
-  constructor(private redisService: RedisService) {
+  constructor(
+    private redisService: RedisService,
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
+  ) {
     this.redis = this.redisService.getOrThrow();
+    this.sseBroadcaster = new SseBroadcaster('waiting', this.logger);
   }
 
-  subscribeQueue(eventId: number) {
-    return this.queueSubscriptionMap
-      .get(eventId)
-      .asObservable()
-      .pipe(
-        map((data) => {
-          return { data };
-        }),
-      );
+  addSseClient(eventId: number, res: Response, sid: string): void {
+    this.sseBroadcaster.addClient(eventId, res, sid);
+  }
+
+  removeSseClient(eventId: number, res: Response): void {
+    this.sseBroadcaster.removeClient(eventId, res);
   }
 
   async pushQueue(eventId: number, sid: string) {
-    if (!this.queueSubscriptionMap.get(eventId)) {
+    if (!this.queueSubscriptionMap.has(eventId)) {
       await this.createQueueSubscription(eventId);
     }
     const order = await this.redis.incr(`waiting-queue:${eventId}:order`);
@@ -64,10 +74,10 @@ export class WaitingQueueService {
       totalWaiting: 0,
       throughputRate: DEFAULT_WAITING_THROUGHPUT_RATE,
     };
-    const subscription = new BehaviorSubject<WaitingSituation>(initialSituation);
-    setInterval(
+    const subject = new BehaviorSubject<WaitingSituation>(initialSituation);
+    const interval = setInterval(
       async () =>
-        subscription.next(
+        subject.next(
           new WaitingSseDto(
             await this.getHeadOrder(eventId),
             await this.getQueueSize(eventId),
@@ -77,8 +87,9 @@ export class WaitingQueueService {
       Math.min(WAITING_BROADCAST_INTERVAL, SSE_MAXIMUM_INTERVAL),
     );
 
-    this.queueSubscriptionMap.set(eventId, subscription);
-    return subscription;
+    this.queueSubscriptionMap.set(eventId, { subject, interval });
+    this.sseBroadcaster.startBroadcast(eventId, subject.asObservable());
+    return subject;
   }
 
   private async getHeadOrder(eventId: number) {
@@ -105,9 +116,11 @@ export class WaitingQueueService {
   }
 
   async clearQueue(eventId: number) {
-    const subscription = this.queueSubscriptionMap.get(eventId);
-    if (subscription) {
-      subscription.complete();
+    this.sseBroadcaster.stopBroadcast(eventId);
+    const queueSubscription = this.queueSubscriptionMap.get(eventId);
+    if (queueSubscription) {
+      clearInterval(queueSubscription.interval);
+      queueSubscription.subject.complete();
       this.queueSubscriptionMap.delete(eventId);
     }
     const keys = await this.redis.keys(`waiting-queue:${eventId}:*`);

--- a/back/src/domains/booking/sse/sse-broadcaster.ts
+++ b/back/src/domains/booking/sse/sse-broadcaster.ts
@@ -1,0 +1,143 @@
+import { Response } from 'express';
+import { Observable, Subscription } from 'rxjs';
+import { Logger as WinstonLogger } from 'winston';
+
+interface SseClientInfo {
+  res: Response;
+  sid: string;
+}
+
+export interface SseBroadcasterOptions {
+  retryMs?: number;
+}
+
+export class SseBroadcaster<T> {
+  private clientsMap = new Map<number, Set<SseClientInfo>>();
+  private subscriptionMap = new Map<number, Subscription>();
+  private latestMessageMap = new Map<number, string>();
+  private messageIdMap = new Map<number, number>();
+
+  constructor(
+    private readonly name: string,
+    private readonly logger: WinstonLogger,
+    private readonly options: SseBroadcasterOptions = {},
+  ) {}
+
+  startBroadcast(eventId: number, source$: Observable<T>): void {
+    if (this.subscriptionMap.has(eventId)) {
+      return;
+    }
+    this.messageIdMap.set(eventId, 0);
+
+    const subscription = source$.subscribe({
+      next: (data) => this.onData(eventId, data),
+      error: (err) => this.logger.error(`[${this.name}] SSE 브로드캐스트 에러: eventId=${eventId}`, err),
+    });
+
+    this.subscriptionMap.set(eventId, subscription);
+  }
+
+  stopBroadcast(eventId: number): void {
+    const subscription = this.subscriptionMap.get(eventId);
+    if (subscription) {
+      subscription.unsubscribe();
+      this.subscriptionMap.delete(eventId);
+    }
+
+    const clients = this.clientsMap.get(eventId);
+    if (clients) {
+      for (const client of clients) {
+        try {
+          client.res.end();
+        } catch {}
+      }
+      this.clientsMap.delete(eventId);
+    }
+
+    this.latestMessageMap.delete(eventId);
+    this.messageIdMap.delete(eventId);
+  }
+
+  addClient(eventId: number, res: Response, sid: string): void {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
+      Pragma: 'no-cache',
+      Expire: '0',
+      'X-Accel-Buffering': 'no',
+    });
+    res.flushHeaders();
+
+    const socket = res.socket;
+    if (socket) {
+      socket.setKeepAlive(true);
+      socket.setNoDelay(true);
+      socket.setTimeout(0);
+    }
+
+    res.write('\n');
+
+    if (!this.clientsMap.has(eventId)) {
+      this.clientsMap.set(eventId, new Set());
+    }
+    const clientInfo: SseClientInfo = { res, sid };
+    this.clientsMap.get(eventId).add(clientInfo);
+
+    const latestMsg = this.latestMessageMap.get(eventId);
+    if (latestMsg) {
+      try {
+        res.write(latestMsg);
+      } catch {}
+    }
+  }
+
+  removeClient(eventId: number, res: Response): void {
+    const clients = this.clientsMap.get(eventId);
+    if (!clients) return;
+
+    for (const client of clients) {
+      if (client.res === res) {
+        clients.delete(client);
+        break;
+      }
+    }
+
+    if (clients.size === 0) {
+      this.clientsMap.delete(eventId);
+    }
+  }
+
+  getClientCount(eventId: number): number {
+    return this.clientsMap.get(eventId)?.size ?? 0;
+  }
+
+  private onData(eventId: number, data: T): void {
+    const currentId = (this.messageIdMap.get(eventId) ?? 0) + 1;
+    this.messageIdMap.set(eventId, currentId);
+
+    const jsonStr = JSON.stringify(data);
+    let sseMessage = `id: ${currentId}\n`;
+    if (this.options.retryMs) {
+      sseMessage += `retry: ${this.options.retryMs}\n`;
+    }
+    sseMessage += `data: ${jsonStr}\n\n`;
+
+    this.latestMessageMap.set(eventId, sseMessage);
+
+    const clients = this.clientsMap.get(eventId);
+    if (!clients) return;
+
+    for (const client of clients) {
+      try {
+        client.res.write(sseMessage);
+      } catch {
+        this.logger.warn(`[${this.name}] SSE 메시지 송신 실패: sid=${client.sid}, 클라이언트 제거`);
+        clients.delete(client);
+        try {
+          client.res.end();
+        } catch {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- close #368

## 🚀 구현 내용
`@Sse` 데코레이터를 제거하고 커스텀 `SseBroadcaster<T>`로 SSE 브로드캐스트 구조를 최적화했다.

**문제:**
- 기존 `@Sse`는 클라이언트마다 독립적인 RxJS 구독 체인, `SseStream` Transform 스트림, 메시지당 Promise를 생성
- 동일 이벤트를 수신하는 N개 클라이언트에게 `JSON.stringify`·SSE 포맷팅이 N번 중복 실행되는 구조
- `concatMap` drain 대기는 좌석 데이터(전체 상태 스냅샷)에는 불필요한 오버헤드

**해결:**
- `SseBroadcaster<T>` 도입: BehaviorSubject 구독 1개로 메시지를 **1회만** 직렬화·포맷팅 후 N개 `Response`에 직접 `write()`
- backpressure를 fire-and-forget 방식으로 처리
- 기존 벤치마크 WS 게이트웨이(`seats.gateway.ts`)와 동일한 패턴으로 통일

## 📘 참고 사항
- 변경 파일: `booking.controller.ts`, `booking-seats.service.ts`, `waiting-queue.service.ts`, `sse-broadcaster.ts`(신규)