### PR TITLE
동적 사전 스케일업 3축 구현

### DIFF
--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -17,7 +17,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 PROMETHEUS_URL       = os.getenv("PROMETHEUS_URL", "http://prometheus:9090")
-POLL_INTERVAL        = int(os.getenv("POLL_INTERVAL", "30"))
+POLL_INTERVAL        = int(os.getenv("POLL_INTERVAL", "5"))
 SCALE_UP_THRESHOLD   = float(os.getenv("SCALE_UP_THRESHOLD", "50"))
 SCALE_DOWN_THRESHOLD = float(os.getenv("SCALE_DOWN_THRESHOLD", "30"))
 COOLDOWN_UP          = int(os.getenv("COOLDOWN_UP", "120"))
@@ -39,6 +39,21 @@ DB_NAME              = os.getenv("DB_NAME", "real_ticket")
 DB_POLL_INTERVAL     = int(os.getenv("DB_POLL_INTERVAL", "3600"))
 PRE_SCALE_UP_WINDOW  = int(os.getenv("PRE_SCALE_UP_WINDOW", "600"))
 SCALE_DOWN_SUPPRESS  = int(os.getenv("SCALE_DOWN_SUPPRESS", "300"))
+
+# Phase 05: 축 1 — 트래픽 기반 선행 감지 임계값 (지표별 별도 설정)
+TRAFFIC_TOTAL_RATE_MULTIPLIER       = float(os.getenv("TRAFFIC_TOTAL_RATE_MULTIPLIER", "3.0"))
+TRAFFIC_TOTAL_MIN_RPS               = float(os.getenv("TRAFFIC_TOTAL_MIN_RPS", "6.0"))
+TRAFFIC_SERVER_TIME_RATE_MULTIPLIER = float(os.getenv("TRAFFIC_SERVER_TIME_RATE_MULTIPLIER", "2.0"))
+TRAFFIC_SERVER_TIME_MIN_RPS         = float(os.getenv("TRAFFIC_SERVER_TIME_MIN_RPS", "3.0"))
+TRAFFIC_CONSECUTIVE                 = int(os.getenv("TRAFFIC_CONSECUTIVE", "2"))
+TRAFFIC_SUPPRESS                    = int(os.getenv("TRAFFIC_SUPPRESS", "120"))
+TRAFFIC_WINDOW                      = os.getenv("TRAFFIC_WINDOW", "30s")
+
+# Phase 05: 축 2 — ready 기반 in-booking 풀 조정 계수
+POOL_PER_REPLICA         = int(os.getenv("POOL_PER_REPLICA", "100"))
+
+# Phase 05: 축 3 — 단계화 사전 스케일업 기준값
+BASE_POOL_SIZE           = int(os.getenv("BASE_POOL_SIZE", "100"))
 
 # Redis 연결 (sessions:active 조회용)
 REDIS_HOST = os.getenv("REDIS_HOST", "redis")
@@ -88,6 +103,8 @@ last_scale_up   = 0.0
 last_scale_down = 0.0
 last_db_poll            = time.time()  # 시작 시 즉시 폴링 방지 — DB_POLL_INTERVAL 후 첫 조회
 suppress_scaledown_until = 0.0
+suppress_traffic_until   = 0.0          # Phase 05: 트래픽 기반 스케일업 후 suppress (D-12)
+consecutive_traffic_alerts = 0          # Phase 05: 연속 트래픽 경보 카운터 (D-06)
 
 
 def get_cpu_percent() -> float | None:
@@ -195,7 +212,6 @@ def check_upcoming_reservations():
         f"사전 스케일업 트리거: 오픈 예정 {len(opens)}건, 최단 {earliest_open - time.time():.0f}s 후"
     )
 
-    # suppress 갱신: 가장 이른 오픈 시각 + SCALE_DOWN_SUPPRESS (기존값보다 크면 덮어쓰기)
     new_suppress_until = earliest_open + SCALE_DOWN_SUPPRESS
     if new_suppress_until > suppress_scaledown_until:
         suppress_scaledown_until = new_suppress_until
@@ -204,7 +220,6 @@ def check_upcoming_reservations():
             f"(현재로부터 {suppress_scaledown_until - time.time():.0f}s 후까지)"
         )
 
-    # 현재 레플리카 확인 + 스케일업
     try:
         service = docker_client.services.get(TARGET_SERVICE)
         service.reload()
