### PR TITLE
예약 초기화 시 WAITING 큐 리스트까지 초기화

### DIFF
--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -131,7 +131,7 @@ export class WaitingQueueService implements OnModuleDestroy {
       queueSubscription.subject.complete();
       this.queueSubscriptionMap.delete(eventId);
     }
-    const keys = await this.redis.keys(`waiting-queue:${eventId}:*`);
+    const keys = [`waiting-queue:${eventId}`, ...(await this.redis.keys(`waiting-queue:${eventId}:*`))];
     if (keys.length > 0) {
       await this.redis.unlink(...keys);
     }

--- a/back/test/booking.e2e-spec.ts
+++ b/back/test/booking.e2e-spec.ts
@@ -491,6 +491,39 @@ describe('Booking (e2e)', () => {
       await openEventReservation(app, adminSid, eventId).expect(201);
     });
 
+    it('관리자 예약 초기화 → WAITING 큐 리스트와 순번 키까지 초기화', async () => {
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      await withAuth(
+        supertest(app.getHttpServer()).post(`/booking/in-booking-pool-size/event/${eventId}`),
+        adminSid,
+      )
+        .send({ maxSize: 1 })
+        .expect(201);
+
+      const user1Sid = await loginAsUser(app, 'initwait1', 'pass1234');
+      await requestPermission(app, user1Sid, eventId).expect(200);
+      await setBookingCount(app, user1Sid, 1).expect(201);
+      await transitionToSelectingSeat(app, user1Sid);
+
+      const user2Sid = await loginAsUser(app, 'initwait2', 'pass1234');
+      const waitRes = await requestPermission(app, user2Sid, eventId).expect(200);
+      expect(waitRes.body.data.waitingStatus).toBe(true);
+
+      const redis = redisService.getOrThrow();
+      expect(await redis.llen(`waiting-queue:${eventId}`)).toBe(1);
+      expect(await redis.get(`waiting-queue:${eventId}:order`)).toBe('1');
+
+      await openEventReservation(app, adminSid, eventId).expect(201);
+
+      expect(await redis.llen(`waiting-queue:${eventId}`)).toBe(0);
+      expect(await redis.get(`waiting-queue:${eventId}:order`)).toBeNull();
+
+      const user2Session = await app.get(AuthService).getUserSession(user2Sid);
+      expect(user2Session.userStatus).toBe('LOGIN');
+      expect(user2Session.targetEvent).toBe(0);
+    });
+
     it('일반 유저 → 401', async () => {
       const userSid = await loginAsUser(app, 'inituser1', 'pass1234');
 


### PR DESCRIPTION
## 🔗 이슈 번호
- close #402

## ✅ 구현 내용
- 예약 초기화 시 waiting-queue:{eventId} 리스트 키를 삭제 대상에 포함
- 기존 waiting-queue:{eventId}:order 순번 키 초기화는 유지
- /booking/init/:eventId 재호출 시 WAITING 큐 리스트, 순번 키, 유저 상태가 함께 정리되는 E2E 회귀 테스트 추가

## 📌 참고 사항
- DB ReservedSeat는 기존 설계대로 삭제하지 않고, 재오픈 시 예약 확정 좌석으로 Redis 좌석 상태에 반영됩니다.

## 🧪 검증
- npm run greenlight