### PR TITLE
예매 대기 화면 남은 시간 서버 시간 기준으로 개선

### DIFF
--- a/front/src/api/booking.ts
+++ b/front/src/api/booking.ts
@@ -1,9 +1,12 @@
 import { apiClient } from '@/api/axios.ts';
 
 import { API } from '@/constants/index.ts';
+import type { ServerTimeResult } from '@/type/booking.ts';
 
 export const getPermission = (id: number) => () =>
   apiClient.get(API.BOOKING.GET_PERMISSION(id)).then((res) => res.data);
+export const getServerTime = (): Promise<ServerTimeResult> =>
+  apiClient.get(API.BOOKING.GET_SERVER_TIME).then((res) => res.data);
 export const postSeatCount = (count: number) =>
   apiClient.post(API.BOOKING.POST_COUNT, { bookingAmount: count });
 export const postSeat = (data: PostSeatData) => apiClient.post(API.BOOKING.POST_SEAT, data);

--- a/front/src/constants/index.ts
+++ b/front/src/constants/index.ts
@@ -31,6 +31,7 @@ export const API = {
   BOOKING: {
     GET_SEATS_SSE: (id: number) => `/booking/seat/${id}`,
     GET_PERMISSION: (id: number) => `/booking/permission/${id}`,
+    GET_SERVER_TIME: `/booking/server-time`,
     POST_COUNT: `/booking/count`,
     POST_SEAT: `/booking`,
     GET_RE_PERMISSION: (id: number) => `/booking/re-permission/${id}`,

--- a/front/src/pages/ReservationWaitingPage/index.tsx
+++ b/front/src/pages/ReservationWaitingPage/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { CustomError } from '@/api/axios.ts';
-import { getPermission } from '@/api/booking.ts';
+import { getPermission, getServerTime } from '@/api/booking.ts';
 import { getEventDetail } from '@/api/event.ts';
 import { getPlaceInformation } from '@/api/place.ts';
 
@@ -12,7 +12,7 @@ import Icon from '@/components/common/Icon.tsx';
 import { getDate, getTime } from '@/utils/date.ts';
 
 import { ROUTE_URL } from '@/constants/index.ts';
-import type { PermissionResult } from '@/type/booking.ts';
+import type { PermissionResult, ServerTimeResult } from '@/type/booking.ts';
 import type { EventDetail, PlaceInformation } from '@/type/index.ts';
 import { useIsFetching, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
@@ -38,9 +38,21 @@ export default function ReservationWaitingPage() {
   const queryClient = useQueryClient();
   const isPermissionFetching = useIsFetching({ queryKey: PERMISSION_QUERY_KEY });
   const intervalRef = useRef<number | null>(null); // intervalType
-  const [serverTime, setServerTime] = useState(Date.now());
-  const restTime = new Date(reservationOpenDate).getTime() - serverTime;
-  const isOpen = restTime <= 0;
+  const [clientNow, setClientNow] = useState(Date.now());
+  const {
+    data: serverTime,
+    dataUpdatedAt: serverTimeUpdatedAt,
+    isPending: isServerTimePending,
+  } = useQuery<ServerTimeResult, CustomError>({
+    queryKey: SERVER_TIME_QUERY_KEY,
+    queryFn: getServerTime,
+    staleTime: 0,
+  });
+  const currentServerTime =
+    serverTime === undefined ? null : serverTime.now + Math.max(0, clientNow - serverTimeUpdatedAt);
+  const restTime =
+    currentServerTime === null ? null : new Date(reservationOpenDate).getTime() - currentServerTime;
+  const isOpen = restTime !== null && restTime <= 0;
 
   const permissionAndGo = async () => {
     const { enteringStatus, userOrder } = await queryClient.fetchQuery<PermissionResult>({
@@ -56,7 +68,8 @@ export default function ReservationWaitingPage() {
     }
   };
   //TODO 좌석 초기 데이터
-  const renderRestTime = (restTime: number) => {
+  const renderRestTime = (restTime: number | null) => {
+    if (restTime === null) return <span className="text-display1 text-typo-sub">loading</span>;
     const restSeconds = Math.floor(restTime / 1000);
     if (restSeconds <= 0) return <span className="text-display1 text-error">000초</span>;
     if (restSeconds <= 100) {
@@ -80,7 +93,7 @@ export default function ReservationWaitingPage() {
   useEffect(() => {
     if (intervalRef.current === null) {
       intervalRef.current = setInterval(() => {
-        setServerTime(Date.now());
+        setClientNow(Date.now());
       }, 1000);
       return () => {
         if (intervalRef.current !== null) {
@@ -127,7 +140,10 @@ export default function ReservationWaitingPage() {
           </div>
         </div>
       </div>
-      <Button disabled={!isOpen || !!isPermissionFetching} className="my-4" onClick={permissionAndGo}>
+      <Button
+        disabled={!isOpen || !!isPermissionFetching || isServerTimePending}
+        className="my-4"
+        onClick={permissionAndGo}>
         {isOpen ? (
           <span className="text-label1 text-typo-display">예매하기</span>
         ) : (
@@ -139,3 +155,4 @@ export default function ReservationWaitingPage() {
 }
 
 const PERMISSION_QUERY_KEY = ['permission'];
+const SERVER_TIME_QUERY_KEY = ['server-time'];

--- a/front/src/type/booking.ts
+++ b/front/src/type/booking.ts
@@ -9,3 +9,7 @@ export interface RePermissionResult {
   totalWaiting: number;
   throughputRate: number;
 }
+
+export interface ServerTimeResult {
+  now: number;
+}


### PR DESCRIPTION
## 📌 이슈 번호
- close #414

## 🚀 구현 내용
- /event/{eventId}/ready 페이지에서 GET /booking/server-time API를 호출하도록 추가
- 서버 시간 응답값과 클라이언트 경과 시간을 조합해 예매 오픈까지 남은 시간을 계산하도록 변경
- 서버 시간 조회 전에는 예매 버튼이 활성화되지 않도록 처리