@@ -214,7 +229,6 @@ def check_upcoming_reservations():
         return
 
     if current < MAX_REPLICAS:
-        # D-16: 현재 레플리카 수 < MAX일 때만 스케일업 실행
         scale_service(MAX_REPLICAS, current, "up")
         logger.info(f"사전 스케일업 완료: {current} -> {MAX_REPLICAS}")
     else:

--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -288,6 +288,36 @@ def check_and_adjust_pool():
         logger.error(f"check_and_adjust_pool: Redis SET+PUBLISH 실패: {e}")
 
 
+def determine_pre_scale_tier(session_count: int, max_replicas: int) -> int:
+    """로그인 세션 비율 기반 단계화 사전 스케일업 목표 레플리카 수.
+
+    ratio = session_count / BASE_POOL_SIZE
+    ratio < 0.15  → 0 (skip)
+    < 0.40        → ceil(max * 0.5)
+    < 0.80        → ceil(max * 0.75)
+    >= 0.80       → max
+    """
+    if BASE_POOL_SIZE <= 0:
+        logger.error("BASE_POOL_SIZE가 0 이하 — 단계화 불가, skip")
+        return 0
+    ratio = session_count / BASE_POOL_SIZE
+    logger.info(f"단계화: session_count={session_count}, ratio={ratio:.3f}")
+    if ratio < 0.15:
+        logger.info(f"tier=SKIP (ratio={ratio:.3f})")
+        return 0
+    elif ratio < 0.40:
+        t = math.ceil(max_replicas * 0.5)
+        logger.info(f"tier=LOW → {t}")
+        return t
+    elif ratio < 0.80:
+        t = math.ceil(max_replicas * 0.75)
+        logger.info(f"tier=MID → {t}")
+        return t
+    else:
+        logger.info(f"tier=HIGH → {max_replicas}")
+        return max_replicas
+
+
 def fetch_upcoming_reservation_opens() -> list[float]:
     """
     MySQL Event 테이블에서 현재 UTC 시각부터 PRE_SCALE_UP_WINDOW 초 이내에
@@ -331,13 +361,10 @@ def fetch_upcoming_reservation_opens() -> list[float]:
 
 
 def check_upcoming_reservations():
-    """
-    미래 예매 중 PRE_SCALE_UP_WINDOW 초 이내 오픈 예정 건이 있으면
-    nest 서비스를 MAX_REPLICAS로 사전 스케일업하고
-    suppress_scaledown_until = 오픈 시각 + SCALE_DOWN_SUPPRESS 로 설정한다.
+    """축 3: 수요 기반 단계화 사전 스케일업 (AUTOSCALER-09 수정).
 
-    - 이미 MAX_REPLICAS에 도달한 경우: 스케일업 skip, suppress만 갱신
-    - 여러 건 탐지 시: 가장 이른 오픈 시각 + SCALE_DOWN_SUPPRESS 와 기존 suppress 중 max 사용
+    target=0: skip (suppress 갱신 없음)
+    target>0: current<target일 때만 scale_service + suppress_scaledown_until max() 갱신
     """
     global suppress_scaledown_until
 
@@ -346,17 +373,22 @@ def check_upcoming_reservations():
         return
 
     earliest_open = min(opens)
-    logger.info(
-        f"사전 스케일업 트리거: 오픈 예정 {len(opens)}건, 최단 {earliest_open - time.time():.0f}s 후"
-    )
+    logger.info(f"사전 스케일업 트리거: 오픈 예정 {len(opens)}건, 최단 {earliest_open - time.time():.0f}s 후")
+
+    session_count = get_active_session_count()
+    if session_count is None:
+        logger.warning("사전 스케일업: sessions:active 조회 실패 — skip")
+        return
+
+    target = determine_pre_scale_tier(session_count, MAX_REPLICAS)
+    if target == 0:
+        logger.info("사전 스케일업 tier=SKIP — 스케일업 및 suppress 갱신 없음")
+        return
 
     new_suppress_until = earliest_open + SCALE_DOWN_SUPPRESS
     if new_suppress_until > suppress_scaledown_until:
         suppress_scaledown_until = new_suppress_until
