### PR TITLE
BE 서버 재시작 시 기예매 좌석 Redis 미반영 수정

### DIFF
--- a/back/src/domains/booking/booking.module.ts
+++ b/back/src/domains/booking/booking.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '../../auth/auth.module';
 import { EventModule } from '../event/event.module';
 import { PlaceModule } from '../place/place.module';
+import { ReservedSeat } from '../reservation/entity/reservedSeat.entity';
+import { ReservedSeatRepository } from '../reservation/repository/reservedSeat.repository';
 
 import { BookingController } from './controller/booking.controller';
 import { BookingSeatsService } from './service/booking-seats.service';
@@ -14,7 +17,13 @@ import { OpenBookingService } from './service/open-booking.service';
 import { WaitingQueueService } from './service/waiting-queue.service';
 
 @Module({
-  imports: [EventEmitterModule.forRoot(), EventModule, AuthModule, PlaceModule],
+  imports: [
+    EventEmitterModule.forRoot(),
+    TypeOrmModule.forFeature([ReservedSeat]),
+    EventModule,
+    AuthModule,
+    PlaceModule,
+  ],
   controllers: [BookingController],
   providers: [
     BookingService,
@@ -23,6 +32,7 @@ import { WaitingQueueService } from './service/waiting-queue.service';
     BookingSeatsService,
     WaitingQueueService,
     EnterBookingService,
+    ReservedSeatRepository,
   ],
   exports: [BookingService, InBookingService, BookingSeatsService],
 })

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -62,13 +62,21 @@ export class BookingSeatsService implements OnModuleDestroy {
     });
   }
 
