### PR TITLE
nginx ALB DNS 캐싱 문제 해결: resolver + 변수 방식 proxy_pass 적용

### DIFF
--- a/front/Dockerfile.dev
+++ b/front/Dockerfile.dev
@@ -20,9 +20,11 @@ COPY --from=build /app/dist/ .
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.conf /etc/nginx/conf.d/
+
 ARG API_SERVER_URL
-# proxy_pass 주입
-RUN sed -i 's|proxy_pass .*|proxy_pass '"${API_SERVER_URL}"';|g' /etc/nginx/conf.d/nginx.conf
+
+RUN sed -i 's|resolver 169.254.169.253|resolver 127.0.0.11|g' /etc/nginx/conf.d/nginx.conf && \
+    sed -i 's|set \$backend .*;|set \$backend '"${API_SERVER_URL}"';|g' /etc/nginx/conf.d/nginx.conf
 
 EXPOSE 80
 

--- a/front/Dockerfile.release
+++ b/front/Dockerfile.release
@@ -1,0 +1,32 @@
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+# Install dependencies
+RUN npm install --legacy-peer-deps
+
+COPY . .
+
+# API 프록싱 활성화
+RUN echo "VITE_API_PROXYING=true" >> .env
+
+RUN npm run build
+
+# Use nginx image for production stage
+FROM nginx:stable-alpine
+
+WORKDIR /usr/share/nginx/html
+RUN rm -rf ./*
+COPY --from=build /app/dist/ .
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx/nginx.conf /etc/nginx/conf.d/
+
+ARG API_SERVER_URL
+
+# ALB DNS 사용 시 resolver 유지, backend만 주입
+RUN sed -i 's|set \$backend .*;|set \$backend '"${API_SERVER_URL}"';|g' /etc/nginx/conf.d/nginx.conf
+
+EXPOSE 80
+
+# Run nginx in the foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/front/nginx/nginx.conf
+++ b/front/nginx/nginx.conf
@@ -14,8 +14,10 @@ server {
         proxy_buffering off;
         proxy_read_timeout 3600s;
 
-        # 백엔드 URL, front 도커파일에서 설정
-        proxy_pass http://nest:8080;
+        # 백엔드 URL, Dockerfile.dev 또는 Dockerfile.release에서 주입
+        resolver 169.254.169.253 valid=10s;
+        set $backend "";
+        proxy_pass $backend;
 
         rewrite ^/api(/.*)$ $1 break;  # /api/ 제거
         proxy_http_version 1.1;


### PR DESCRIPTION
## 📌 이슈 번호
- close #408

## 🚀 구현 내용

nginx가 ALB DNS를 `proxy_pass`에 직접 사용하면 컨테이너 시작 시점에 IP를 캐싱하여, ALB 노드가 교체됐을 때 모든 API 요청이 타임아웃으로 실패하는 문제를 수정합니다.

- **`nginx/nginx.conf`**: `proxy_pass` 도메인 직접 사용 → `resolver + set $backend` 변수 방식으로 변경 (DNS를 `valid=10s` 주기로 재조회)
- **`Dockerfile` 분리** (`Dockerfile.dev` / `Dockerfile.release`): 환경별로 적합한 resolver를 빌드 시 주입
  - `Dockerfile.dev`: Docker 내부 DNS(`127.0.0.11`)를 resolver로 교체 — 컨테이너 서비스명(`nest:8080` 등) 해석 가능
  - `Dockerfile.release`: AWS VPC DNS(`169.254.169.253`) 유지 — ALB DNS 동적 재조회