-        logger.info(
-            f"스케일다운 억제 갱신: suppress_scaledown_until={suppress_scaledown_until:.0f} "
-            f"(현재로부터 {suppress_scaledown_until - time.time():.0f}s 후까지)"
-        )
+        logger.info(f"스케일다운 억제 갱신: {suppress_scaledown_until - time.time():.0f}s 후까지")
 
     try:
         service = docker_client.services.get(TARGET_SERVICE)
@@ -366,11 +398,11 @@ def check_upcoming_reservations():
         logger.error(f"사전 스케일업: 현재 레플리카 조회 실패: {e}")
         return
 
-    if current < MAX_REPLICAS:
-        scale_service(MAX_REPLICAS, current, "up")
-        logger.info(f"사전 스케일업 완료: {current} -> {MAX_REPLICAS}")
+    if current < target:
+        scale_service(target, current, "up")
+        logger.info(f"단계화 사전 스케일업 완료: {current} -> {target}")
     else:
-        logger.info(f"사전 스케일업 skip (이미 MAX={MAX_REPLICAS}) — suppress만 갱신")
+        logger.info(f"단계화 사전 스케일업 skip (current={current} >= target={target}) — suppress만 갱신")
 
 
 def scale_service(target: int, current: int, direction: str):

--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -229,6 +229,65 @@ def get_current_replicas(service) -> int:
     return service.attrs["Spec"]["Mode"]["Replicated"]["Replicas"]
 
 
