### PR TITLE
백엔드 Dockerfile Node.js 버전 고정 (20.18.0)

### DIFF
--- a/back/Dockerfile.debug-in-local
+++ b/back/Dockerfile.debug-in-local
@@ -1,4 +1,4 @@
-FROM node
+FROM node:20.18.0
 COPY package*.json ./
 RUN npm install
 COPY . .

--- a/back/Dockerfile.debug-in-prod
+++ b/back/Dockerfile.debug-in-prod
@@ -1,4 +1,4 @@
-FROM node
+FROM node:20.18.0
 COPY package*.json ./
 RUN npm install
 COPY . .

--- a/back/Dockerfile.dev-in-local
+++ b/back/Dockerfile.dev-in-local
@@ -1,4 +1,4 @@
-FROM node
+FROM node:20.18.0
 COPY package*.json ./
 RUN npm install
 COPY . .

--- a/back/Dockerfile.dev-in-prod
+++ b/back/Dockerfile.dev-in-prod
@@ -1,4 +1,4 @@
-FROM node
+FROM node:20.18.0
 COPY package*.json ./
 RUN npm install
 COPY . .

--- a/back/Dockerfile.release
+++ b/back/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM node
+FROM node:20.18.0
 COPY package*.json ./
 RUN npm install
 COPY . .


### PR DESCRIPTION
## 📌 이슈 번호
- close #376

## 🚀 구현 내용
백엔드 Dockerfile 5개 모두 `FROM node`를 `FROM node:20.18.0`으로 수정하여 Node.js 버전을 명시적으로 고정했다.

- `Dockerfile.debug-in-local`
- `Dockerfile.debug-in-prod`
- `Dockerfile.dev-in-local`
- `Dockerfile.dev-in-prod`
- `Dockerfile.release`