### PR TITLE
기본 API 로깅 미들웨어에 excludeUrls 옵션 추가 및 /metrics 로깅 제외

### DIFF
--- a/back/src/util/logger/logging.module.ts
+++ b/back/src/util/logger/logging.module.ts
@@ -10,6 +10,7 @@ import { winstonConfig } from './winston.config';
 const DefaultRequestLoggingMiddleware = RequestLoggingMiddleware.instantiate({
   includeDetails: [LoggingDetailType.RESPONSE_TIME, LoggingDetailType.STATUS_CODE],
   loggerName: 'Default-API',
+  excludeUrls: ['/metrics'],
 });
 
 export const FullRequestLoggingInterceptor = RequestLoggingInterceptor.instantiate({

--- a/back/src/util/logger/middleware/request-logging.middleware.ts
+++ b/back/src/util/logger/middleware/request-logging.middleware.ts
@@ -24,6 +24,11 @@ export class RequestLoggingMiddleware implements NestMiddleware {
   }
 
   async use(req: Request, res: Response, next: NextFunction) {
+    const { excludeUrls } = this.loggingOptions;
+    if (excludeUrls?.some((url) => req.path === url)) {
+      return next();
+    }
+
     const startTime = Date.now();
 
     try {

--- a/back/src/util/logger/types/logging.types.ts
+++ b/back/src/util/logger/types/logging.types.ts
@@ -16,6 +16,7 @@ export interface LoggingOptions {
   includeDetails?: LoggingDetailType[];
   excludeDetails?: LoggingDetailType[];
   loggerName?: string;
+  excludeUrls?: string[];
 }
 
 export interface DetailedLogData {


### PR DESCRIPTION
## 📌 이슈 번호
- close #410

## 🚀 구현 내용
`RequestLoggingMiddleware`에 `excludeUrls` 옵션을 추가하여 특정 URL의 요청을 로깅에서 제외할 수 있도록 했다.

- `LoggingOptions` 인터페이스에 `excludeUrls?: string[]` 필드 추가
- `RequestLoggingMiddleware.use()`에서 `req.path`가 `excludeUrls`에 포함되면 로깅 없이 즉시 `next()` 호출
- `DefaultRequestLoggingMiddleware` 인스턴스에 `excludeUrls: ['/metrics']` 적용 — Prometheus 스크래핑 노이즈 제거