+def get_ready_replicas() -> int | None:
+    """Prometheus up{job="nest-app"}==1 기반 ready 레플리카 수 반환. 실패 시 None."""
+    try:
+        result = prom.custom_query(query='count(up{job="nest-app"}==1)')
+        if not result:
+            logger.warning("get_ready_replicas: 결과 없음 — skip")
+            return None
+        val = float(result[0]["value"][1])
+        return None if math.isnan(val) else int(val)
+    except Exception as e:
+        logger.error(f"get_ready_replicas 쿼리 실패: {e}")
+        return None
+
+
+def update_in_booking_pool_size(new_size: int) -> None:
+    """Redis in-booking:default-max-size SET + booking:events PUBLISH."""
+    redis_client.set('in-booking:default-max-size', str(new_size))
+    redis_client.publish('booking:events', '{"type":"all-in-booking-max-size-changed"}')
+    logger.info(f"in-booking 풀 사이즈 업데이트: {new_size} (SET + PUBLISH)")
+
+
+def check_and_adjust_pool():
+    """축 2: min(docker desired, prometheus ready) × POOL_PER_REPLICA로 풀 동적 조정."""
+    try:
+        service = docker_client.services.get(TARGET_SERVICE)
+        service.reload()
+        desired = get_current_replicas(service)
+    except Exception as e:
+        logger.error(f"check_and_adjust_pool: Docker desired 조회 실패 — skip: {e}")
+        return
+
+    ready = get_ready_replicas()
+    if ready is None:
+        logger.debug("check_and_adjust_pool: ready=None — skip")
+        return
+    if ready == 0:
+        logger.warning("check_and_adjust_pool: ready=0 — skip (풀 0 설정 방지)")
+        return
+
+    new_pool = min(desired, ready) * POOL_PER_REPLICA
+
+    try:
+        current_val = redis_client.get('in-booking:default-max-size')
+        current_pool = int(current_val) if current_val is not None else None
+    except Exception as e:
+        logger.error(f"check_and_adjust_pool: Redis GET 실패 — skip: {e}")
+        return
+
+    if current_pool == new_pool:
+        logger.debug(f"check_and_adjust_pool: 변화 없음 (pool={new_pool}) — skip")
+        return
+
+    logger.info(f"in-booking 풀 조정: desired={desired}, ready={ready}, {current_pool} -> {new_pool}")
+    try:
+        update_in_booking_pool_size(new_pool)
+    except Exception as e:
+        logger.error(f"check_and_adjust_pool: Redis SET+PUBLISH 실패: {e}")
+
+
 def fetch_upcoming_reservation_opens() -> list[float]:
     """
     MySQL Event 테이블에서 현재 UTC 시각부터 PRE_SCALE_UP_WINDOW 초 이내에
@@ -387,6 +446,11 @@ if __name__ == "__main__":
             check_traffic_preemptive()
         except Exception as e:
             logger.error(f"폴링 루프 오류 (check_traffic_preemptive): {e}")
+
+        try:
+            check_and_adjust_pool()
+        except Exception as e:
+            logger.error(f"폴링 루프 오류 (check_and_adjust_pool): {e}")
 
         try:
             active_sessions = get_active_session_count()

--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -145,6 +145,85 @@ def get_active_session_count() -> int | None:
         return None
 
 
+def check_traffic_preemptive():
+    """축 1: HTTP RPS 증가율 기반 선행 감지 스케일업.
+
+    suppress_traffic_until 활성 중이면 즉시 반환.
+    PromQL 2종 중 하나라도 임계값 초과 시 consecutive_traffic_alerts += 1.
+    TRAFFIC_CONSECUTIVE 회 연속 초과 시 current + SCALE_UP_STEP으로 스케일업.
+    """
+    global suppress_traffic_until, consecutive_traffic_alerts
+
+    now = time.time()
+    if now < suppress_traffic_until:
+        logger.debug(
+            f"트래픽 suppress 활성 중 ({suppress_traffic_until - now:.0f}s 남음) — 트래픽 체크 skip"
+        )
+        return
+
+    window = TRAFFIC_WINDOW
+
+    q_total_now        = f'sum(rate(http_requests_total[{window}]))'
+    q_server_time_now  = f'sum(rate(http_requests_total{{path="/booking/server-time"}}[{window}]))'
+    q_total_base       = f'sum(rate(http_requests_total[5m]))'
+    q_server_time_base = f'sum(rate(http_requests_total{{path="/booking/server-time"}}[5m]))'
+
+    def query_scalar(q: str) -> float | None:
+        try:
+            result = prom.custom_query(query=q)
+            if not result:
+                return None
+            val = float(result[0]["value"][1])
+            return None if math.isnan(val) else val
+        except Exception as e:
+            logger.error(f"트래픽 PromQL 쿼리 실패 ({q[:60]}...): {e}")
+            return None
+
+    total_now  = query_scalar(q_total_now)
+    total_base = query_scalar(q_total_base)
+    st_now     = query_scalar(q_server_time_now)
+    st_base    = query_scalar(q_server_time_base)
+
+    def exceeds(cur: float | None, base: float | None, mult: float, min_rps: float) -> bool:
+        if cur is None or base is None or cur < min_rps:
+            return False
+        return cur >= min_rps if base < 0.1 else cur >= base * mult
+
+    triggered = (
+        exceeds(total_now, total_base, TRAFFIC_TOTAL_RATE_MULTIPLIER, TRAFFIC_TOTAL_MIN_RPS) or
+        exceeds(st_now, st_base, TRAFFIC_SERVER_TIME_RATE_MULTIPLIER, TRAFFIC_SERVER_TIME_MIN_RPS)
+    )
+
+    if triggered:
+        consecutive_traffic_alerts += 1
+        logger.info(
+            f"트래픽 선행 감지: consecutive={consecutive_traffic_alerts}/{TRAFFIC_CONSECUTIVE}, "
+            f"total_rps={total_now:.2f}(base={total_base:.2f}), "
+            f"server_time_rps={st_now:.2f}(base={st_base:.2f})"
+        )
+        if consecutive_traffic_alerts >= TRAFFIC_CONSECUTIVE:
+            consecutive_traffic_alerts = 0
+            try:
+                service = docker_client.services.get(TARGET_SERVICE)
+                service.reload()
+                current = get_current_replicas(service)
+                target = min(current + SCALE_UP_STEP, MAX_REPLICAS)
+                new_suppress = now + TRAFFIC_SUPPRESS
+                if target > current:
+                    scale_service(target, current, "up")
+                    suppress_traffic_until = max(suppress_traffic_until, new_suppress)
+                    logger.info(f"트래픽 기반 스케일업: {current} -> {target}, suppress {TRAFFIC_SUPPRESS}s")
+                else:
+                    logger.info(f"트래픽 기반 스케일업 skip (이미 MAX={MAX_REPLICAS})")
+                    suppress_traffic_until = max(suppress_traffic_until, new_suppress)
+            except Exception as e:
+                logger.error(f"트래픽 기반 스케일업 실패: {e}")
+    else:
+        if consecutive_traffic_alerts > 0:
+            logger.debug(f"트래픽 선행 감지 미달 — 카운터 리셋 (was {consecutive_traffic_alerts})")
+        consecutive_traffic_alerts = 0
+
+
 def get_current_replicas(service) -> int:
     """현재 레플리카 수 반환."""
     return service.attrs["Spec"]["Mode"]["Replicated"]["Replicas"]
@@ -272,9 +351,12 @@ def check_and_scale():
             scale_service(target, current, "up")
 
     elif cpu <= SCALE_DOWN_THRESHOLD:
-        if now < suppress_scaledown_until:
+        if now < suppress_scaledown_until or now < suppress_traffic_until:
+            active = max(suppress_scaledown_until, suppress_traffic_until)
             logger.info(
-                f"스케일다운 억제 중 (suppress까지 {suppress_scaledown_until - now:.0f}s 남음)"
+                f"스케일다운 억제 중 (suppress까지 {active - now:.0f}s 남음, "
+                f"scaledown={suppress_scaledown_until - now:.0f}s, "
+                f"traffic={suppress_traffic_until - now:.0f}s)"
             )
             return
         if now - last_scale_up < COOLDOWN_DOWN_AFTER_UP:
@@ -300,6 +382,11 @@ if __name__ == "__main__":
             check_and_scale()
         except Exception as e:
             logger.error(f"폴링 루프 오류 (check_and_scale): {e}")
+
+        try:
+            check_traffic_preemptive()
+        except Exception as e:
+            logger.error(f"폴링 루프 오류 (check_traffic_preemptive): {e}")
 
         try:
             active_sessions = get_active_session_count()

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -26,7 +26,8 @@ scrape_configs:
         type: 'A'
         port: 9100
 
-  - job_name: 'nest'
+  - job_name: 'nest-app'
+    scrape_interval: 3s
     dns_sd_configs:
       - names:
           - 'tasks.nest'


### PR DESCRIPTION
## 📌 이슈 번호
- close #386

## 🚀 구현 내용

반응형 오토스케일링의 콜드스타트 지연 문제를 해결하기 위해 선행 트래픽을 지표로 사용하는 동적 사전 스케일업 로직을 3축으로 구현

**인프라 설정**
- `prometheus.yml` nest scrape job을 `nest-app`으로 rename, `scrape_interval: 3s` 적용
- `autoscaler/main.py` `POLL_INTERVAL` 기본값 30s → 5s, 환경변수 10개 신설

**축 1 — HTTP RPS 선행 감지 스케일업** (`check_traffic_preemptive`)
- 전체 HTTP RPS가 직전 30s 대비 3배 이상 & 절댓값 6 req/s 이상, 또는 서버시간 조회 RPS가 2배 이상 & 절댓값 3 req/s 이상 조건을 연속 2회 감지하면 스케일업 실행
- CPU 스파이크보다 앞서 트래픽 증가를 감지해 콜드스타트 구간을 줄임
- 스케일업 후 120s 동안 `suppress_traffic_until`로 추가 스케일다운 억제

**축 2 — ready 레플리카 수 기반 in-booking 풀 동적 조정** (`check_and_adjust_pool`)
- `count(up{job="nest-app"}==1)` PromQL로 실제 헬스체크를 통과한 레플리카 수 조회
- `min(docker desired, ready) × POOL_PER_REPLICA(100)`로 in-booking 풀 사이즈를 매 폴링 주기 조정
- 스케일업 직후 준비되지 않은 레플리카로 과잉 트래픽이 유입되는 것을 방지
- `ready=0`, PromQL 실패 등 예외 상황에서는 기존 Redis 값 유지 (skip)

**축 3 — 로그인 세션 비율 기반 단계화 사전 스케일업** (`check_upcoming_reservations` 개조)
- 예매 오픈 10분 전, 현재 로그인 세션 수 / 기준값(현재 100, 인스턴스 성능에 따라 `IN_BOOKING_DEFAULT_MAX_SIZE`로 조정) 비율로 tier 결정
  - ratio < 0.15 → SKIP (스케일업 없음)
  - 0.15~0.40 → LOW (MAX × 0.5)
  - 0.40~0.80 → MID (MAX × 0.75)
  - 0.80 이상 → HIGH (MAX)
- 수요가 낮을 때 불필요한 풀 확장을 방지해 자원 낭비를 줄임
- SKIP tier 시 `suppress_scaledown_until` 갱신 없음

## 📘 참고 사항
- Prometheus `job_name` 변경(`nest` → `nest-app`)으로 기존 Grafana 대시보드의 `job="nest"` 쿼리 수정이 필요할 수 있음
- `sessions:active` ZSET은 이전 Redis 리팩토링 작업에서 이미 구현됨