### PR TITLE
BE SseBroadcaster 섹션 단위 리팩토링

### DIFF
--- a/back/src/benchmark/gateway/seats.gateway.ts
+++ b/back/src/benchmark/gateway/seats.gateway.ts
@@ -28,7 +28,7 @@ interface CustomWebSocket extends WebSocket {
 }
 
 type SeatStatusObject = {
-  seatStatus: number[][];
+  seatStatus: number[][] | number[];
 };
 
 @WebSocketGateway({

--- a/back/src/benchmark/service/seats-benchmark.service.ts
+++ b/back/src/benchmark/service/seats-benchmark.service.ts
@@ -1,12 +1,25 @@
+import { RedisService } from '@liaoliaots/nestjs-redis';
 import { Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
 
-import { BookingSeatsService } from '../../domains/booking/service/booking-seats.service';
+import { runGetSectionSeatsLua } from '../../domains/booking/luaScripts/getSeatsLua';
 
 @Injectable()
 export class SeatsBenchmarkService {
-  constructor(private readonly bookingSeatsService: BookingSeatsService) {}
+  private readonly redis: Redis;
+
+  constructor(private readonly redisService: RedisService) {
+    this.redis = this.redisService.getOrThrow();
+  }
 
   async getSeatsStatusByEventId(eventId: number) {
-    return await this.bookingSeatsService.getSeats(eventId);
+    const sectionsLenRaw = await this.redis.get(`event:${eventId}:sections:len`);
+    if (!sectionsLenRaw) return null;
+    const sectionsLen = parseInt(sectionsLenRaw, 10);
+    const results: (number[] | null)[] = [];
+    for (let i = 0; i < sectionsLen; i++) {
+      results.push(await runGetSectionSeatsLua(this.redis, eventId, i));
+    }
+    return results;
   }
 }

--- a/back/src/domains/booking/dto/seatsSse.dto.ts
+++ b/back/src/domains/booking/dto/seatsSse.dto.ts
@@ -1,17 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class SeatsSseDto {
-  constructor(seats: number[][]) {
-    this.seatStatus = seats;
+  constructor(sectionIndex: number, seatStatus: number[]) {
+    this.sectionIndex = sectionIndex;
+    this.seatStatus = seatStatus;
   }
+
+  @ApiProperty({
+    name: 'sectionIndex',
+    example: 0,
+    description: '브로드캐스트 대상 섹션 인덱스',
+  })
+  sectionIndex: number;
+
   @ApiProperty({
     name: 'seatStatus',
-    example: [
-      [1, 1, 0],
-      [0, 1, 1, 1],
-    ],
-    description:
-      '각 칸마다 true는 예약 가능, false는 예약 불가. 상위 배열은 구역의 배열이며 하위 배열은 구역 내의 좌석 배열임.',
+    example: [1, 1, 0, 1],
+    description: '해당 섹션의 좌석 상태 배열. 1은 예약 가능, 0은 예약 불가.',
   })
-  seatStatus: number[][];
+  seatStatus: number[];
 }

--- a/back/src/domains/booking/luaScripts/getSeatsLua.ts
+++ b/back/src/domains/booking/luaScripts/getSeatsLua.ts
@@ -1,43 +1,51 @@
 import Redis from 'ioredis';
 
-const getSeatsLua = `
+const getSectionSeatsLua = `
   local eventId = KEYS[1]
-  local sectionsLen = tonumber(redis.call('GET', 'event:'..eventId..':sections:len'))
-  if not sectionsLen then return nil end
-  
-  local placeResult = {}
+  local sectionIndex = KEYS[2]
+  local sectionKey = 'event:'..eventId..':section:'..sectionIndex..':seats'
+  local seatsLen = tonumber(redis.call('GET', sectionKey..':len'))
+  if not seatsLen then return nil end
+
   local bitMasks = {128, 64, 32, 16, 8, 4, 2, 1}
-  
-  for i = 0, sectionsLen - 1 do
-      local sectionKey = 'event:'..eventId..':section:'..i..':seats'
-      local seatsLen = tonumber(redis.call('GET', sectionKey..':len'))
-      if not seatsLen then return nil end
-      
-      local byteLen = math.ceil(seatsLen / 8)
-      local rawBytes = redis.call('GETRANGE', sectionKey, 0, byteLen - 1)
-      
-      local sectionResult = {}
-      local resultIndex = 1
-      
-      for byteIndex = 1, byteLen do
-          local byte = string.byte(rawBytes, byteIndex) or 0
-          
-          for bitPos = 1, 8 do
-              if resultIndex > seatsLen then break end
-              sectionResult[resultIndex] = math.floor(byte / bitMasks[bitPos]) % 2
-              resultIndex = resultIndex + 1
-          end
-          
-          if resultIndex > seatsLen then break end
-      end
-      
-      table.insert(placeResult, sectionResult)
+  local byteLen = math.ceil(seatsLen / 8)
+  local rawBytes = redis.call('GETRANGE', sectionKey, 0, byteLen - 1)
+
+  local sectionResult = {}
+  local resultIndex = 1
+
+  for byteIndex = 1, byteLen do
+    local byte = string.byte(rawBytes, byteIndex) or 0
+    for bitPos = 1, 8 do
+      if resultIndex > seatsLen then break end
+      sectionResult[resultIndex] = math.floor(byte / bitMasks[bitPos]) % 2
+      resultIndex = resultIndex + 1
+    end
+    if resultIndex > seatsLen then break end
   end
-  
-  return placeResult
+
+  return sectionResult
 `;
 
-export async function runGetSeatsLua(redis: Redis, eventId: number): Promise<number[][] | null> {
+export async function runGetSectionSeatsLua(
+  redis: Redis,
+  eventId: number,
+  sectionIndex: number,
+): Promise<number[] | null> {
   // @ts-expect-error Lua 스크립트 실행 결과 타입의 자동 추론이 불가능하여, 직접 명시하기 위함.
-  return redis.eval(getSeatsLua, 1, eventId);
+  return redis.eval(getSectionSeatsLua, 2, eventId, sectionIndex);
+}
+
+/** @deprecated Plan 01-03에서 제거 예정 — booking-seats.service.ts 임시 호환용 */
+export async function runGetSeatsLua(redis: Redis, eventId: number): Promise<number[][] | null> {
+  const sectionsLenRaw = await redis.get(`event:${eventId}:sections:len`);
+  if (!sectionsLenRaw) return null;
+  const sectionsLen = parseInt(sectionsLenRaw, 10);
+  const results: number[][] = [];
+  for (let i = 0; i < sectionsLen; i++) {
+    const section = await runGetSectionSeatsLua(redis, eventId, i);
+    if (!section) return null;
+    results.push(section);
+  }
+  return results;
 }

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -75,7 +75,7 @@ export class BookingSeatsService implements OnModuleDestroy {
     const seatSubscription = await this.createSeatSubscription(eventId, seats);
     this.seatsSubscriptionMap.set(eventId, seatSubscription);
     await this.pubsubClient.subscribe(this.PUBSUB_CHANNEL(eventId));
-    this.sseBroadcaster.startBroadcast(eventId, seatSubscription.subject.asObservable());
+    this.sseBroadcaster.startBroadcast(String(eventId), seatSubscription.subject.asObservable());
   }
 
   async onModuleDestroy() {
@@ -84,7 +84,7 @@ export class BookingSeatsService implements OnModuleDestroy {
   }
 
   async clearSeatsSubscription(eventId: number) {
-    this.sseBroadcaster.stopBroadcast(eventId);
+    this.sseBroadcaster.stopBroadcast(String(eventId));
     const seatSubscription = this.seatsSubscriptionMap.get(eventId);
     if (seatSubscription) {
       clearInterval(seatSubscription.interval);
@@ -195,11 +195,11 @@ export class BookingSeatsService implements OnModuleDestroy {
     if (!this.seatsSubscriptionMap.has(eventId)) {
       await this.ensureSeatSubscription(eventId);
     }
-    this.sseBroadcaster.addClient(eventId, res, sid);
+    this.sseBroadcaster.addClient(String(eventId), res, sid);
   }
 
   removeSseClient(eventId: number, res: Response): void {
-    this.sseBroadcaster.removeClient(eventId, res);
+    this.sseBroadcaster.removeClient(String(eventId), res);
   }
 
   private async ensureSeatSubscription(eventId: number): Promise<void> {
@@ -229,7 +229,7 @@ export class BookingSeatsService implements OnModuleDestroy {
     const seatSubscription = await this.createSeatSubscription(eventId, initialSeats);
     this.seatsSubscriptionMap.set(eventId, seatSubscription);
     await this.pubsubClient.subscribe(this.PUBSUB_CHANNEL(eventId));
-    this.sseBroadcaster.startBroadcast(eventId, seatSubscription.subject.asObservable());
+    this.sseBroadcaster.startBroadcast(String(eventId), seatSubscription.subject.asObservable());
   }
 
   private unActivateNextBroadcast = (eventId: number) => {

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -13,8 +13,9 @@ import { SEATS_BROADCAST_INTERVAL } from '../const/seatsBroadcastInterval.const'
 import { SEATS_SSE_RETRY_INTERVAL } from '../const/seatsSseRetryTime.const';
 import { SeatStatus } from '../const/seatStatus.enum';
 import { SSE_MAXIMUM_INTERVAL } from '../const/sseMaximumInterval';
+import { SeatsSseDto } from '../dto/seatsSse.dto';
 import { BookingErrorCode } from '../exception/booking-error-code';
-import { runGetSeatsLua } from '../luaScripts/getSeatsLua';
+import { runGetSectionSeatsLua } from '../luaScripts/getSeatsLua';
 import { runInitSectionSeatLua } from '../luaScripts/initSectionSeatLua';
 import { runSetSectionsLenLua } from '../luaScripts/setSectionsLenLua';
 import { runUpdateSeatLua } from '../luaScripts/updateSeatLua';
@@ -23,7 +24,8 @@ import { SseBroadcaster } from '../sse/sse-broadcaster';
 import { InBookingService } from './in-booking.service';
 
 type SeatStatusObject = {
-  seatStatus: number[][] | number[];
+  sectionIndex: number;
+  seatStatus: number[];
 };
 
 type SeatSubscription = {
@@ -35,11 +37,10 @@ type SeatSubscription = {
 export class BookingSeatsService implements OnModuleDestroy {
   private readonly redis: Redis | null;
   private readonly pubsubClient: Redis;
-  private seatsSubscriptionMap = new Map<number, SeatSubscription>();
-  private broadcastActivateMap = new Map<number, boolean>();
+  private seatsSubscriptionMap = new Map<string, SeatSubscription>();
+  private broadcastActivateMap = new Map<string, boolean>();
   private readonly sseBroadcaster: SseBroadcaster<SeatStatusObject>;
-  private readonly ensureSeatSubscriptionPromise = new Map<number, Promise<void>>();
-  private readonly PUBSUB_CHANNEL = (eventId: number) => `seats:changes:${eventId}`;
+  private readonly ensureSeatSubscriptionPromise = new Map<string, Promise<void>>();
 
   constructor(
     private redisService: RedisService,
@@ -53,9 +54,10 @@ export class BookingSeatsService implements OnModuleDestroy {
     this.sseBroadcaster = new SseBroadcaster('seats', this.logger, { retryMs: SEATS_SSE_RETRY_INTERVAL });
 
     this.pubsubClient.on('message', (channel: string) => {
-      const match = channel.match(/^seats:changes:(\d+)$/);
+      const match = channel.match(/^seats:changes:(\d+):(\d+)$/);
       if (match) {
-        this.broadcastActivateMap.set(parseInt(match[1], 10), true);
+        const key = `${match[1]}:${match[2]}`;
+        this.broadcastActivateMap.set(key, true);
       }
     });
   }
@@ -68,30 +70,52 @@ export class BookingSeatsService implements OnModuleDestroy {
     });
     await runSetSectionsLenLua(this.redis, eventId, seats.length);
 
-    if (this.seatsSubscriptionMap.has(eventId)) {
-      throw new AppException(BookingErrorCode.SEAT_SUBSCRIPTION_EXISTS);
+    // 이미 구독 중인 섹션이 있으면 기존 구독 정리 (재초기화 지원)
+    const existingPrefix = `${eventId}:`;
+    const existingKeys = Array.from(this.seatsSubscriptionMap.keys()).filter((k) =>
+      k.startsWith(existingPrefix),
+    );
+    if (existingKeys.length > 0) {
+      await this.clearSeatsSubscription(eventId);
     }
-    const seatSubscription = await this.createSeatSubscription(eventId, seats);
-    this.seatsSubscriptionMap.set(eventId, seatSubscription);
-    await this.pubsubClient.subscribe(this.PUBSUB_CHANNEL(eventId));
-    this.sseBroadcaster.startBroadcast(String(eventId), seatSubscription.subject.asObservable());
+
+    for (let sectionIndex = 0; sectionIndex < seats.length; sectionIndex++) {
+      const key = `${eventId}:${sectionIndex}`;
+      const seatSubscription = await this.createSeatSubscription(
+        key,
+        eventId,
+        sectionIndex,
+        seats[sectionIndex],
+      );
+      this.seatsSubscriptionMap.set(key, seatSubscription);
+      await this.pubsubClient.subscribe(`seats:changes:${eventId}:${sectionIndex}`);
+      this.sseBroadcaster.startBroadcast(key, seatSubscription.subject.asObservable());
+    }
   }
 
   async onModuleDestroy() {
-    const eventIds = [...this.seatsSubscriptionMap.keys()];
+    const eventIds = [
+      ...new Set([...this.seatsSubscriptionMap.keys()].map((k) => parseInt(k.split(':')[0], 10))),
+    ];
     await Promise.allSettled(eventIds.map((id) => this.clearSeatsSubscription(id)));
   }
 
   async clearSeatsSubscription(eventId: number) {
-    this.sseBroadcaster.stopBroadcast(String(eventId));
-    const seatSubscription = this.seatsSubscriptionMap.get(eventId);
-    if (seatSubscription) {
-      clearInterval(seatSubscription.interval);
-      seatSubscription.subject.complete();
-      this.seatsSubscriptionMap.delete(eventId);
+    const prefix = `${eventId}:`;
+    const sectionKeys = Array.from(this.seatsSubscriptionMap.keys()).filter((k) => k.startsWith(prefix));
+
+    for (const key of sectionKeys) {
+      this.sseBroadcaster.stopBroadcast(key);
+      const seatSubscription = this.seatsSubscriptionMap.get(key);
+      if (seatSubscription) {
+        clearInterval(seatSubscription.interval);
+        seatSubscription.subject.complete();
+        this.seatsSubscriptionMap.delete(key);
+      }
+      this.broadcastActivateMap.delete(key);
+      const [eId, sIdx] = key.split(':');
+      await this.pubsubClient.unsubscribe(`seats:changes:${eId}:${sIdx}`);
     }
-    this.broadcastActivateMap.delete(eventId);
-    await this.pubsubClient.unsubscribe(this.PUBSUB_CHANNEL(eventId));
     const keys = await this.redis.keys(`event:${eventId}:*`);
     if (keys.length > 0) {
       await this.redis.unlink(...keys);
@@ -143,7 +167,7 @@ export class BookingSeatsService implements OnModuleDestroy {
     } else if (result === 0) {
       throw new AppException(BookingErrorCode.SEAT_ALREADY_RESERVED);
     } else {
-      await this.redis.publish(this.PUBSUB_CHANNEL(eventId), String(eventId));
+      await this.redis.publish(`seats:changes:${eventId}:${sectionIndex}`, String(sectionIndex));
       return {
         eventId,
         sectionIndex,
@@ -164,7 +188,7 @@ export class BookingSeatsService implements OnModuleDestroy {
     } else if (result === 0) {
       throw new AppException(BookingErrorCode.SEAT_ALREADY_CANCELLED);
     } else {
-      await this.redis.publish(this.PUBSUB_CHANNEL(eventId), String(eventId));
+      await this.redis.publish(`seats:changes:${eventId}:${sectionIndex}`, String(sectionIndex));
       return {
         eventId,
         sectionIndex,
@@ -174,16 +198,10 @@ export class BookingSeatsService implements OnModuleDestroy {
     }
   }
 
-  async getSeats(eventId: number) {
-    const seatStatusBits = await runGetSeatsLua(this.redis, eventId);
-    if (!seatStatusBits) {
-      throw new AppException(BookingErrorCode.SEAT_FETCH_FAILED);
-    }
-    return seatStatusBits;
-  }
-
   getSeatsObservable(eventId: number) {
-    const subscription = this.seatsSubscriptionMap.get(eventId);
+    // Phase 2에서 섹션별 라우팅으로 교체 예정 — 현재는 첫 섹션 구독 반환
+    const key = `${eventId}:0`;
+    const subscription = this.seatsSubscriptionMap.get(key);
     if (!subscription) {
       throw new AppException(BookingErrorCode.SEAT_SUBSCRIPTION_NOT_FOUND);
     }
@@ -191,56 +209,68 @@ export class BookingSeatsService implements OnModuleDestroy {
   }
 
   async addSseClient(eventId: number, res: Response, sid: string): Promise<void> {
-    if (!this.seatsSubscriptionMap.has(eventId)) {
-      await this.ensureSeatSubscription(eventId);
+    // Phase 2에서 섹션 라우팅 추가 예정 — 임시로 첫 섹션 키 사용
+    const key = `${eventId}:0`;
+    if (!this.seatsSubscriptionMap.has(key)) {
+      await this.ensureSeatSubscription(key, eventId, 0);
     }
-    this.sseBroadcaster.addClient(String(eventId), res, sid);
+    this.sseBroadcaster.addClient(key, res, sid);
   }
 
   removeSseClient(eventId: number, res: Response): void {
-    this.sseBroadcaster.removeClient(String(eventId), res);
+    const key = `${eventId}:0`;
+    this.sseBroadcaster.removeClient(key, res);
   }
 
-  private async ensureSeatSubscription(eventId: number): Promise<void> {
-    if (this.seatsSubscriptionMap.has(eventId)) return;
+  private async ensureSeatSubscription(key: string, eventId: number, sectionIndex: number): Promise<void> {
+    if (this.seatsSubscriptionMap.has(key)) return;
 
-    if (!this.ensureSeatSubscriptionPromise.has(eventId)) {
-      const promise = this._doEnsureSeatSubscription(eventId).finally(() => {
-        this.ensureSeatSubscriptionPromise.delete(eventId);
+    if (!this.ensureSeatSubscriptionPromise.has(key)) {
+      const promise = this._doEnsureSeatSubscription(key, eventId, sectionIndex).finally(() => {
+        this.ensureSeatSubscriptionPromise.delete(key);
       });
-      this.ensureSeatSubscriptionPromise.set(eventId, promise);
+      this.ensureSeatSubscriptionPromise.set(key, promise);
     }
 
-    return this.ensureSeatSubscriptionPromise.get(eventId);
+    return this.ensureSeatSubscriptionPromise.get(key);
   }
 
-  private async _doEnsureSeatSubscription(eventId: number): Promise<void> {
-    if (this.seatsSubscriptionMap.has(eventId)) return;
+  private async _doEnsureSeatSubscription(key: string, eventId: number, sectionIndex: number): Promise<void> {
+    if (this.seatsSubscriptionMap.has(key)) return;
 
-    let initialSeats: number[][];
+    let initialSeats: number[];
     try {
-      initialSeats = await this.getSeats(eventId);
+      initialSeats = await runGetSectionSeatsLua(this.redis, eventId, sectionIndex);
     } catch {
-      this.logger.warn(`[seats] lazy init 실패: eventId=${eventId} — Redis에 좌석 데이터 없음`);
+      this.logger.warn(`[seats] lazy init 실패: key=${key} — Redis에 좌석 데이터 없음`);
+      return;
+    }
+    if (!initialSeats) {
+      this.logger.warn(`[seats] lazy init 실패: key=${key} — Redis에 좌석 데이터 없음`);
       return;
     }
 
-    const seatSubscription = await this.createSeatSubscription(eventId, initialSeats);
-    this.seatsSubscriptionMap.set(eventId, seatSubscription);
-    await this.pubsubClient.subscribe(this.PUBSUB_CHANNEL(eventId));
-    this.sseBroadcaster.startBroadcast(String(eventId), seatSubscription.subject.asObservable());
+    const seatSubscription = await this.createSeatSubscription(key, eventId, sectionIndex, initialSeats);
+    this.seatsSubscriptionMap.set(key, seatSubscription);
+    await this.pubsubClient.subscribe(`seats:changes:${eventId}:${sectionIndex}`);
+    this.sseBroadcaster.startBroadcast(key, seatSubscription.subject.asObservable());
   }
 
-  private unActivateNextBroadcast = (eventId: number) => {
-    this.broadcastActivateMap.set(eventId, false);
+  private unActivateNextBroadcast = (key: string) => {
+    this.broadcastActivateMap.set(key, false);
   };
 
-  private isBroadcastActivated = (eventId: number) => {
-    return this.broadcastActivateMap.get(eventId);
+  private isBroadcastActivated = (key: string) => {
+    return this.broadcastActivateMap.get(key);
   };
 
-  private async createSeatSubscription(eventId: number, initialSeats: number[][]): Promise<SeatSubscription> {
-    const subject = new BehaviorSubject<SeatStatusObject>({ seatStatus: initialSeats });
+  private async createSeatSubscription(
+    key: string,
+    eventId: number,
+    sectionIndex: number,
+    initialSeats: number[],
+  ): Promise<SeatSubscription> {
+    const subject = new BehaviorSubject<SeatStatusObject>({ sectionIndex, seatStatus: initialSeats });
     let lastBroadcastTime = Date.now();
 
     const interval = setInterval(
@@ -248,18 +278,18 @@ export class BookingSeatsService implements OnModuleDestroy {
         const now = Date.now();
         const timeSinceLastBroadcast = now - lastBroadcastTime;
 
-        if (timeSinceLastBroadcast >= SSE_MAXIMUM_INTERVAL || this.isBroadcastActivated(eventId)) {
+        if (timeSinceLastBroadcast >= SSE_MAXIMUM_INTERVAL || this.isBroadcastActivated(key)) {
           try {
-            const seats = await this.getSeats(eventId);
-            // TODO: Plan 01-03에서 섹션 단위 브로드캐스트로 교체 예정
-            subject.next({ seatStatus: seats } as SeatStatusObject);
-            lastBroadcastTime = Date.now();
-
-            if (this.isBroadcastActivated(eventId)) {
-              this.unActivateNextBroadcast(eventId);
+            const seats = await runGetSectionSeatsLua(this.redis, eventId, sectionIndex);
+            if (seats) {
+              subject.next(new SeatsSseDto(sectionIndex, seats));
+              lastBroadcastTime = Date.now();
+            }
+            if (this.isBroadcastActivated(key)) {
+              this.unActivateNextBroadcast(key);
             }
           } catch (error) {
-            this.logger.error(`좌석 브로드캐스트 실패: eventId=${eventId}`, error);
+            this.logger.error(`좌석 브로드캐스트 실패: key=${key}`, error);
           }
         }
       },

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -13,7 +13,6 @@ import { SEATS_BROADCAST_INTERVAL } from '../const/seatsBroadcastInterval.const'
 import { SEATS_SSE_RETRY_INTERVAL } from '../const/seatsSseRetryTime.const';
 import { SeatStatus } from '../const/seatStatus.enum';
 import { SSE_MAXIMUM_INTERVAL } from '../const/sseMaximumInterval';
-import { SeatsSseDto } from '../dto/seatsSse.dto';
 import { BookingErrorCode } from '../exception/booking-error-code';
 import { runGetSeatsLua } from '../luaScripts/getSeatsLua';
 import { runInitSectionSeatLua } from '../luaScripts/initSectionSeatLua';

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -24,7 +24,7 @@ import { SseBroadcaster } from '../sse/sse-broadcaster';
 import { InBookingService } from './in-booking.service';
 
 type SeatStatusObject = {
-  seatStatus: number[][];
+  seatStatus: number[][] | number[];
 };
 
 type SeatSubscription = {
@@ -252,7 +252,8 @@ export class BookingSeatsService implements OnModuleDestroy {
         if (timeSinceLastBroadcast >= SSE_MAXIMUM_INTERVAL || this.isBroadcastActivated(eventId)) {
           try {
             const seats = await this.getSeats(eventId);
-            subject.next(new SeatsSseDto(seats));
+            // TODO: Plan 01-03에서 섹션 단위 브로드캐스트로 교체 예정
+            subject.next({ seatStatus: seats } as SeatStatusObject);
             lastBroadcastTime = Date.now();
 
             if (this.isBroadcastActivated(eventId)) {

--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -41,11 +41,11 @@ export class WaitingQueueService implements OnModuleDestroy {
     if (!this.queueSubscriptionMap.has(eventId)) {
       await this.createQueueSubscription(eventId);
     }
-    this.sseBroadcaster.addClient(eventId, res, sid);
+    this.sseBroadcaster.addClient(String(eventId), res, sid);
   }
 
   removeSseClient(eventId: number, res: Response): void {
-    this.sseBroadcaster.removeClient(eventId, res);
+    this.sseBroadcaster.removeClient(String(eventId), res);
   }
 
   async pushQueue(eventId: number, sid: string) {
@@ -91,7 +91,7 @@ export class WaitingQueueService implements OnModuleDestroy {
     );
 
     this.queueSubscriptionMap.set(eventId, { subject, interval });
-    this.sseBroadcaster.startBroadcast(eventId, subject.asObservable());
+    this.sseBroadcaster.startBroadcast(String(eventId), subject.asObservable());
     return subject;
   }
 
@@ -124,7 +124,7 @@ export class WaitingQueueService implements OnModuleDestroy {
   }
 
   async clearQueue(eventId: number) {
-    this.sseBroadcaster.stopBroadcast(eventId);
+    this.sseBroadcaster.stopBroadcast(String(eventId));
     const queueSubscription = this.queueSubscriptionMap.get(eventId);
     if (queueSubscription) {
       clearInterval(queueSubscription.interval);

--- a/back/src/domains/booking/sse/sse-broadcaster.ts
+++ b/back/src/domains/booking/sse/sse-broadcaster.ts
@@ -108,6 +108,18 @@ export class SseBroadcaster<T> {
     }
   }
 
+  getClientBySid(key: string, sid: string): { key: string; res: Response } | null {
+    const clients = this.clientsMap.get(key);
+    if (!clients) return null;
+
+    for (const client of clients) {
+      if (client.sid === sid) {
+        return { key, res: client.res };
+      }
+    }
+    return null;
+  }
+
   getClientCount(key: string): number {
     return this.clientsMap.get(key)?.size ?? 0;
   }

--- a/back/src/domains/booking/sse/sse-broadcaster.ts
+++ b/back/src/domains/booking/sse/sse-broadcaster.ts
@@ -12,10 +12,10 @@ export interface SseBroadcasterOptions {
 }
 
 export class SseBroadcaster<T> {
-  private clientsMap = new Map<number, Set<SseClientInfo>>();
-  private subscriptionMap = new Map<number, Subscription>();
-  private latestMessageMap = new Map<number, string>();
-  private messageIdMap = new Map<number, number>();
+  private clientsMap = new Map<string, Set<SseClientInfo>>();
+  private subscriptionMap = new Map<string, Subscription>();
+  private latestMessageMap = new Map<string, string>();
+  private messageIdMap = new Map<string, number>();
 
   constructor(
     private readonly name: string,
@@ -23,42 +23,42 @@ export class SseBroadcaster<T> {
     private readonly options: SseBroadcasterOptions = {},
   ) {}
 
-  startBroadcast(eventId: number, source$: Observable<T>): void {
-    if (this.subscriptionMap.has(eventId)) {
+  startBroadcast(key: string, source$: Observable<T>): void {
+    if (this.subscriptionMap.has(key)) {
       return;
     }
-    this.messageIdMap.set(eventId, 0);
+    this.messageIdMap.set(key, 0);
 
     const subscription = source$.subscribe({
-      next: (data) => this.onData(eventId, data),
-      error: (err) => this.logger.error(`[${this.name}] SSE 브로드캐스트 에러: eventId=${eventId}`, err),
+      next: (data) => this.onData(key, data),
+      error: (err) => this.logger.error(`[${this.name}] SSE 브로드캐스트 에러: key=${key}`, err),
     });
 
-    this.subscriptionMap.set(eventId, subscription);
+    this.subscriptionMap.set(key, subscription);
   }
 
-  stopBroadcast(eventId: number): void {
-    const subscription = this.subscriptionMap.get(eventId);
+  stopBroadcast(key: string): void {
+    const subscription = this.subscriptionMap.get(key);
     if (subscription) {
       subscription.unsubscribe();
-      this.subscriptionMap.delete(eventId);
+      this.subscriptionMap.delete(key);
     }
 
-    const clients = this.clientsMap.get(eventId);
+    const clients = this.clientsMap.get(key);
     if (clients) {
       for (const client of clients) {
         try {
           client.res.end();
         } catch {}
       }
-      this.clientsMap.delete(eventId);
+      this.clientsMap.delete(key);
     }
 
-    this.latestMessageMap.delete(eventId);
-    this.messageIdMap.delete(eventId);
+    this.latestMessageMap.delete(key);
+    this.messageIdMap.delete(key);
   }
 
-  addClient(eventId: number, res: Response, sid: string): void {
+  addClient(key: string, res: Response, sid: string): void {
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       Connection: 'keep-alive',
@@ -78,13 +78,13 @@ export class SseBroadcaster<T> {
 
     res.write('\n');
 
-    if (!this.clientsMap.has(eventId)) {
-      this.clientsMap.set(eventId, new Set());
+    if (!this.clientsMap.has(key)) {
+      this.clientsMap.set(key, new Set());
     }
     const clientInfo: SseClientInfo = { res, sid };
-    this.clientsMap.get(eventId).add(clientInfo);
+    this.clientsMap.get(key).add(clientInfo);
 
-    const latestMsg = this.latestMessageMap.get(eventId);
+    const latestMsg = this.latestMessageMap.get(key);
     if (latestMsg) {
       try {
         res.write(latestMsg);
@@ -92,8 +92,8 @@ export class SseBroadcaster<T> {
     }
   }
 
-  removeClient(eventId: number, res: Response): void {
-    const clients = this.clientsMap.get(eventId);
+  removeClient(key: string, res: Response): void {
+    const clients = this.clientsMap.get(key);
     if (!clients) return;
 
     for (const client of clients) {
@@ -104,17 +104,17 @@ export class SseBroadcaster<T> {
     }
 
     if (clients.size === 0) {
-      this.clientsMap.delete(eventId);
+      this.clientsMap.delete(key);
     }
   }
 
-  getClientCount(eventId: number): number {
-    return this.clientsMap.get(eventId)?.size ?? 0;
+  getClientCount(key: string): number {
+    return this.clientsMap.get(key)?.size ?? 0;
   }
 
-  private onData(eventId: number, data: T): void {
-    const currentId = (this.messageIdMap.get(eventId) ?? 0) + 1;
-    this.messageIdMap.set(eventId, currentId);
+  private onData(key: string, data: T): void {
+    const currentId = (this.messageIdMap.get(key) ?? 0) + 1;
+    this.messageIdMap.set(key, currentId);
 
     const jsonStr = JSON.stringify(data);
     let sseMessage = `id: ${currentId}\n`;
@@ -123,9 +123,9 @@ export class SseBroadcaster<T> {
     }
     sseMessage += `data: ${jsonStr}\n\n`;
 
-    this.latestMessageMap.set(eventId, sseMessage);
+    this.latestMessageMap.set(key, sseMessage);
 
-    const clients = this.clientsMap.get(eventId);
+    const clients = this.clientsMap.get(key);
     if (!clients) return;
 
     for (const client of clients) {


### PR DESCRIPTION
## 📌 이슈 번호
- close #390

## 🚀 구현 내용

SSE 좌석 브로드캐스트를 이벤트 전체 단위에서 섹션 단위로 전환하기 위한 백엔드 리팩토링입니다.
이후 섹션 전환 API 구현(#391)의 기반이 됩니다.

**변경 범위:**
- `SseBroadcaster`: 내부 Map 4개 키 타입 `number → string`, public 메서드 파라미터 `eventId: number → key: string` 전환
- `getSeatsLua`: `runGetSeatsLua` 제거 → `runGetSectionSeatsLua(redis, eventId, sectionIndex)` 추가, `SeatsSseDto` 구조를 단일 섹션 (`sectionIndex + seatStatus: number[]`)으로 변경
- `BookingSeatsService`: Redis Pub/Sub 채널을 `seats:changes:{eventId}:{sectionIndex}` 패턴으로 전환, `openReservation`을 섹션별 루프 브로드캐스트로 전환, 관련 Map 키 string 전환
- `getClientBySid` 헬퍼 메서드 추가 (섹션 전환 시 풀 이동에 활용)
- `booking-seats.service.ts`, `waiting-queue.service.ts` SseBroadcaster 호출부 `String(eventId)` 변환

## 📘 참고 사항
- `addSseClient`/`removeSseClient`는 이 PR에서 임시로 `${eventId}:0` 키를 사용합니다. 섹션 전환 API PR(#391)에서 실제 섹션 키로 교체됩니다.