-  async openReservation(eventId: number, seats: number[][]) {
-    seats.forEach((section, sectionIndex) => {
+  async openReservation(eventId: number, seats: number[][], reservedSeats: [number, number][] = []) {
+    const seatsCopy = seats.map((s) => [...s]);
+    for (const [secIdx, seatIdx] of reservedSeats) {
+      if (seatsCopy[secIdx] && seatIdx >= 0 && seatIdx < seatsCopy[secIdx].length) {
+        seatsCopy[secIdx][seatIdx] = 0;
+      }
+    }
+
+    for (let sectionIndex = 0; sectionIndex < seatsCopy.length; sectionIndex++) {
+      const section = seatsCopy[sectionIndex];
       const seatBitMap = section.map((seat) => seat.toString()).join('');
       const key = `event:${eventId}:section:${sectionIndex}:seats`;
-      runInitSectionSeatLua(this.redis, key, seatBitMap);
-    });
-    await runSetSectionsLenLua(this.redis, eventId, seats.length);
+      await runInitSectionSeatLua(this.redis, key, seatBitMap);
+    }
+    await runSetSectionsLenLua(this.redis, eventId, seatsCopy.length);
 
     // 이미 구독 중인 섹션이 있으면 기존 구독 정리 (재초기화 지원)
     const existingPrefix = `${eventId}:`;
@@ -79,14 +87,48 @@ export class BookingSeatsService implements OnModuleDestroy {
       await this.clearSeatsSubscription(eventId);
     }
 
-    for (let sectionIndex = 0; sectionIndex < seats.length; sectionIndex++) {
+    for (let sectionIndex = 0; sectionIndex < seatsCopy.length; sectionIndex++) {
       const key = `${eventId}:${sectionIndex}`;
       const seatSubscription = await this.createSeatSubscription(
         key,
         eventId,
         sectionIndex,
-        seats[sectionIndex],
+        seatsCopy[sectionIndex],
       );
+      this.seatsSubscriptionMap.set(key, seatSubscription);
+      await this.pubsubClient.subscribe(`seats:changes:${eventId}:${sectionIndex}`);
+      this.sseBroadcaster.startBroadcast(key, seatSubscription.subject.asObservable());
+    }
+  }
+
+  async attachSubscriptionsForExistingEvent(eventId: number, sectionsLen: number) {
+    const existingPrefix = `${eventId}:`;
+    const existingKeys = Array.from(this.seatsSubscriptionMap.keys()).filter((k) =>
+      k.startsWith(existingPrefix),
+    );
+    if (existingKeys.length > 0) {
+      return;
+    }
+
+    for (let sectionIndex = 0; sectionIndex < sectionsLen; sectionIndex++) {
+      let initialSeats: number[];
+      try {
+        initialSeats = await runGetSectionSeatsLua(this.redis, eventId, sectionIndex);
+      } catch (error) {
+        this.logger.warn(
+          `[seats] attach 실패: eventId=${eventId} section=${sectionIndex} — Lua 호출 오류: ${error?.message ?? error}`,
+        );
+        continue;
+      }
+      if (!initialSeats) {
+        this.logger.warn(
+          `[seats] attach 실패: eventId=${eventId} section=${sectionIndex} — Redis에 좌석 데이터 없음`,
+        );
+        continue;
+      }
+
+      const key = `${eventId}:${sectionIndex}`;
+      const seatSubscription = await this.createSeatSubscription(key, eventId, sectionIndex, initialSeats);
       this.seatsSubscriptionMap.set(key, seatSubscription);
       await this.pubsubClient.subscribe(`seats:changes:${eventId}:${sectionIndex}`);
       this.sseBroadcaster.startBroadcast(key, seatSubscription.subject.asObservable());
@@ -232,7 +274,9 @@ export class BookingSeatsService implements OnModuleDestroy {
     if (session && session.bookedSeats.length > 0) {
       const payload: SeatsSseDto = { sectionIndex: -1, seatStatus: [], occupiedSeats: session.bookedSeats };
       const msg = `data: ${JSON.stringify(payload)}\n\n`;
-      try { res.write(msg); } catch {}
+      try {
+        res.write(msg);
+      } catch {}
     }
   }
 
@@ -260,7 +304,9 @@ export class BookingSeatsService implements OnModuleDestroy {
     if (session) {
       const payload: SeatsSseDto = { sectionIndex: -1, seatStatus: [], occupiedSeats: session.bookedSeats };
       const msg = `data: ${JSON.stringify(payload)}\n\n`;
-      try { res.write(msg); } catch {}
+      try {
+        res.write(msg);
+      } catch {}
     }
   }
 

--- a/back/src/domains/booking/service/open-booking.service.ts
+++ b/back/src/domains/booking/service/open-booking.service.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../../../auth/service/auth.service';
 import { Event } from '../../event/entity/event.entity';
 import { EventRepository } from '../../event/repository/event.reposiotry';
 import { SectionRepository } from '../../place/repository/section.repository';
+import { ReservedSeatRepository } from '../../reservation/repository/reservedSeat.repository';
 import { ONE_MINUTE_BEFORE_THE_HOUR } from '../const/cronExpressions.const';
 import { IN_BOOKING_DEFAULT_MAX_SIZE } from '../const/inBookingDefaultMaxSize.const';
 
@@ -31,6 +32,7 @@ export class OpenBookingService implements OnApplicationBootstrap {
     private waitingQueueService: WaitingQueueService,
     private enterBookingService: EnterBookingService,
     private schedulerRegistry: SchedulerRegistry,
+    private reservedSeatRepository: ReservedSeatRepository,
   ) {
     this.redis = this.redisService.getOrThrow();
   }
@@ -149,13 +151,30 @@ export class OpenBookingService implements OnApplicationBootstrap {
     const defaultMaxSize = await this.inBookingService.getInBookingSessionsDefaultMaxSize();
     await this.inBookingService.setInBookingSessionsMaxSize(eventId, defaultMaxSize);
 
-    const initialSeats = sections.map((section) => section.seats);
-    await this.seatsUpdateService.openReservation(eventId, initialSeats);
+    const acquired = await this.redis.set(`open-booking:${eventId}:opened`, 'true', 'NX');
+
+    if (acquired === 'OK') {
+      try {
+        const initialSeats = sections.map((section) => section.seats);
+
+        const reservedRows = await this.reservedSeatRepository.findByEventId(eventId);
+        const reservedSeats: [number, number][] = reservedRows.map((rs) => [
+          rs.sectionIndex,
+          (rs.row - 1) * rs.colLen + (rs.col - 1),
+        ]);
+
+        await this.seatsUpdateService.openReservation(eventId, initialSeats, reservedSeats);
+      } catch (error) {
+        await this.redis.unlink(`open-booking:${eventId}:opened`);
+        throw error;
+      }
+    } else {
+      this.logger.debug(`[openReservation] eventId=${eventId} skip init — opened 키 선점됨, 구독만 attach`);
+      await this.seatsUpdateService.attachSubscriptionsForExistingEvent(eventId, sections.length);
+    }
 
     await this.enterBookingService.gcEnteringSessions(eventId);
     await this.inBookingService.gcReconnectingSessions(eventId);
-
-    await this.registerOpenedEvent(eventId);
   }
 
   private validateOpeningEvent(event: Event) {
@@ -168,10 +187,6 @@ export class OpenBookingService implements OnApplicationBootstrap {
       return false;
     }
     return true;
-  }
-
-  private async registerOpenedEvent(eventId: number) {
-    await this.redis.set(`open-booking:${eventId}:opened`, 'true');
   }
 
   async closeReservationAnyway(eventId: number) {

--- a/back/src/domains/reservation/repository/reservedSeat.repository.ts
+++ b/back/src/domains/reservation/repository/reservedSeat.repository.ts
@@ -18,4 +18,8 @@ export class ReservedSeatRepository {
       reservation: { id: reservationId },
     });
   }
+
+  async findByEventId(eventId: number): Promise<ReservedSeat[]> {
+    return this.reservedSeatRepository.find({ where: { event: { id: eventId } } });
+  }
 }

--- a/back/test/booking-abnormal.e2e-spec.ts
+++ b/back/test/booking-abnormal.e2e-spec.ts
@@ -6,6 +6,7 @@ import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
   bookSeat,
+  cleanupReservedSeats,
   createEvent,
   createPlace,
   createProgram,
@@ -54,6 +55,8 @@ describe('이상 패턴 & 경계 케이스 (booking-abnormal)', () => {
 
   beforeEach(async () => {
     await redisService.flushAll();
+    await cleanupReservedSeats(app, eventId);
+    await cleanupReservedSeats(app, eventId2);
     adminSid = await loginAsAdmin(app, 'abnadmin1', 'pass1234');
   });
 

--- a/back/test/booking-cross-event.e2e-spec.ts
+++ b/back/test/booking-cross-event.e2e-spec.ts
@@ -7,6 +7,7 @@ import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
   bookSeat,
+  cleanupReservedSeats,
   createEvent,
   createPlace,
   createProgram,
@@ -58,6 +59,8 @@ describe('크로스-이벤트 격리 (booking-cross-event)', () => {
 
   beforeEach(async () => {
     await redisService.flushAll();
+    await cleanupReservedSeats(app, eventId);
+    await cleanupReservedSeats(app, eventId2);
     adminSid = await loginAsAdmin(app, 'crosadmin1', 'pass1234');
   });
 

--- a/back/test/booking-reconnect.e2e-spec.ts
+++ b/back/test/booking-reconnect.e2e-spec.ts
@@ -7,6 +7,7 @@ import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
   bookSeat,
+  cleanupReservedSeats,
   createEvent,
   createPlace,
   createProgram,
@@ -56,6 +57,7 @@ describe('SSE 재연결 시나리오 (booking-reconnect)', () => {
 
   beforeEach(async () => {
     await redisService.flushAll();
+    await cleanupReservedSeats(app, eventId);
     adminSid = await loginAsAdmin(app, 'rcnadmin1', 'pass1234');
   });
 

--- a/back/test/booking-redis-init.e2e-spec.ts
+++ b/back/test/booking-redis-init.e2e-spec.ts
@@ -1,0 +1,178 @@
+import { INestApplication } from '@nestjs/common';
+
+import { AppException } from 'src/common/exception/app.exception';
+import { BookingSeatsService } from 'src/domains/booking/service/booking-seats.service';
+import { OpenBookingService } from 'src/domains/booking/service/open-booking.service';
+import { EventRepository } from 'src/domains/event/repository/event.reposiotry';
+import { ReservationRepository } from 'src/domains/reservation/repository/reservation.repository';
+import { ReservedSeatRepository } from 'src/domains/reservation/repository/reservedSeat.repository';
+import { UserRepository } from 'src/domains/user/repository/user.repository';
+import { TestRedisService } from 'src/testing/redis/test-redis.service';
+
+import {
+  bookSeat,
+  createEvent,
+  createPlace,
+  createProgram,
+  createSections,
+  createTestApp,
+  getRedisService,
+  loginAsAdmin,
+  loginAsUser,
+  setupSelectingSeat,
+} from './helpers/e2e-setup';
+
+describe('Phase 2: BE Redis 초기화 기예매 반영', () => {
+  let app: INestApplication;
+  let redisService: TestRedisService;
+  let adminSid: string;
+  let placeId: number;
+  let programId: number;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    redisService = getRedisService(app);
+    adminSid = await loginAsAdmin(app, 'bradmin1', 'pass1234');
+    placeId = await createPlace(app, adminSid);
+    await createSections(app, adminSid, placeId, [
+      { name: 'A', colLen: 3, seats: [1, 1, 1, 1, 1, 1], order: 0 },
+    ]);
+    programId = await createProgram(app, adminSid, placeId);
+  });
+
+  beforeEach(async () => {
+    await redisService.flushAll();
+    adminSid = await loginAsAdmin(app, 'bradmin1', 'pass1234');
+  });
+
+  afterAll(async () => {
+    await redisService.flushAll();
+    await redisService.disconnect();
+    await app.close();
+  });
+
+  it('BE-01: ReservedSeat이 DB에 사전 존재하면 init 후 해당 좌석은 SEAT_ALREADY_RESERVED', async () => {
+    // ── 1) Event 생성 ──────────────────────────────────────────────
+    const eventId = await createEvent(app, adminSid, programId, {
+      reservationOpenDate: new Date(Date.now() - 86_400_000).toISOString(),
+    });
+
+    // ── 2) 사전 주입에 사용할 user 준비 (loginAsUser → UserRepository로 user.id 조회) ──
+    const targetLoginId = 'be01user1';
+    await loginAsUser(app, targetLoginId, 'pass1234'); // signup-or-login
+
+    const userRepo = app.get(UserRepository);
+    const user = await userRepo.findByLoginId(targetLoginId);
+    expect(user).toBeTruthy();
+    const userId = user!.id;
+
+    // ── 3) Reservation + ReservedSeat 사전 주입 ────────────────────
+    // 좌석: section 'A' (sectionIndex 0), row=1 col=1 → seatIndex = (1-1)*3 + (1-1) = 0
+    const reservationRepo = app.get(ReservationRepository);
+    const reservedSeatRepo = app.get(ReservedSeatRepository);
+
+    const reservation = await reservationRepo.storeReservation({
+      createdAt: new Date(),
+      amount: 1,
+      program: { id: programId },
+      event: { id: eventId },
+      user: { id: userId },
+    });
+    const reservationId = (reservation as unknown as { id: number }).id;
+    expect(reservationId).toBeGreaterThan(0);
+
+    await reservedSeatRepo.storeReservedSeat([
+      {
+        event: { id: eventId },
+        sectionName: 'A',
+        sectionIndex: 0,
+        colLen: 3,
+        row: 1,
+        col: 1,
+        reservation: { id: reservationId },
+      },
+    ]);
+
+    // ── 4) initReservation 트리거 (closeReservationAnyway → openReservationById) ──
+    // openReservationById: SETNX 점유 + ReservedSeat 조회 + 비트맵에 0 반영
+    const openSvc = app.get(OpenBookingService);
+    await openSvc.initReservation(eventId);
+
+    // ── 5) 새 유저로 SELECTING_SEAT 진입 + 동일 좌석 bookSeat 시도 ──
+    // setupSelectingSeat 내부의 openEventReservation이 또 init 트리거함
+    // → initReservation = closeReservationAnyway(unlinkOpenedEvent) + openReservationById
+    // → unlinkOpenedEvent로 SETNX 키 삭제 후 다시 SETNX 성공 → ReservedSeat 재반영
+    // 따라서 좌석 (sectionIndex=0, seatIndex=0)은 여전히 0(예약됨) 상태 유지
+    const user2Sid = await loginAsUser(app, 'be01user2', 'pass1234');
+    await setupSelectingSeat(app, adminSid, eventId, user2Sid, 1, 0);
+
+    const res = await bookSeat(app, user2Sid, eventId, 0, 0, 'reserved');
+
+    // ── 6) HTTP 409 + errorCode 'BOOKING_SEAT_ALREADY_RESERVED' 검증 ─
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('BOOKING_SEAT_ALREADY_RESERVED');
+  });
+
+  it('BE-02: opened 키가 점유된 상태에서 openReservation 재호출 시 attach 분기 진입 + 데이터 보존', async () => {
+    // ── 1) Event 생성 ──────────────────────────────────────────────
+    const eventId = await createEvent(app, adminSid, programId, {
+      reservationOpenDate: new Date(Date.now() - 86_400_000).toISOString(),
+    });
+
+    // ── 2) 1차 init + 임의 좌석 점유 ───────────────────────────────
+    // setupSelectingSeat 내부의 openEventReservation이 첫 init을 트리거 → SETNX 키 'true' SET
+    const userSid = await loginAsUser(app, 'be02user1', 'pass1234');
+    await setupSelectingSeat(app, adminSid, eventId, userSid, 1, 0);
+
+    // 좌석 (sectionIndex=0, seatIndex=1) 점유 → Redis 비트맵 변경
+    const bookRes = await bookSeat(app, userSid, eventId, 0, 1, 'reserved');
+    expect(bookRes.status).toBe(201);
+
+    // 1차 init 후 SETNX 키가 'true'로 SET된 상태 검증
+    const redis = redisService.getOrThrow();
+    const openedBefore = await redis.get(`open-booking:${eventId}:opened`);
+    expect(openedBefore).toBe('true');
+
+    // ── 3) BookingSeatsService spy 설치 (보조 검증용) ──────────────
+    // 두 번째 openReservation 호출 시 attach 분기만 호출되고 full init은 호출되지 않아야 함.
+    const openSvc = app.get(OpenBookingService);
+    const seatsSvc = (openSvc as unknown as { seatsUpdateService: BookingSeatsService }).seatsUpdateService;
+
+    const fullInitSpy = jest.spyOn(seatsSvc, 'openReservation');
+    const attachSpy = jest.spyOn(seatsSvc, 'attachSubscriptionsForExistingEvent');
+
+    // ── 4) 두 번째 인스턴스의 openReservation 시도 시뮬레이션 ──────
+    // initReservation은 unlinkOpenedEvent로 SETNX 키를 지우므로 BE-02 분기를 못 탐.
+    // → private openReservation을 (svc as any) 캐스팅으로 직접 호출.
+    // 이 경로는 unlink 없이 SETNX 게이트만 거치므로 두 번째 호출은 attach 분기 진입.
+    const eventRepo = app.get(EventRepository);
+    const event = await eventRepo.selectEvent(eventId);
+    await (openSvc as any).openReservation(event);
+
+    // ── 5) spy 검증: attach만 호출되고 full init은 호출되지 않음 ────
+    expect(attachSpy).toHaveBeenCalledTimes(1);
+    expect(attachSpy).toHaveBeenCalledWith(eventId, expect.any(Number));
+    expect(fullInitSpy).not.toHaveBeenCalled();
+
+    // ── 6) 데이터 보존 검증 ────────────────────────────────────────
+    // 첫 init 시점에 점유된 좌석 (sectionIndex=0, seatIndex=1)이 여전히 0(예약됨) 상태인지 확인.
+    // attach 분기는 Redis 데이터를 변경하지 않으므로 비트맵이 그대로 보존돼야 한다.
+    let caughtError: unknown;
+    try {
+      await seatsSvc.updateSeatReserved(eventId, [0, 1]);
+    } catch (err) {
+      caughtError = err;
+    }
+    expect(caughtError).toBeInstanceOf(AppException);
+    expect((caughtError as AppException).getCode()).toBe('BOOKING_SEAT_ALREADY_RESERVED');
+
+    // ── 7) 점유되지 않은 좌석은 여전히 가용 ───────────────────────
+    // 비트맵 데이터가 보존됐다는 증거 — 다른 자리에 RESERVE 시도가 정상 성공.
+    const otherSeatRes = await seatsSvc.updateSeatReserved(eventId, [0, 0]);
+    expect(otherSeatRes.acceptedStatus).toBeDefined();
+
+    // spy 정리
+    fullInitSpy.mockRestore();
+    attachSpy.mockRestore();
+  });
+});

--- a/back/test/booking-section.e2e-spec.ts
+++ b/back/test/booking-section.e2e-spec.ts
@@ -6,6 +6,7 @@ import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
   bookSeat,
+  cleanupReservedSeats,
   createEvent,
   createPlace,
   createProgram,
@@ -50,6 +51,7 @@ describe('Phase 2: 섹션 전환 엔드포인트 + 재연결 복원', () => {
 
   beforeEach(async () => {
     await redisService.flushAll();
+    await cleanupReservedSeats(app, eventId);
     adminSid = await loginAsAdmin(app, 'sectadmin1', 'pass1234');
     userSid = await loginAsUser(app, 'sectionuser1', 'pass1234');
     await setupSelectingSeat(app, adminSid, eventId, userSid, 1, 0);

--- a/back/test/booking.e2e-spec.ts
+++ b/back/test/booking.e2e-spec.ts
@@ -11,6 +11,7 @@ import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
   bookSeat,
+  cleanupReservedSeats,
   createEvent,
   createPlace,
   createProgram,
@@ -56,6 +57,7 @@ describe('Booking (e2e)', () => {
 
   beforeEach(async () => {
     await redisService.flushAll();
+    await cleanupReservedSeats(app, eventId);
     adminSid = await loginAsAdmin(app, 'bkadmin1', 'pass1234');
   });
 

--- a/back/test/helpers/e2e-setup.ts
+++ b/back/test/helpers/e2e-setup.ts
@@ -2,6 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test as NestTest, TestingModule } from '@nestjs/testing';
 import cookieParser from 'cookie-parser';
 import supertest from 'supertest';
+import { Repository } from 'typeorm';
 
 import { AppModule } from 'src/app.module';
 import { AuthService } from 'src/auth/service/auth.service';
@@ -10,6 +11,7 @@ import { GlobalExceptionFilter } from 'src/common/exception/global-exception.fil
 import { ResponseWrapperInterceptor } from 'src/common/interceptor/response-wrapper.interceptor';
 import { BookingService } from 'src/domains/booking/service/booking.service';
 import { InBookingService } from 'src/domains/booking/service/in-booking.service';
+import { ReservedSeat } from 'src/domains/reservation/entity/reservedSeat.entity';
 import { USER_ROLE } from 'src/domains/user/const/userRole';
 import { CommonErrorCode } from 'src/domains/user/exception/user-error-code';
 import { UserService } from 'src/domains/user/service/user.service';
@@ -455,4 +457,22 @@ export async function simulateSSEReconnectWithSection(app: INestApplication, sid
   const eventId = await authService.getUserEventTarget(sid);
   await inBookingService.removeReconnectingSession(eventId, sid);
   await authService.setUserStatusSelectingSeat(sid);
+}
+
+/**
+ * 특정 이벤트의 ReservedSeat 레코드를 DB에서 물리 삭제한다.
+ *
+ * BE-01 구현(openReservation 시 DB ReservedSeat 반영) 이후, 예매 확정 테스트가 생성한
+ * ReservedSeat 레코드가 동일 eventId를 공유하는 다음 테스트의 Redis 초기화에 영향을 준다.
+ * 테스트 간 격리를 위해 beforeEach에서 이 함수를 호출하여 예약 데이터를 정리한다.
+ */
+export async function cleanupReservedSeats(app: INestApplication, eventId: number): Promise<void> {
+  const { DataSource } = await import('typeorm');
+  const dataSource = app.get(DataSource);
+  await dataSource
+    .createQueryBuilder()
+    .delete()
+    .from(ReservedSeat)
+    .where('event_id = :eventId', { eventId })
+    .execute();
 }

--- a/back/test/reservation.e2e-spec.ts
+++ b/back/test/reservation.e2e-spec.ts
@@ -5,6 +5,7 @@ import { TestRedisService } from 'src/testing/redis/test-redis.service';
 
 import {
   bookSeat,
+  cleanupReservedSeats,
   createEvent,
   createPlace,
   createProgram,
@@ -48,6 +49,7 @@ describe('Reservation (e2e)', () => {
 
   beforeEach(async () => {
     await redisService.flushAll();
+    await cleanupReservedSeats(app, eventId);
     adminSid = await loginAsAdmin(app, 'rsadmin1', 'pass1234');
   });
 


### PR DESCRIPTION
## 📌 이슈 번호
- close #397

## 🚀 구현 내용

서버(재)시작 시 `openReservation`이 DB의 기존 예매 데이터를 Redis 좌석 비트맵에 반영하고, Redis가 이미 초기화된 상태라면 init을 건너뛰도록 한다. 다중 인스턴스 환경에서 같은 event를 동시에 init 시도해도 데이터가 덮어써지지 않는다.

**핵심 변경:**

- `OpenBookingService.openReservation`
  - `SETNX(open-booking:{eventId}:opened)`로 init 시작 지점을 atomic하게 점유
  - 점유 성공 (첫 인스턴스): `ReservedSeat` 조회 → `[sectionIndex, seatIndex]` 변환 → `BookingSeatsService.openReservation`에 전달
  - 점유 실패 (다른 인스턴스): `attachSubscriptionsForExistingEvent`로 Lua init 건너뛰고 구독만 셋업 (Redis 비트맵 보존)
  - 점유 후 init 도중 예외 시 `unlink`로 키 롤백 (좀비 상태 방지)
  - 기존 `registerOpenedEvent`는 SETNX와 동일 키를 점유하므로 제거

- `BookingSeatsService.openReservation`
  - 시그니처에 `reservedSeats: [number, number][]` 추가
  - seats deep copy 후 reservedSeats 위치를 0으로 mutation해 비트맵 사전 빌드 (Lua 무변경)
  - init Lua를 `for...of + await`로 직렬화해 비트맵 쓰기 완료 보장

- `BookingSeatsService.attachSubscriptionsForExistingEvent` (신규)
  - Redis 키를 보존한 채 `runGetSectionSeatsLua`로 현재 상태 fetch + Pub/Sub 구독 + sseBroadcaster 구동
  - `clearSeatsSubscription` 미호출 (해당 메서드는 Redis 비트맵까지 unlink)
  - 진입 시 동일 eventId 잔존 구독이 있으면 즉시 return (중복 interval 방지)

- 인프라
  - `ReservedSeatRepository.findByEventId(eventId)` 추가
  - `BookingModule`에 `TypeOrmModule.forFeature([ReservedSeat])` + `ReservedSeatRepository` provider 등록 (`ReservationModule` import 없이 순환 의존 회피)

**테스트:**
- 신규 `back/test/booking-redis-init.e2e-spec.ts` — 사전 ReservedSeat 반영 시 동일 좌석 재예매 거절 + SETNX 점유 상태에서 재호출 시 attach 분기 + 비트맵 보존 검증
- 기존 6개 spec의 `beforeEach`에 `cleanupReservedSeats` 적용해 테스트 간 ReservedSeat 누수 격리

## 📘 참고 사항
- 단일 인스턴스에서도 SETNX는 멱등 가드로 동작해 `closeReservation` → `openReservation` 흐름이 안전하게 처리됨
- Lua 스크립트 자체는 수정하지 않음 (비트맵 사전 빌드는 TS에서)