### PR TITLE
Redis 자료구조 리팩토링 — KEEPTTL 적용 / in-booking HASH 전환 / sessions:active ZSET 구현

### DIFF
--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -4,6 +4,7 @@ import json as _json
 import logging
 import math
 import os
+import redis
 import socket
 import time
 import pymysql
@@ -38,6 +39,12 @@ DB_NAME              = os.getenv("DB_NAME", "real_ticket")
 DB_POLL_INTERVAL     = int(os.getenv("DB_POLL_INTERVAL", "3600"))
 PRE_SCALE_UP_WINDOW  = int(os.getenv("PRE_SCALE_UP_WINDOW", "600"))
 SCALE_DOWN_SUPPRESS  = int(os.getenv("SCALE_DOWN_SUPPRESS", "300"))
+
+# Redis 연결 (sessions:active 조회용)
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+
+redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
 QUERY = (
     f'avg(rate(container_cpu_usage_seconds_total'
@@ -97,6 +104,27 @@ def get_cpu_percent() -> float | None:
         return raw * 100
     except Exception as e:
         logger.error(f"Prometheus 쿼리 실패: {e}")
+        return None
+
+
+def get_active_session_count() -> int | None:
+    """sessions:active ZSET에서 만료되지 않은 세션 수를 반환한다.
+
+    pipeline:
+      1. ZREMRANGEBYSCORE sessions:active 0 {now_ms}  — 만료 항목 GC
+      2. ZCOUNT sessions:active {now_ms} +inf          — 유효 세션 수
+
+    실패 시 None 반환.
+    """
+    try:
+        now_ms = int(time.time() * 1000)
+        pipe = redis_client.pipeline()
+        pipe.zremrangebyscore('sessions:active', 0, now_ms)
+        pipe.zcount('sessions:active', now_ms, '+inf')
+        results = pipe.execute()
+        return int(results[1])
+    except Exception as e:
+        logger.error(f"sessions:active 조회 실패: {e}")
         return None
 
 
@@ -258,6 +286,13 @@ if __name__ == "__main__":
             check_and_scale()
         except Exception as e:
             logger.error(f"폴링 루프 오류 (check_and_scale): {e}")
+
+        try:
+            active_sessions = get_active_session_count()
+            if active_sessions is not None:
+                logger.info(f"active_session_count={active_sessions}")
+        except Exception as e:
+            logger.error(f"폴링 루프 오류 (get_active_session_count): {e}")
 
         # D-11: DB 조회는 별도 주기 (기본 60분)
         try:

--- a/autoscaler/requirements.txt
+++ b/autoscaler/requirements.txt
@@ -1,3 +1,4 @@
 docker==7.1.0
 prometheus-api-client==0.7.0
 pymysql==1.1.1
+redis>=4.0.0

--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -60,7 +60,7 @@ export class AuthService {
     if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
-    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.LOGIN }));
+    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.LOGIN }), 'KEEPTTL');
   }
 
   async setUserStatusWaiting(sid: string) {
@@ -68,7 +68,7 @@ export class AuthService {
     if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
-    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.WAITING }));
+    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.WAITING }), 'KEEPTTL');
   }
 
   async setUserStatusEntering(sid: string) {
@@ -76,7 +76,7 @@ export class AuthService {
     if (!session) return;
     if (session.userStatus === USER_STATUS.ADMIN) return;
 
-    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.ENTERING }));
+    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.ENTERING }), 'KEEPTTL');
   }
 
   async setUserStatusSelectingSeat(sid: string) {
@@ -87,6 +87,7 @@ export class AuthService {
     await this.redis.set(
       `user:${sid}`,
       JSON.stringify({ ...session, userStatus: USER_STATUS.SELECTING_SEAT }),
+      'KEEPTTL',
     );
   }
 
@@ -98,6 +99,7 @@ export class AuthService {
     await this.redis.set(
       `user:${sid}`,
       JSON.stringify({ ...session, userStatus: USER_STATUS.RECONNECTING_SELECTING }),
+      'KEEPTTL',
     );
   }
 
@@ -105,7 +107,7 @@ export class AuthService {
     const session = await this.getParsedSession(sid);
     if (!session) return;
 
-    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.ADMIN }));
+    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, userStatus: USER_STATUS.ADMIN }), 'KEEPTTL');
   }
 
   async removeSession(sid: string, loginId: string) {
@@ -191,7 +193,7 @@ export class AuthService {
       return;
     }
 
-    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, targetEvent: eventId }));
+    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, targetEvent: eventId }), 'KEEPTTL');
   }
 
   async getUserEventTarget(sid: string) {

--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -112,6 +112,7 @@ export class AuthService {
 
   async removeSession(sid: string, loginId: string) {
     this.redis.unlink(`user-id:${loginId}`);
+    this.redis.zrem('sessions:active', loginId);
     return this.redis.unlink(`user:${sid}`);
   }
 
@@ -147,6 +148,7 @@ export class AuthService {
 
       await this.redis.set(`user-id:${id}`, sessionId, 'EX', AUTH_EXPIRE_TIME);
       await this.redis.set(`user:${sessionId}`, JSON.stringify(cachedUserInfo), 'EX', AUTH_EXPIRE_TIME);
+      await this.redis.zadd('sessions:active', Date.now() + AUTH_EXPIRE_TIME * 1000, user.loginId);
 
       return { sessionId: sessionId, userInfo: userInfoDto };
     } catch (err) {
@@ -225,6 +227,7 @@ export class AuthService {
 
       await this.redis.set(`user-id:${guestId}`, uuid, 'EX', AUTH_EXPIRE_TIME);
       await this.redis.set(`user:${uuid}`, JSON.stringify(guestSession), 'EX', AUTH_EXPIRE_TIME);
+      await this.redis.zadd('sessions:active', Date.now() + AUTH_EXPIRE_TIME * 1000, guestId);
 
       return { sessionId: uuid, userInfo: guestSession };
     } catch (err) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -146,11 +146,7 @@ export class InBookingService {
   }
 
   async getInBookingSessionCount(eventId: number): Promise<number> {
-    return this.redis.scard(this.getEventKey(eventId));
-  }
-
-  private getSessionKey(eventId: number, sid: string) {
-    return `in-booking:${eventId}:session:${sid}`;
+    return this.redis.hlen(this.getEventKey(eventId));
   }
 
   private getEventKey(eventId: number) {
@@ -158,24 +154,17 @@ export class InBookingService {
   }
 
   async setSession(eventId: number, inBookingSession: InBookingSession): Promise<void> {
-    const sessionKey = this.getSessionKey(eventId, inBookingSession.sid);
     const eventKey = this.getEventKey(eventId);
-
-    await this.redis.sadd(eventKey, inBookingSession.sid);
-    await this.redis.set(sessionKey, JSON.stringify(inBookingSession));
+    await this.redis.hset(eventKey, inBookingSession.sid, JSON.stringify(inBookingSession));
   }
 
   async getSession(eventId: number, sid: string): Promise<InBookingSession | null> {
-    const session = await this.redis.get(this.getSessionKey(eventId, sid));
+    const session = await this.redis.hget(this.getEventKey(eventId), sid);
     return session ? JSON.parse(session) : null;
   }
 
   private async removeInBooking(eventId: number, sid: string): Promise<void> {
-    const session = await this.getSession(eventId, sid);
-    if (session) {
-      await this.redis.del(this.getSessionKey(eventId, sid));
-      await this.redis.srem(this.getEventKey(eventId), sid);
-    }
+    await this.redis.hdel(this.getEventKey(eventId), sid);
   }
 
   async getBookAmountAndBookedSeats(sid: string, eventId: number) {
@@ -226,8 +215,9 @@ export class InBookingService {
     return { flushedSeats };
   }
 
-  async getAllInBookingSids(eventId: number) {
-    return this.redis.smembers(this.getEventKey(eventId));
+  async getAllInBookingSids(eventId: number): Promise<string[]> {
+    const result = await this.redis.hgetall(this.getEventKey(eventId));
+    return result ? Object.keys(result) : [];
   }
 
   async clearInBookingPool(eventId: number) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -221,10 +221,10 @@ export class InBookingService {
   }
 
   async clearInBookingPool(eventId: number) {
-    const keys = await this.redis.keys(`in-booking:${eventId}:*`);
-    if (keys.length > 0) {
-      await this.redis.unlink(...keys);
-    }
+    await this.redis.unlink(
+      `in-booking:${eventId}:sessions`,
+      `in-booking:${eventId}:max-size`,
+    );
   }
 
   async gcReconnectingSessions(eventId: number) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -296,10 +296,7 @@ export class InBookingService {
 
   async clearReconnectingPool(eventId: number) {
     this.clearReconnectingGCInterval(eventId);
-    const keys = await this.redis.keys(`reconnecting:${eventId}:*`);
-    if (keys.length > 0) {
-      await this.redis.unlink(...keys);
-    }
+    await this.redis.unlink(`reconnecting:${eventId}`);
   }
 
   @OnEvent('logout-start')


### PR DESCRIPTION
## 📌 이슈 번호
- close #384

## 🚀 구현 내용

### 1. KEEPTTL 적용 — 상태 변경 시 TTL 소멸 버그 수정
로그인 시 `EX AUTH_EXPIRE_TIME`으로 설정된 TTL이 이후 상태 변경 SET 호출(TTL 인수 없음)에 의해 삭제되어 세션이 영구화되는 문제를 수정.
`setUserStatus*` 계열 함수 및 `setUserEventTarget`의 `redis.set` 호출에 `'KEEPTTL'` 옵션을 추가.

### 2. in-booking 세션 저장 구조 HASH 전환
세션당 STRING + SET 인덱스 2개 키 → 이벤트당 HASH 1개 키로 전환하여 keyspace를 절감
- `setSession` → `HSET`, `getSession` → `HGET`, `removeInBooking` → `HDEL`, `getInBookingSessionCount` → `HLEN`, `getAllInBookingSids` → `HGETALL + Object.keys()`

### 3. `keys()` 블로킹 명령 제거
운영 Redis에서 `keys()` 와일드카드는 모든 작업을 차단합니다. 2곳을 명시적 키 unlink로 교체
- `clearInBookingPool`: `keys('in-booking:{eventId}:*')` → `unlink(sessions, max-size)` 명시적 2개 키
- `clearReconnectingPool`: `keys('reconnecting:{eventId}:*')` → `unlink('reconnecting:{eventId}')` 직접 키

### 4. `sessions:active` ZSET 신규 구현
오토스케일러가 `ZCOUNT sessions:active {now_ms} +inf`로 O(log N)에 활성 세션 수를 조회할 수 있도록 ZSET 인덱스를 구축
- `validateUser` / `makeGuestUser`: 로그인·게스트 생성 시 `ZADD sessions:active {expiry_ms} {loginId}`
- `removeSession`: 로그아웃 시 `ZREM sessions:active {loginId}`
- `autoscaler/main.py`: Redis 클라이언트 초기화 + `get_active_session_count()` (ZREMRANGEBYSCORE GC + ZCOUNT pipeline)