### PR TITLE
fix: /metrics 로그 제외 조건 보정

### DIFF
--- a/back/src/util/logger/middleware/request-logging.middleware.ts
+++ b/back/src/util/logger/middleware/request-logging.middleware.ts
@@ -24,8 +24,7 @@ export class RequestLoggingMiddleware implements NestMiddleware {
   }
 
   async use(req: Request, res: Response, next: NextFunction) {
-    const { excludeUrls } = this.loggingOptions;
-    if (excludeUrls?.some((url) => req.path === url)) {
+    if (this.isExcludedRequest(req)) {
       return next();
     }
 
@@ -72,5 +71,20 @@ export class RequestLoggingMiddleware implements NestMiddleware {
 
       next(error);
     }
+  }
+
+  private isExcludedRequest(req: Request): boolean {
+    const { excludeUrls } = this.loggingOptions;
+    if (!excludeUrls?.length) {
+      return false;
+    }
+
+    const requestPath = this.normalizePath(req.originalUrl || req.url || req.path);
+    return excludeUrls.some((url) => this.normalizePath(url) === requestPath);
+  }
+
+  private normalizePath(url: string): string {
+    const path = url.split('?')[0];
+    return path || '/';
   }
 }


### PR DESCRIPTION
## 🔗 이슈 번호
- close #412

## 🛠 구현 내용
- RequestLoggingMiddleware의 excludeUrls 비교 기준을 req.path에서 원본 요청 경로 기반으로 변경
- forRoutes('*') 등록 시 Express mount 이후 req.path가 '/'로 바뀌어 /metrics 제외가 실패하던 문제를 보정
- query string이 붙은 /metrics 요청도 제외되도록 경로 정규화를 추가

## ✅ 검증
- npm.cmd --prefix back run build
- npm.cmd run greenlight
  - front: 2 files, 11 tests passed
  - back e2e: 12 suites, 127 tests passed