### PR TITLE
Redis Sentinel 호스트/이름을 환경변수로 외부화

### DIFF
--- a/back/src/config/redisConfig.ts
+++ b/back/src/config/redisConfig.ts
@@ -2,14 +2,17 @@ import { RedisModuleOptions } from '@liaoliaots/nestjs-redis';
 
 const isSentinelMode = process.env.REDIS_SENTINEL_MODE === 'true';
 
+function parseSentinels(hostsEnv: string): { host: string; port: number }[] {
+  return hostsEnv.split(',').map((entry) => {
+    const [host, portStr] = entry.trim().split(':');
+    return { host, port: parseInt(portStr || '26379', 10) };
+  });
+}
+
 const sharedConnection = isSentinelMode
   ? {
-      sentinels: [
-        { host: 'redis-sentinel-1', port: 26379 },
-        { host: 'redis-sentinel-2', port: 26379 },
-        { host: 'redis-sentinel-3', port: 26379 },
-      ],
-      name: 'mymaster',
+      sentinels: parseSentinels(process.env.REDIS_SENTINEL_HOSTS),
+      name: process.env.REDIS_SENTINEL_NAME || 'mymaster',
       password: process.env.REDIS_PASSWORD || undefined,
     }
   : {


### PR DESCRIPTION
## 📌 이슈 번호
- close #400

## 🚀 구현 내용
기존에 `redisConfig.ts`에 하드코딩되어 있던 Redis Sentinel 설정을 환경변수로 외부화함.

- `REDIS_SENTINEL_HOSTS` (CSV, 예: `redis-sentinel-1:26379,redis-sentinel-2:26379,redis-sentinel-3:26379`) 로 Sentinel 호스트 목록 주입
- `REDIS_SENTINEL_NAME` 으로 마스터 이름 주입 (기본값: `mymaster`)
- `parseSentinels()` 헬퍼 함수를 추가해 CSV 파싱 처리