### PR TITLE
Greenlight 스탬프 방식 개선: 타임스탬프 → 코드 해시

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,17 +12,17 @@ if [ ! -f "$STAMP" ]; then
   exit 1
 fi
 
-STAMP_TIME=$(cat "$STAMP")
-NOW=$(date +%s)
-ELAPSED=$((NOW - STAMP_TIME))
-MAX_AGE=600  # 10분
+STAMP_HASH=$(cat "$STAMP")
+CURRENT_HASH=$(git diff HEAD | sha256sum | cut -d' ' -f1)
 
-if [ "$ELAPSED" -gt "$MAX_AGE" ]; then
+if [ "$STAMP_HASH" != "$CURRENT_HASH" ]; then
   echo ""
-  echo "❌  E2E Greenlight 만료 (${ELAPSED}초 경과 / 유효 ${MAX_AGE}초)"
+  echo "❌  Greenlight 발급 이후 코드가 변경됐습니다."
   echo "    npm run greenlight 재실행 후 커밋하세요."
   echo ""
+  rm "$STAMP"
   exit 1
 fi
 
-echo "✅  Greenlight 유효 (${ELAPSED}초 전 발급)"
+echo "✅  Greenlight 검증 통과"
+rm "$STAMP"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:front": "npm --prefix front run test -- --run",
     "test:e2e": "npm --prefix back run test",
-    "greenlight": "npm run test:front && npm run test:e2e && node -e \"require('fs').writeFileSync('.greenlight-stamp', String(Math.floor(Date.now()/1000)))\" && echo '✅ Greenlight 발급: 모든 테스트 통과'",
+    "greenlight": "npm run test:front && npm run test:e2e && node -e \"const{execSync}=require('child_process'),crypto=require('crypto');const hash=crypto.createHash('sha256').update(execSync('git diff HEAD').toString()).digest('hex');require('fs').writeFileSync('.greenlight-stamp',hash);\" && echo '✅ Greenlight 발급: 모든 테스트 통과'",
     "lint-staged": "lint-staged",
     "prepare": "husky",
     "branch": "node ./scripts/makeLinkedBranch.js"


### PR DESCRIPTION
## 📌 이슈 번호
- close #374

## 🚀 구현 내용
#372에서 도입한 Greenlight 게이트의 스탬프 방식을 타임스탬프에서 코드 해시로 교체했다.

**변경 전 (타임스탬프 방식)**
- greenlight 실행 시 Unix timestamp를 `.greenlight-stamp`에 기록
- pre-commit에서 경과 시간(10분) 초과 여부만 검사
- 문제: 기능 A 테스트 후 10분 내에 기능 B를 테스트 없이 커밋 가능

**변경 후 (코드 해시 방식)**
- greenlight 실행 시 `git diff HEAD`의 SHA-256 해시를 `.greenlight-stamp`에 기록
- pre-commit에서 현재 코드의 해시와 스탬프 해시를 비교
- greenlight 이후 코드가 한 줄이라도 바뀌면 커밋 차단
- 검증 통과/실패 모두 스탬프 삭제 (단회성)