### PR TITLE
유저 상태 전이 로직들이 다시 FSM 전이 테이블에 집약되도록 복구

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -16,6 +16,7 @@
     "start:prod:debug": "cross-env NODE_ENV=production EXEC_MODE=dev nest start --debug 0.0.0.0:9229 --watch",
     "test": "cross-env NODE_ENV=test EXEC_MODE=test jest --config ./test/jest-e2e.json",
     "test:unit": "cross-env NODE_ENV=test jest",
+    "test:lua": "cross-env NODE_ENV=test jest --testRegex \".*\\.real-spec\\.ts$\"",
     "test:watch": "cross-env NODE_ENV=test EXEC_MODE=test jest --config ./test/jest-e2e.json --watch",
     "test:cov": "cross-env NODE_ENV=test jest --coverage",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/back/src/auth/fsm/user-state-transition.contract.spec.ts
+++ b/back/src/auth/fsm/user-state-transition.contract.spec.ts
@@ -1,0 +1,253 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  type TargetEventPatch,
+  buildLuaUserStateTransitionInput,
+  mapLuaUserStateTransitionResult,
+  type LuaUserStateTransitionCode,
+} from './user-state-transition.contract';
+import { USER_STATUS, getAllowedTransitions } from './user-state.fsm';
+
+const baseFailureCodes = [
+  'SESSION_MISSING',
+  'STATE_MISMATCH',
+  'TARGET_EVENT_MISMATCH',
+  'SESSION_EXPIRED_DURING_WRITE',
+] as const satisfies readonly LuaUserStateTransitionCode[];
+
+describe('Lua 사용자 상태 전이 계약', () => {
+  it('계약 모듈은 프레임워크와 저장소 의존성을 가져오지 않음', () => {
+    const source = readFileSync(join(__dirname, 'user-state-transition.contract.ts'), 'utf8');
+
+    expect(source).not.toMatch(/@nestjs|Redis|ioredis|AuthService|BookingService/);
+  });
+
+  it('targetEvent patch 모드를 명시적으로 정의함', () => {
+    const patches = [
+      { mode: 'set', eventId: 12 },
+      { mode: 'preserve' },
+      { mode: 'clear' },
+    ] as const satisfies readonly TargetEventPatch[];
+
+    expect(patches).toEqual([{ mode: 'set', eventId: 12 }, { mode: 'preserve' }, { mode: 'clear' }]);
+  });
+
+  it('TypeScript FSM 결과로 Lua 전이 입력을 생성함', () => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'sid-1',
+        action: 'enterWaiting',
+        expectedFrom: USER_STATUS.LOGIN,
+        targetEventPatch: { mode: 'set', eventId: 1 },
+        expectedTargetEvent: null,
+      }),
+    ).toMatchObject({
+      sessionKey: expect.any(String),
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+      targetEventPatch: { mode: 'set', eventId: 1 },
+      expectedTargetEvent: null,
+    });
+  });
+
+  it('Lua 입력 생성 전 기존 의미 전이 실패를 그대로 반환함', () => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'sid-1',
+        action: 'startSeatSelection',
+        expectedFrom: USER_STATUS.LOGIN,
+        targetEventPatch: { mode: 'preserve' },
+      }),
+    ).toEqual({
+      ok: false,
+      action: 'startSeatSelection',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.SELECTING_SEAT,
+      reason: 'INVALID_TRANSITION',
+    });
+  });
+
+  it('expectedFrom을 생략하면 현재 상태 검증 없이 resetToLogin 입력을 생성함', () => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'sid-1',
+        action: 'resetToLogin',
+        targetEventPatch: { mode: 'clear' },
+        expectedTargetEvent: 7,
+      }),
+    ).toEqual({
+      sessionKey: 'user:sid-1',
+      action: 'resetToLogin',
+      nextTo: USER_STATUS.LOGIN,
+      targetEventPatch: { mode: 'clear' },
+      expectedTargetEvent: 7,
+    });
+  });
+
+  it('expectedFrom을 생략해도 LOGIN 대상이 아닌 전이의 nextTo를 FSM에서 도출함', () => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'sid-1',
+        action: 'startSeatSelection',
+        targetEventPatch: { mode: 'preserve' },
+      }),
+    ).toEqual({
+      sessionKey: 'user:sid-1',
+      action: 'startSeatSelection',
+      nextTo: USER_STATUS.SELECTING_SEAT,
+      targetEventPatch: { mode: 'preserve' },
+      expectedTargetEvent: undefined,
+    });
+  });
+
+  it('OK Lua 원시 응답을 성공 전이 결과로 매핑함', () => {
+    expect(
+      mapLuaUserStateTransitionResult(['OK'], {
+        action: 'enterWaiting',
+        expectedFrom: USER_STATUS.LOGIN,
+        nextTo: USER_STATUS.WAITING,
+      }),
+    ).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'enterWaiting',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.WAITING,
+    });
+  });
+
+  it('expectedFrom 없이 OK Lua 원시 응답을 성공 전이 결과로 매핑함', () => {
+    expect(
+      mapLuaUserStateTransitionResult(['OK'], {
+        action: 'resetToLogin',
+        nextTo: USER_STATUS.LOGIN,
+      }),
+    ).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'resetToLogin',
+      to: USER_STATUS.LOGIN,
+    });
+  });
+
+  it.each(baseFailureCodes)('기본 fail-closed 결과 코드 %s를 예외 없이 변환함', (code) => {
+    expect(
+      mapLuaUserStateTransitionResult([code, 'detail'], {
+        action: 'enterWaiting',
+        expectedFrom: USER_STATUS.LOGIN,
+        nextTo: USER_STATUS.WAITING,
+      }),
+    ).toEqual({
+      ok: false,
+      code,
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+      details: ['detail'],
+    });
+  });
+
+  it('호출자가 선언한 경로별 비즈니스 결과 코드 확장을 허용함', () => {
+    expect(
+      mapLuaUserStateTransitionResult(['CAPACITY_FULL'], {
+        action: 'enterBookingGate',
+        expectedFrom: USER_STATUS.LOGIN,
+        nextTo: USER_STATUS.ENTERING,
+        businessCodes: ['CAPACITY_FULL'],
+      }),
+    ).toMatchObject({
+      ok: false,
+      code: 'CAPACITY_FULL',
+    });
+  });
+
+  it('선언되지 않은 비기본 코드는 스크립트 계약 실패로 거부함', () => {
+    expect(() =>
+      mapLuaUserStateTransitionResult(['UNDECLARED_CODE'], {
+        action: 'enterWaiting',
+        expectedFrom: USER_STATUS.LOGIN,
+        nextTo: USER_STATUS.WAITING,
+      }),
+    ).toThrow('Unknown Lua user state transition code');
+  });
+
+  it('제거된 malformed-session 코드는 선언되지 않은 계약 실패로 거부함', () => {
+    const removedMalformedSessionCode = `MALFORMED_${'SESSION'}` as LuaUserStateTransitionCode;
+
+    expect(() =>
+      mapLuaUserStateTransitionResult([removedMalformedSessionCode], {
+        action: 'enterWaiting',
+        expectedFrom: USER_STATUS.LOGIN,
+        nextTo: USER_STATUS.WAITING,
+      }),
+    ).toThrow('Unknown Lua user state transition code');
+  });
+
+  it.each(getAllowedTransitions())('$action 전이에 대해 $from에서 $to로 가는 Lua 입력을 정확히 도출함', (row) => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'sid-1',
+        action: row.action,
+        expectedFrom: row.from,
+        targetEventPatch: { mode: 'preserve' },
+      }),
+    ).toMatchObject({
+      sessionKey: 'user:sid-1',
+      action: row.action,
+      expectedFrom: row.from,
+      nextTo: row.to,
+      targetEventPatch: { mode: 'preserve' },
+    });
+  });
+
+  it('즉시 입장과 대기열 선두 입장을 위한 enterBookingGate 시작 상태를 정확히 지원함', () => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'immediate-sid',
+        action: 'enterBookingGate',
+        expectedFrom: USER_STATUS.LOGIN,
+        targetEventPatch: { mode: 'set', eventId: 10 },
+      }),
+    ).toMatchObject({
+      sessionKey: 'user:immediate-sid',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.ENTERING,
+    });
+
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'waiting-head-sid',
+        action: 'enterBookingGate',
+        expectedFrom: USER_STATUS.WAITING,
+        targetEventPatch: { mode: 'set', eventId: 10 },
+      }),
+    ).toMatchObject({
+      sessionKey: 'user:waiting-head-sid',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.ENTERING,
+    });
+  });
+
+  it.each([
+    ['startSeatSelection', USER_STATUS.LOGIN, USER_STATUS.SELECTING_SEAT, 'INVALID_TRANSITION'],
+    ['enterBookingGate', USER_STATUS.SELECTING_SEAT, USER_STATUS.ENTERING, 'INVALID_TRANSITION'],
+    ['enterWaiting', 'BROKEN_STATE', USER_STATUS.WAITING, 'UNKNOWN_STATE'],
+  ] as const)('Lua 입력 생성 전 잘못된 시작 상태 %s / %s를 거부함', (action, from, to, reason) => {
+    expect(
+      buildLuaUserStateTransitionInput({
+        sid: 'sid-1',
+        action,
+        expectedFrom: from,
+        targetEventPatch: { mode: 'preserve' },
+      }),
+    ).toEqual({
+      ok: false,
+      action,
+      from,
+      to,
+      reason,
+    });
+  });
+});

--- a/back/src/auth/fsm/user-state-transition.contract.ts
+++ b/back/src/auth/fsm/user-state-transition.contract.ts
@@ -1,0 +1,187 @@
+import {
+  getUserStateTransitionTarget,
+  transitionUserState,
+  type BookingUserState,
+  type SessionUserStatus,
+  type TransitionResult,
+  type UserStateTransitionAction,
+} from './user-state.fsm';
+
+export type TargetEventPatch = { mode: 'set'; eventId: number } | { mode: 'preserve' } | { mode: 'clear' };
+
+export type LuaUserStateTransitionBaseCode =
+  | 'OK'
+  | 'SESSION_MISSING'
+  | 'STATE_MISMATCH'
+  | 'TARGET_EVENT_MISMATCH'
+  | 'SESSION_EXPIRED_DURING_WRITE';
+
+export type LuaUserStateTransitionCode<TBusinessCode extends string = never> =
+  | LuaUserStateTransitionBaseCode
+  | TBusinessCode;
+
+export type LuaUserStateTransitionInput = {
+  sessionKey: string;
+  action: UserStateTransitionAction;
+  expectedFrom?: BookingUserState;
+  nextTo: BookingUserState;
+  targetEventPatch: TargetEventPatch;
+  expectedTargetEvent?: number | null;
+};
+
+export type LuaUserStateTransitionResult<TBusinessCode extends string = never> =
+  | {
+      ok: true;
+      code: 'OK';
+      action: UserStateTransitionAction;
+      from?: BookingUserState;
+      to: BookingUserState;
+    }
+  | {
+      ok: false;
+      code: Exclude<LuaUserStateTransitionCode<TBusinessCode>, 'OK'>;
+      action: UserStateTransitionAction;
+      expectedFrom?: BookingUserState;
+      nextTo: BookingUserState;
+      details: readonly unknown[];
+    };
+
+export type LuaUserStateTransitionRawResult<TBusinessCode extends string = never> =
+  | LuaUserStateTransitionCode<TBusinessCode>
+  | readonly [LuaUserStateTransitionCode<TBusinessCode>, ...unknown[]]
+  | {
+      code: LuaUserStateTransitionCode<TBusinessCode>;
+      details?: readonly unknown[] | Record<string, unknown>;
+    };
+
+export type BuildLuaUserStateTransitionInputParams = {
+  sid: string;
+  action: UserStateTransitionAction;
+  expectedFrom?: SessionUserStatus | string;
+  targetEventPatch: TargetEventPatch;
+  expectedTargetEvent?: number | null;
+};
+
+export type MapLuaUserStateTransitionResultContext<TBusinessCode extends string = never> = {
+  action: UserStateTransitionAction;
+  expectedFrom?: BookingUserState;
+  nextTo: BookingUserState;
+  businessCodes?: readonly TBusinessCode[];
+};
+
+const BASE_CODES = [
+  'OK',
+  'SESSION_MISSING',
+  'STATE_MISMATCH',
+  'TARGET_EVENT_MISMATCH',
+  'SESSION_EXPIRED_DURING_WRITE',
+] as const satisfies readonly LuaUserStateTransitionBaseCode[];
+
+const BASE_CODE_SET = new Set<string>(BASE_CODES);
+
+function isKnownBaseCode(code: string): code is LuaUserStateTransitionBaseCode {
+  return BASE_CODE_SET.has(code);
+}
+
+function isDeclaredBusinessCode<TBusinessCode extends string>(
+  code: string,
+  businessCodes: readonly TBusinessCode[] | undefined,
+): code is TBusinessCode {
+  return businessCodes?.includes(code as TBusinessCode) ?? false;
+}
+
+function normalizeDetails(details: unknown): readonly unknown[] {
+  if (details === undefined) {
+    return [];
+  }
+
+  return Array.isArray(details) ? details : [details];
+}
+
+function parseRawLuaResult<TBusinessCode extends string>(
+  raw: LuaUserStateTransitionRawResult<TBusinessCode>,
+): {
+  code: LuaUserStateTransitionCode<TBusinessCode>;
+  details: readonly unknown[];
+} {
+  if (typeof raw === 'string') {
+    return { code: raw, details: [] };
+  }
+
+  if (Array.isArray(raw)) {
+    const [code, ...details] = raw;
+    if (typeof code !== 'string') {
+      throw new TypeError('Lua user state transition result code must be a string');
+    }
+
+    return { code: code as LuaUserStateTransitionCode<TBusinessCode>, details };
+  }
+
+  if (raw && typeof raw === 'object' && 'code' in raw && typeof raw.code === 'string') {
+    return {
+      code: raw.code,
+      details: normalizeDetails(raw.details),
+    };
+  }
+
+  throw new TypeError('Lua user state transition result must include a string code');
+}
+
+export function buildLuaUserStateTransitionInput(
+  params: BuildLuaUserStateTransitionInputParams,
+): TransitionResult | LuaUserStateTransitionInput {
+  if (params.expectedFrom === undefined) {
+    return {
+      sessionKey: `user:${params.sid}`,
+      action: params.action,
+      nextTo: getUserStateTransitionTarget(params.action),
+      targetEventPatch: params.targetEventPatch,
+      expectedTargetEvent: params.expectedTargetEvent,
+    };
+  }
+
+  const result = transitionUserState(params.action, params.expectedFrom);
+
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    sessionKey: `user:${params.sid}`,
+    action: params.action,
+    expectedFrom: result.from,
+    nextTo: result.to,
+    targetEventPatch: params.targetEventPatch,
+    expectedTargetEvent: params.expectedTargetEvent,
+  };
+}
+
+export function mapLuaUserStateTransitionResult<TBusinessCode extends string = never>(
+  raw: LuaUserStateTransitionRawResult<TBusinessCode>,
+  context: MapLuaUserStateTransitionResultContext<TBusinessCode>,
+): LuaUserStateTransitionResult<TBusinessCode> {
+  const { code, details } = parseRawLuaResult(raw);
+
+  if (!isKnownBaseCode(code) && !isDeclaredBusinessCode(code, context.businessCodes)) {
+    throw new TypeError(`Unknown Lua user state transition code: ${code}`);
+  }
+
+  if (code === 'OK') {
+    return {
+      ok: true,
+      code: 'OK',
+      action: context.action,
+      to: context.nextTo,
+      ...(context.expectedFrom === undefined ? {} : { from: context.expectedFrom }),
+    };
+  }
+
+  return {
+    ok: false,
+    code: code as Exclude<LuaUserStateTransitionCode<TBusinessCode>, 'OK'>,
+    action: context.action,
+    nextTo: context.nextTo,
+    details,
+    ...(context.expectedFrom === undefined ? {} : { expectedFrom: context.expectedFrom }),
+  };
+}

--- a/back/src/auth/fsm/user-state-transition.contract.ts
+++ b/back/src/auth/fsm/user-state-transition.contract.ts
@@ -127,6 +127,28 @@ function parseRawLuaResult<TBusinessCode extends string>(
   throw new TypeError('Lua user state transition result must include a string code');
 }
 
+export type ResolvedUserStateTransition = {
+  action: UserStateTransitionAction;
+  from: BookingUserState;
+  to: BookingUserState;
+};
+
+export function resolveUserStateTransition(
+  action: UserStateTransitionAction,
+  expectedFrom: BookingUserState,
+): ResolvedUserStateTransition {
+  const result = transitionUserState(action, expectedFrom);
+
+  // strictNullChecks가 꺼져 있어 ok 판별만으로는 좁혀지지 않으므로 reason 유무로 실패를 가른다.
+  if ('reason' in result) {
+    throw new TypeError(
+      `상태 전이 테이블이 허용하지 않는 전이입니다: ${action} (from=${expectedFrom}, reason=${result.reason})`,
+    );
+  }
+
+  return { action, from: result.from, to: result.to };
+}
+
 export function buildLuaUserStateTransitionInput(
   params: BuildLuaUserStateTransitionInputParams,
 ): TransitionResult | LuaUserStateTransitionInput {

--- a/back/src/auth/fsm/user-state.fsm.spec.ts
+++ b/back/src/auth/fsm/user-state.fsm.spec.ts
@@ -8,6 +8,7 @@ import {
   enterBookingGate,
   enterWaiting,
   getAllowedTransitions,
+  getUserStateTransitionTarget,
   markReconnectingSelection,
   resetToLogin,
   restoreSeatSelection,
@@ -29,8 +30,8 @@ const namedTransitions: Record<UserStateTransitionAction, (current: SessionUserS
     resetToLogin,
   };
 
-describe('user-state FSM', () => {
-  it('exports the persisted status strings from the FSM source of truth', () => {
+describe('사용자 상태 FSM', () => {
+  it('영속 상태 문자열을 FSM 원천에서 그대로 내보냄', () => {
     expect(USER_STATUS).toEqual({
       LOGIN: 'LOGIN',
       WAITING: 'WAITING',
@@ -49,13 +50,13 @@ describe('user-state FSM', () => {
     expect(BOOKING_USER_STATES).not.toContain('ADMIN');
   });
 
-  it('keeps the legacy const surface compatible with the FSM source', () => {
+  it('기존 const 표면을 FSM 원천과 호환되게 유지함', () => {
     expect(compatUserStatus).toBe(fsmUserStatus);
     expect(compatUserStatus.SELECTING_SEAT).toBe('SELECTING_SEAT');
     expect(compatUserStatus.RECONNECTING_SELECTING).toBe('RECONNECTING_SELECTING');
   });
 
-  it('exposes exactly the allowed transition table', () => {
+  it('허용된 전이 테이블만 정확히 노출함', () => {
     expect(getAllowedTransitions()).toBe(USER_STATE_TRANSITIONS);
     expect(getAllowedTransitions()).toEqual([
       { action: 'enterWaiting', from: USER_STATUS.LOGIN, to: USER_STATUS.WAITING },
@@ -79,9 +80,20 @@ describe('user-state FSM', () => {
     ]);
   });
 
-  it.each(getAllowedTransitions())('$action allows $from -> $to', ({ action, from, to }) => {
+  it.each(getAllowedTransitions())('$action 전이는 $from에서 $to로 이동함', ({ action, from, to }) => {
     expect(transitionUserState(action, from)).toEqual({ ok: true, action, from, to });
     expect(namedTransitions[action](from)).toEqual({ ok: true, action, from, to });
+  });
+
+  it.each([
+    ['enterWaiting', USER_STATUS.WAITING],
+    ['enterBookingGate', USER_STATUS.ENTERING],
+    ['startSeatSelection', USER_STATUS.SELECTING_SEAT],
+    ['markReconnectingSelection', USER_STATUS.RECONNECTING_SELECTING],
+    ['restoreSeatSelection', USER_STATUS.SELECTING_SEAT],
+    ['resetToLogin', USER_STATUS.LOGIN],
+  ] as const)('%s 전이의 기본 도착 상태를 제공함', (action, to) => {
+    expect(getUserStateTransitionTarget(action)).toBe(to);
   });
 
   it.each([
@@ -90,7 +102,7 @@ describe('user-state FSM', () => {
     ['enterBookingGate', USER_STATUS.SELECTING_SEAT, USER_STATUS.ENTERING],
     ['restoreSeatSelection', USER_STATUS.SELECTING_SEAT, USER_STATUS.SELECTING_SEAT],
     ['resetToLogin', USER_STATUS.LOGIN, USER_STATUS.LOGIN],
-  ] as const)('%s rejects invalid transition from %s', (action, from, to) => {
+  ] as const)('%s 전이는 %s 시작 상태를 거부함', (action, from, to) => {
     expect(transitionUserState(action, from)).toEqual({
       ok: false,
       action,
@@ -100,7 +112,7 @@ describe('user-state FSM', () => {
     });
   });
 
-  it('treats a stale ADMIN persisted state as unknown', () => {
+  it('오래된 ADMIN 저장 상태를 알 수 없는 상태로 취급함', () => {
     expect(transitionUserState('enterBookingGate', 'ADMIN')).toEqual({
       ok: false,
       action: 'enterBookingGate',
@@ -110,7 +122,7 @@ describe('user-state FSM', () => {
     });
   });
 
-  it('rejects unknown persisted states without coercing them', () => {
+  it('알 수 없는 저장 상태를 변환하지 않고 거부함', () => {
     expect(transitionUserState('enterWaiting', 'BROKEN_STATE')).toEqual({
       ok: false,
       action: 'enterWaiting',
@@ -120,7 +132,7 @@ describe('user-state FSM', () => {
     });
   });
 
-  it('checks state capability by exact explicit membership', () => {
+  it('명시된 상태 집합 포함 여부로 접근 가능 상태를 판단함', () => {
     expect(canAccessState(USER_STATUS.SELECTING_SEAT, USER_STATUS.LOGIN)).toBe(false);
     expect(canAccessState(USER_STATUS.SELECTING_SEAT, USER_STATUS.SELECTING_SEAT)).toBe(true);
     expect(

--- a/back/src/auth/fsm/user-state.fsm.ts
+++ b/back/src/auth/fsm/user-state.fsm.ts
@@ -26,7 +26,7 @@ export type UserStateTransitionAction =
   | 'resetToLogin';
 
 export type TransitionResult =
-  | { ok: true; action: UserStateTransitionAction; from: BookingUserState; to: BookingUserState }
+  | { ok: true; action: UserStateTransitionAction; from?: BookingUserState; to: BookingUserState }
   | {
       ok: false;
       action: UserStateTransitionAction;
@@ -81,11 +81,15 @@ export function getAllowedTransitions(): readonly UserStateTransition[] {
   return USER_STATE_TRANSITIONS;
 }
 
+export function getUserStateTransitionTarget(action: UserStateTransitionAction): BookingUserState {
+  return TRANSITION_DEFAULT_TARGETS[action];
+}
+
 export function transitionUserState(
   action: UserStateTransitionAction,
   current: SessionUserStatus | string,
 ): TransitionResult {
-  const to = TRANSITION_DEFAULT_TARGETS[action];
+  const to = getUserStateTransitionTarget(action);
 
   if (!isSessionUserStatus(current)) {
     return { ok: false, action, from: current, to, reason: 'UNKNOWN_STATE' };

--- a/back/src/auth/luaScripts/sessionLuaHelpers.spec.ts
+++ b/back/src/auth/luaScripts/sessionLuaHelpers.spec.ts
@@ -1,0 +1,34 @@
+import { sessionWriteLuaHelpers } from './sessionLuaHelpers';
+
+describe('세션 쓰기 Lua 공용 helper', () => {
+  it('TTL 보존 쓰기와 만료 판정 함수를 한 곳에서만 정의함', () => {
+    expect(sessionWriteLuaHelpers).toContain('local function prepareSessionWrite');
+    expect(sessionWriteLuaHelpers).toContain('local function writePreparedSessionPreservingTtl');
+  });
+
+  it('0 PTTL과 -2 PTTL을 만료 없는 세션 분기로 처리하지 않음', () => {
+    expect(sessionWriteLuaHelpers).toContain('if ttl == -2 or ttl == 0 then');
+    expect(sessionWriteLuaHelpers).toContain("return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'");
+  });
+
+  it('쓰기 대상으로 통과시키는 TTL은 양수와 만료 없음(-1)뿐임', () => {
+    expect(sessionWriteLuaHelpers).toContain('if ttl > 0 or ttl == -1 then');
+    expect(sessionWriteLuaHelpers).toContain("return encodedSession, ttl, 'OK'");
+  });
+
+  it('양수 TTL은 PSETEX로 남은 시간을 보존함', () => {
+    expect(sessionWriteLuaHelpers).toContain("redis.call('PSETEX', sessionKey, ttl, encodedSession)");
+  });
+
+  it('옵션 없는 SET은 만료 없는 세션에만 쓰임', () => {
+    expect(sessionWriteLuaHelpers).toContain("redis.call('SET', sessionKey, encodedSession)");
+    expect(sessionWriteLuaHelpers).not.toContain('KEEPTTL');
+    expect(sessionWriteLuaHelpers).not.toMatch(/redis\.call\('SET', sessionKey, encodedSession, /);
+  });
+
+  it('TTL을 새로 갱신하는 명령을 쓰지 않음', () => {
+    expect(sessionWriteLuaHelpers).not.toContain("redis.call('EXPIRE'");
+    expect(sessionWriteLuaHelpers).not.toContain("redis.call('PEXPIRE'");
+    expect(sessionWriteLuaHelpers).not.toContain("redis.call('SETEX'");
+  });
+});

--- a/back/src/auth/luaScripts/sessionLuaHelpers.ts
+++ b/back/src/auth/luaScripts/sessionLuaHelpers.ts
@@ -1,0 +1,24 @@
+export const sessionWriteLuaHelpers = `
+  local function prepareSessionWrite(sessionKey, session)
+    local encodedSession = cjson.encode(session)
+    local ttl = redis.call('PTTL', sessionKey)
+    if ttl == -2 or ttl == 0 then
+      return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'
+    end
+
+    if ttl > 0 or ttl == -1 then
+      return encodedSession, ttl, 'OK'
+    end
+
+    return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'
+  end
+
+  local function writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+    if ttl > 0 then
+      redis.call('PSETEX', sessionKey, ttl, encodedSession)
+      return
+    end
+
+    redis.call('SET', sessionKey, encodedSession)
+  end
+`;

--- a/back/src/auth/luaScripts/userStateTransitionLua.spec.ts
+++ b/back/src/auth/luaScripts/userStateTransitionLua.spec.ts
@@ -1,0 +1,380 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+
+import {
+  buildLuaUserStateTransitionInput,
+  type LuaUserStateTransitionInput,
+  type LuaUserStateTransitionRawResult,
+} from '../fsm/user-state-transition.contract';
+import { USER_STATUS } from '../fsm/user-state.fsm';
+
+import { runUserStateTransitionLua } from './userStateTransitionLua';
+
+const baseSession = {
+  id: 1,
+  loginId: 'guest-1',
+  roles: ['USER'],
+  targetEvent: null,
+  userStatus: USER_STATUS.LOGIN,
+};
+
+type RedisWithStubbedCommand = Redis & {
+  userStateTransition?: jest.Mock;
+};
+type UserStateTransitionCommandArgs = [
+  sessionKey: string,
+  expectedFromMode: string,
+  expectedFromValue: string,
+  nextTo: string,
+  targetEventPatchMode: string,
+  targetEventPatchValue: string,
+  expectedTargetEventMode: string,
+  expectedTargetEventValue: string,
+];
+
+function buildInput(overrides: Partial<LuaUserStateTransitionInput> = {}): LuaUserStateTransitionInput {
+  const input = buildLuaUserStateTransitionInput({
+    sid: 'sid-1',
+    action: 'enterWaiting',
+    expectedFrom: USER_STATUS.LOGIN,
+    targetEventPatch: { mode: 'set', eventId: 42 },
+    expectedTargetEvent: null,
+  });
+
+  if (!('sessionKey' in input)) {
+    throw new Error('유효한 Lua 전이 입력이어야 함');
+  }
+
+  return { ...input, ...overrides };
+}
+
+async function emulateUserStateTransitionCommand(
+  redis: Redis,
+  ...[
+    sessionKey,
+    expectedFromMode,
+    expectedFromValue,
+    nextTo,
+    targetEventPatchMode,
+    targetEventPatchValue,
+    expectedTargetEventMode,
+    expectedTargetEventValue,
+  ]: UserStateTransitionCommandArgs
+): Promise<LuaUserStateTransitionRawResult> {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return ['SESSION_MISSING'];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+
+  if (expectedFromMode === 'value' && session.userStatus !== expectedFromValue) {
+    return ['STATE_MISMATCH', session.userStatus];
+  }
+
+  if (expectedTargetEventMode !== 'none') {
+    const expectedTargetEvent =
+      expectedTargetEventMode === 'null' ? null : Number(expectedTargetEventValue);
+
+    if (session.targetEvent !== expectedTargetEvent) {
+      return ['TARGET_EVENT_MISMATCH', session.targetEvent];
+    }
+  }
+
+  session.userStatus = nextTo;
+
+  if (targetEventPatchMode === 'set') {
+    session.targetEvent = Number(targetEventPatchValue);
+  } else if (targetEventPatchMode === 'clear') {
+    session.targetEvent = null;
+  }
+
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  if (ttl > 0) {
+    await redis.set(sessionKey, JSON.stringify(session), 'PX', ttl);
+  } else if (ttl === -1) {
+    await redis.set(sessionKey, JSON.stringify(session));
+  } else {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  return ['OK'];
+}
+
+function installUserStateTransitionCommandStub(redis: Redis): jest.SpyInstance {
+  return jest.spyOn(redis, 'defineCommand').mockImplementation(function (
+    this: RedisWithStubbedCommand,
+    name: string,
+  ) {
+    this[name as 'userStateTransition'] = jest.fn((...args: UserStateTransitionCommandArgs) =>
+      emulateUserStateTransitionCommand(redis, ...args),
+    );
+
+    return this;
+  } as never);
+}
+
+describe('runUserStateTransitionLua 실행', () => {
+  let redis: Redis;
+  let defineCommandSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    redis = new RedisMock() as unknown as Redis;
+    defineCommandSpy = installUserStateTransitionCommandStub(redis);
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('사용자 세션이 없으면 SESSION_MISSING을 반환함', async () => {
+    const result = await runUserStateTransitionLua(redis, buildInput());
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'SESSION_MISSING',
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+    });
+  });
+
+  it.each(['{broken-json'])(
+    '문법이 깨진 세션 JSON은 typed 결과로 변환하지 않고 throw함: %s',
+    async (payload) => {
+      const input = buildInput();
+      await redis.set(input.sessionKey, payload);
+
+      await expect(runUserStateTransitionLua(redis, input)).rejects.toThrow();
+      expect(await redis.get(input.sessionKey)).toBe(payload);
+    },
+  );
+
+  it('저장된 userStatus가 expectedFrom과 다르면 쓰기 없이 STATE_MISMATCH를 반환함', async () => {
+    const input = buildInput();
+    const session = { ...baseSession, targetEvent: null, userStatus: USER_STATUS.ENTERING };
+    await redis.set(input.sessionKey, JSON.stringify(session));
+
+    const result = await runUserStateTransitionLua(redis, input);
+
+    expect(result).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toEqual(session);
+  });
+
+  it('expectedFrom을 생략하면 현재 상태 비교만 건너뛰고 explicit nextTo를 저장함', async () => {
+    const input = buildInput({
+      action: 'resetToLogin',
+      expectedFrom: undefined,
+      nextTo: USER_STATUS.LOGIN,
+      targetEventPatch: { mode: 'clear' },
+      expectedTargetEvent: 7,
+    });
+    await redis.set(
+      input.sessionKey,
+      JSON.stringify({ ...baseSession, targetEvent: 7, userStatus: USER_STATUS.SELECTING_SEAT }),
+    );
+
+    const result = await runUserStateTransitionLua(redis, input);
+
+    expect(result).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'resetToLogin',
+      to: USER_STATUS.LOGIN,
+    });
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toMatchObject({
+      targetEvent: null,
+      userStatus: USER_STATUS.LOGIN,
+    });
+  });
+
+  it('expectedFrom을 생략해도 세션이 없으면 SESSION_MISSING을 반환함', async () => {
+    const result = await runUserStateTransitionLua(
+      redis,
+      buildInput({ expectedFrom: undefined, nextTo: USER_STATUS.LOGIN }),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'SESSION_MISSING',
+      action: 'enterWaiting',
+      nextTo: USER_STATUS.LOGIN,
+    });
+    expect(result).not.toHaveProperty('expectedFrom');
+  });
+
+  it('expectedFrom을 생략해도 targetEvent 검증은 유지함', async () => {
+    const input = buildInput({
+      expectedFrom: undefined,
+      expectedTargetEvent: 99,
+    });
+    const session = { ...baseSession, targetEvent: 42, userStatus: USER_STATUS.ENTERING };
+    await redis.set(input.sessionKey, JSON.stringify(session));
+
+    const result = await runUserStateTransitionLua(redis, input);
+
+    expect(result).toMatchObject({ ok: false, code: 'TARGET_EVENT_MISMATCH' });
+    expect(result).not.toHaveProperty('expectedFrom');
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toEqual(session);
+  });
+
+  it('기대 targetEvent가 다르면 쓰기 없이 TARGET_EVENT_MISMATCH를 반환함', async () => {
+    const input = buildInput({ expectedTargetEvent: 99 });
+    const session = { ...baseSession, targetEvent: 42 };
+    await redis.set(input.sessionKey, JSON.stringify(session));
+
+    const result = await runUserStateTransitionLua(redis, input);
+
+    expect(result).toMatchObject({ ok: false, code: 'TARGET_EVENT_MISMATCH' });
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toEqual(session);
+  });
+
+  it('성공한 상태 전이를 set targetEvent 패치와 함께 저장함', async () => {
+    const input = buildInput();
+    await redis.set(input.sessionKey, JSON.stringify(baseSession));
+
+    const result = await runUserStateTransitionLua(redis, input);
+
+    expect(result).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'enterWaiting',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.WAITING,
+    });
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toEqual({
+      ...baseSession,
+      targetEvent: 42,
+      userStatus: USER_STATUS.WAITING,
+    });
+  });
+
+  it('패치 모드가 preserve이면 targetEvent를 유지함', async () => {
+    const input = buildInput({
+      expectedTargetEvent: 7,
+      targetEventPatch: { mode: 'preserve' },
+    });
+    await redis.set(input.sessionKey, JSON.stringify({ ...baseSession, targetEvent: 7 }));
+
+    await runUserStateTransitionLua(redis, input);
+
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toMatchObject({
+      targetEvent: 7,
+      userStatus: USER_STATUS.WAITING,
+    });
+  });
+
+  it('패치 모드가 clear이면 targetEvent를 null로 비움', async () => {
+    const input = buildInput({
+      expectedTargetEvent: 7,
+      targetEventPatch: { mode: 'clear' },
+    });
+    await redis.set(input.sessionKey, JSON.stringify({ ...baseSession, targetEvent: 7 }));
+
+    await runUserStateTransitionLua(redis, input);
+
+    expect(JSON.parse((await redis.get(input.sessionKey)) ?? '{}')).toMatchObject({
+      targetEvent: null,
+      userStatus: USER_STATUS.WAITING,
+    });
+  });
+
+  it('Redis Lua 명령 실패는 인프라 실패로 throw함', async () => {
+    const error = new Error('Lua 명령 실패');
+    const failingRedis = {
+      defineCommand: jest.fn(function (this: RedisWithStubbedCommand, name: string) {
+        this[name as 'userStateTransition'] = jest.fn().mockRejectedValue(error);
+        return this;
+      }),
+    } as unknown as Redis;
+
+    await expect(runUserStateTransitionLua(failingRedis, buildInput())).rejects.toThrow(error);
+  });
+
+  it('양수 세션 TTL을 갱신하지 않고 보존함', async () => {
+    const input = buildInput();
+    await redis.set(input.sessionKey, JSON.stringify(baseSession), 'PX', 5000);
+    const before = await redis.pttl(input.sessionKey);
+
+    await runUserStateTransitionLua(redis, input);
+
+    const after = await redis.pttl(input.sessionKey);
+    expect(before).toBeGreaterThan(0);
+    expect(after).toBeGreaterThan(0);
+    expect(after).toBeLessThanOrEqual(before);
+    expect(after).toBeLessThanOrEqual(5000);
+  });
+
+  it('만료 없는 세션은 전이 후에도 만료 없음으로 유지함', async () => {
+    const input = buildInput();
+    await redis.set(input.sessionKey, JSON.stringify(baseSession));
+
+    await runUserStateTransitionLua(redis, input);
+
+    expect(await redis.ttl(input.sessionKey)).toBe(-1);
+  });
+
+  it('SESSION_EXPIRED_DURING_WRITE를 타입화된 거부 결과로 매핑함', async () => {
+    const expiringRedis = {
+      defineCommand: jest.fn(function (this: RedisWithStubbedCommand, name: string) {
+        this[name as 'userStateTransition'] = jest
+          .fn()
+          .mockResolvedValue(['SESSION_EXPIRED_DURING_WRITE']);
+        return this;
+      }),
+    } as unknown as Redis;
+
+    await expect(runUserStateTransitionLua(expiringRedis, buildInput())).resolves.toMatchObject({
+      ok: false,
+      code: 'SESSION_EXPIRED_DURING_WRITE',
+    });
+  });
+
+  it('같은 Redis 인스턴스에서는 Lua 명령을 한 번만 등록함', async () => {
+    const input = buildInput();
+    await redis.set(input.sessionKey, JSON.stringify(baseSession));
+    await runUserStateTransitionLua(redis, input);
+    await redis.set(input.sessionKey, JSON.stringify(baseSession));
+
+    await runUserStateTransitionLua(redis, input);
+
+    expect(defineCommandSpy).toHaveBeenCalledTimes(1);
+    expect(defineCommandSpy).toHaveBeenCalledWith('userStateTransition', {
+      numberOfKeys: 1,
+      lua: expect.stringContaining('local session = cjson.decode(raw)'),
+    });
+  });
+
+  it('Lua 소스에서 mock JSON fallback과 직접 eval 호출을 제거함', () => {
+    const source = readFileSync(join(__dirname, 'userStateTransitionLua.ts'), 'utf8');
+    const removedHotPathTerms = [
+      'MALFORMED_' + 'SESSION',
+      'MOCK_JSON_' + 'NULL',
+      'decodeSession' + 'Json',
+      'replaceJson' + 'Field',
+      'has' + 'Cjson',
+    ];
+
+    for (const removedTerm of removedHotPathTerms) {
+      expect(source).not.toContain(removedTerm);
+    }
+    expect(source).not.toMatch(/redis\.eval\(\s*userStateTransitionLua/);
+    expect(source).toContain("redis.defineCommand('userStateTransition'");
+    expect(source).toContain("return {'OK'}");
+  });
+
+  it('0 PTTL을 만료 없는 세션 분기로 처리하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'userStateTransitionLua.ts'), 'utf8');
+
+    expect(source).toContain('if ttl == -2 or ttl == 0 then');
+    expect(source).toContain('elseif ttl == -1 then');
+  });
+});

--- a/back/src/auth/luaScripts/userStateTransitionLua.spec.ts
+++ b/back/src/auth/luaScripts/userStateTransitionLua.spec.ts
@@ -76,8 +76,7 @@ async function emulateUserStateTransitionCommand(
   }
 
   if (expectedTargetEventMode !== 'none') {
-    const expectedTargetEvent =
-      expectedTargetEventMode === 'null' ? null : Number(expectedTargetEventValue);
+    const expectedTargetEvent = expectedTargetEventMode === 'null' ? null : Number(expectedTargetEventValue);
 
     if (session.targetEvent !== expectedTargetEvent) {
       return ['TARGET_EVENT_MISMATCH', session.targetEvent];
@@ -325,9 +324,7 @@ describe('runUserStateTransitionLua 실행', () => {
   it('SESSION_EXPIRED_DURING_WRITE를 타입화된 거부 결과로 매핑함', async () => {
     const expiringRedis = {
       defineCommand: jest.fn(function (this: RedisWithStubbedCommand, name: string) {
-        this[name as 'userStateTransition'] = jest
-          .fn()
-          .mockResolvedValue(['SESSION_EXPIRED_DURING_WRITE']);
+        this[name as 'userStateTransition'] = jest.fn().mockResolvedValue(['SESSION_EXPIRED_DURING_WRITE']);
         return this;
       }),
     } as unknown as Redis;
@@ -371,10 +368,13 @@ describe('runUserStateTransitionLua 실행', () => {
     expect(source).toContain("return {'OK'}");
   });
 
-  it('0 PTTL을 만료 없는 세션 분기로 처리하지 않음', () => {
+  it('TTL 보존 쓰기를 자체 구현하지 않고 공용 helper에 위임함', () => {
     const source = readFileSync(join(__dirname, 'userStateTransitionLua.ts'), 'utf8');
 
-    expect(source).toContain('if ttl == -2 or ttl == 0 then');
-    expect(source).toContain('elseif ttl == -1 then');
+    expect(source).toContain('sessionWriteLuaHelpers');
+    expect(source).toContain('prepareSessionWrite(sessionKey, session)');
+    expect(source).toContain('writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)');
+    expect(source).not.toContain("redis.call('PSETEX'");
+    expect(source).not.toContain("redis.call('PTTL'");
   });
 });

--- a/back/src/auth/luaScripts/userStateTransitionLua.ts
+++ b/back/src/auth/luaScripts/userStateTransitionLua.ts
@@ -7,7 +7,11 @@ import {
   type LuaUserStateTransitionResult,
 } from '../fsm/user-state-transition.contract';
 
+import { sessionWriteLuaHelpers } from './sessionLuaHelpers';
+
 const userStateTransitionLua = `
+  ${sessionWriteLuaHelpers}
+
   local sessionKey = KEYS[1]
 
   local expectedFromMode = ARGV[1]
@@ -50,19 +54,12 @@ const userStateTransitionLua = `
     session.targetEvent = cjson.null
   end
 
-  local encodedSession = cjson.encode(session)
-  local ttl = redis.call('PTTL', sessionKey)
-  if ttl == -2 or ttl == 0 then
-    return {'SESSION_EXPIRED_DURING_WRITE'}
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
   end
 
-  if ttl > 0 then
-    redis.call('PSETEX', sessionKey, ttl, encodedSession)
-  elseif ttl == -1 then
-    redis.call('SET', sessionKey, encodedSession)
-  else
-    return {'SESSION_EXPIRED_DURING_WRITE'}
-  end
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
 
   return {'OK'}
 `;

--- a/back/src/auth/luaScripts/userStateTransitionLua.ts
+++ b/back/src/auth/luaScripts/userStateTransitionLua.ts
@@ -1,0 +1,150 @@
+import Redis from 'ioredis';
+
+import {
+  mapLuaUserStateTransitionResult,
+  type LuaUserStateTransitionInput,
+  type LuaUserStateTransitionRawResult,
+  type LuaUserStateTransitionResult,
+} from '../fsm/user-state-transition.contract';
+
+const userStateTransitionLua = `
+  local sessionKey = KEYS[1]
+
+  local expectedFromMode = ARGV[1]
+  local expectedFromValue = ARGV[2]
+  local nextTo = ARGV[3]
+  local targetEventPatchMode = ARGV[4]
+  local targetEventPatchValue = ARGV[5]
+  local expectedTargetEventMode = ARGV[6]
+  local expectedTargetEventValue = ARGV[7]
+
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    return {'SESSION_MISSING'}
+  end
+
+  local session = cjson.decode(raw)
+
+  if expectedFromMode == 'value' and session.userStatus ~= expectedFromValue then
+    return {'STATE_MISMATCH', session.userStatus}
+  end
+
+  if expectedTargetEventMode ~= 'none' then
+    if expectedTargetEventMode == 'null' then
+      if session.targetEvent ~= cjson.null then
+        return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+      end
+    else
+      local expectedTargetEvent = tonumber(expectedTargetEventValue)
+      if session.targetEvent ~= expectedTargetEvent then
+        return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+      end
+    end
+  end
+
+  session.userStatus = nextTo
+
+  if targetEventPatchMode == 'set' then
+    session.targetEvent = tonumber(targetEventPatchValue)
+  elseif targetEventPatchMode == 'clear' then
+    session.targetEvent = cjson.null
+  end
+
+  local encodedSession = cjson.encode(session)
+  local ttl = redis.call('PTTL', sessionKey)
+  if ttl == -2 or ttl == 0 then
+    return {'SESSION_EXPIRED_DURING_WRITE'}
+  end
+
+  if ttl > 0 then
+    redis.call('PSETEX', sessionKey, ttl, encodedSession)
+  elseif ttl == -1 then
+    redis.call('SET', sessionKey, encodedSession)
+  else
+    return {'SESSION_EXPIRED_DURING_WRITE'}
+  end
+
+  return {'OK'}
+`;
+
+type RedisWithUserStateTransitionCommand = Redis & {
+  userStateTransition(
+    sessionKey: string,
+    expectedFromMode: string,
+    expectedFromValue: string,
+    nextTo: string,
+    targetEventPatchMode: string,
+    targetEventPatchValue: string,
+    expectedTargetEventMode: string,
+    expectedTargetEventValue: string,
+  ): Promise<LuaUserStateTransitionRawResult>;
+};
+
+const commandRegisteredRedisSet = new WeakSet<object>();
+
+function getUserStateTransitionCommandRedis(redis: Redis): RedisWithUserStateTransitionCommand {
+  if (!commandRegisteredRedisSet.has(redis)) {
+    redis.defineCommand('userStateTransition', {
+      numberOfKeys: 1,
+      lua: userStateTransitionLua,
+    });
+    commandRegisteredRedisSet.add(redis);
+  }
+
+  return redis as RedisWithUserStateTransitionCommand;
+}
+
+function getExpectedFromArgs(input: LuaUserStateTransitionInput): [string, string] {
+  if (input.expectedFrom === undefined) {
+    return ['none', ''];
+  }
+
+  return ['value', input.expectedFrom];
+}
+
+function getTargetEventPatchArgs(input: LuaUserStateTransitionInput): [string, string] {
+  if (input.targetEventPatch.mode === 'set') {
+    return ['set', String(input.targetEventPatch.eventId)];
+  }
+
+  return [input.targetEventPatch.mode, ''];
+}
+
+function getExpectedTargetEventArgs(input: LuaUserStateTransitionInput): [string, string] {
+  if (input.expectedTargetEvent === undefined) {
+    return ['none', ''];
+  }
+
+  if (input.expectedTargetEvent === null) {
+    return ['null', ''];
+  }
+
+  return ['number', String(input.expectedTargetEvent)];
+}
+
+export async function runUserStateTransitionLua(
+  redis: Redis,
+  input: LuaUserStateTransitionInput,
+): Promise<LuaUserStateTransitionResult> {
+  const [expectedFromMode, expectedFromValue] = getExpectedFromArgs(input);
+  const [targetEventPatchMode, targetEventPatchValue] = getTargetEventPatchArgs(input);
+  const [expectedTargetEventMode, expectedTargetEventValue] = getExpectedTargetEventArgs(input);
+  const commandRedis = getUserStateTransitionCommandRedis(redis);
+
+  const rawResult = await commandRedis.userStateTransition(
+    input.sessionKey,
+    expectedFromMode,
+    expectedFromValue,
+    input.nextTo,
+    targetEventPatchMode,
+    targetEventPatchValue,
+    expectedTargetEventMode,
+    expectedTargetEventValue,
+  );
+
+  return mapLuaUserStateTransitionResult(rawResult, {
+    action: input.action,
+    expectedFrom: input.expectedFrom,
+    nextTo: input.nextTo,
+  });
+}

--- a/back/src/auth/service/auth.service.spec.ts
+++ b/back/src/auth/service/auth.service.spec.ts
@@ -1,9 +1,12 @@
 import * as bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 
+import { AppException } from '../../common/exception/app.exception';
 import { USER_ROLE } from '../../domains/user/const/userRole';
 import { AUTH_EXPIRE_TIME } from '../const/authExpireTime.const';
+import { AuthErrorCode } from '../exception/auth-error-code';
 import { USER_STATUS } from '../fsm/user-state.fsm';
+import { runUserStateTransitionLua } from '../luaScripts/userStateTransitionLua';
 
 import { AuthService } from './auth.service';
 
@@ -13,6 +16,10 @@ jest.mock('bcryptjs', () => ({
 
 jest.mock('uuid', () => ({
   v4: jest.fn(),
+}));
+
+jest.mock('../luaScripts/userStateTransitionLua', () => ({
+  runUserStateTransitionLua: jest.fn(),
 }));
 
 type SessionFixture = {
@@ -95,8 +102,12 @@ beforeEach(() => {
   (uuidv4 as jest.Mock).mockReturnValue('session-1');
 });
 
-describe('AuthService FSM session transitions', () => {
-  it('writes a valid semantic transition with existing fields and KEEPTTL preserved', async () => {
+const mockedRunUserStateTransitionLua = runUserStateTransitionLua as jest.MockedFunction<
+  typeof runUserStateTransitionLua
+>;
+
+describe('AuthService FSM 세션 전이', () => {
+  it('enterWaiting은 set targetEvent 패치 모드로 Lua를 호출함', async () => {
     const session = {
       id: 1,
       loginId: 'user1',
@@ -105,29 +116,179 @@ describe('AuthService FSM session transitions', () => {
       nickname: 'kept',
     };
     const { service, redis, multi } = createService(session);
-
-    await expect(service.enterBookingGate('sid-1', 7)).resolves.toEqual({
+    mockedRunUserStateTransitionLua.mockResolvedValue({
       ok: true,
-      action: 'enterBookingGate',
+      code: 'OK',
+      action: 'enterWaiting',
       from: USER_STATUS.LOGIN,
+      to: USER_STATUS.WAITING,
+    });
+
+    await expect(service.enterWaiting('sid-1', 7)).resolves.toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'enterWaiting',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.WAITING,
+    });
+
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+      targetEventPatch: { mode: 'set', eventId: 7 },
+      expectedTargetEvent: null,
+    });
+    expect(redis.watch).not.toHaveBeenCalled();
+    expect(multi.set).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('enterBookingGate는 targetEvent를 유지하고 WAITING 시작 상태로 Lua를 호출함', async () => {
+    const { service, redis, multi } = createService({
+      id: 1,
+      loginId: 'user1',
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: 7,
+    });
+    mockedRunUserStateTransitionLua.mockResolvedValue({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      from: USER_STATUS.WAITING,
       to: USER_STATUS.ENTERING,
     });
 
-    expect(redis.watch).toHaveBeenCalledWith('user:sid-1');
-    expect(multi.set).toHaveBeenCalledWith(
-      'user:sid-1',
-      JSON.stringify({ ...session, targetEvent: 7, userStatus: USER_STATUS.ENTERING }),
-      'KEEPTTL',
-    );
-    expect(multi.exec).toHaveBeenCalledTimes(1);
-    expect(redis.set).not.toHaveBeenCalled();
+    await expect(service.enterBookingGate('sid-1')).resolves.toMatchObject({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      from: USER_STATUS.WAITING,
+      to: USER_STATUS.ENTERING,
+    });
+
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.ENTERING,
+      targetEventPatch: { mode: 'preserve' },
+      expectedTargetEvent: 7,
+    });
+    expect(multi.set).not.toHaveBeenCalled();
+  });
+
+  it('WAITING에서 예매 진입 시 호출자 event를 expectedTargetEvent로 전달함', async () => {
+    const { service, redis } = createService({
+      id: 1,
+      loginId: 'user1',
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: 8,
+    });
+    mockedRunUserStateTransitionLua.mockResolvedValue({
+      ok: false,
+      code: 'TARGET_EVENT_MISMATCH',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.ENTERING,
+      details: [8],
+    });
+
+    await expect(service.enterBookingGate('sid-1', 7)).resolves.toEqual({
+      ok: false,
+      code: 'TARGET_EVENT_MISMATCH',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.ENTERING,
+      details: [8],
+    });
+
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.ENTERING,
+      targetEventPatch: { mode: 'set', eventId: 7 },
+      expectedTargetEvent: 7,
+    });
+  });
+
+  it.each([
+    ['startSeatSelection', USER_STATUS.ENTERING, USER_STATUS.SELECTING_SEAT],
+    ['markReconnectingSelection', USER_STATUS.SELECTING_SEAT, USER_STATUS.RECONNECTING_SELECTING],
+    ['restoreSeatSelection', USER_STATUS.RECONNECTING_SELECTING, USER_STATUS.SELECTING_SEAT],
+  ] as const)('%s는 targetEvent를 유지하며 Lua를 호출함', async (methodName, from, to) => {
+    const { service, redis } = createService({
+      id: 1,
+      loginId: 'user1',
+      userStatus: from,
+      targetEvent: 7,
+    });
+    mockedRunUserStateTransitionLua.mockResolvedValue({
+      ok: true,
+      code: 'OK',
+      action: methodName,
+      from,
+      to,
+    });
+
+    await expect(service[methodName]('sid-1')).resolves.toMatchObject({
+      ok: true,
+      code: 'OK',
+      action: methodName,
+      from,
+      to,
+    });
+
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      action: methodName,
+      expectedFrom: from,
+      nextTo: to,
+      targetEventPatch: { mode: 'preserve' },
+      expectedTargetEvent: 7,
+    });
+  });
+
+  it('skipExpectedFromCheck가 명시되면 현재 상태 비교 없이 Lua 입력을 생성함', async () => {
+    const { service, redis, multi } = createService({
+      id: 1,
+      loginId: 'user1',
+      userStatus: USER_STATUS.SELECTING_SEAT,
+      targetEvent: 7,
+    });
+    mockedRunUserStateTransitionLua.mockResolvedValue({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      to: USER_STATUS.ENTERING,
+    });
+
+    await expect(
+      service.enterBookingGate('sid-1', 7, { skipExpectedFromCheck: true }),
+    ).resolves.toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      to: USER_STATUS.ENTERING,
+    });
+
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      action: 'enterBookingGate',
+      nextTo: USER_STATUS.ENTERING,
+      targetEventPatch: { mode: 'set', eventId: 7 },
+      expectedTargetEvent: 7,
+    });
+    expect(multi.set).not.toHaveBeenCalled();
   });
 
   it.each([
     [USER_STATUS.SELECTING_SEAT, 'INVALID_TRANSITION'],
     ['ADMIN', 'UNKNOWN_STATE'],
     ['BROKEN_STATE', 'UNKNOWN_STATE'],
-  ])('does not write for rejected transition from %s', async (userStatus, reason) => {
+  ])('%s에서 거부된 전이는 세션을 쓰지 않음', async (userStatus, reason) => {
     const { service, redis, multi } = createService({
       id: 1,
       loginId: 'user1',
@@ -143,13 +304,15 @@ describe('AuthService FSM session transitions', () => {
       reason,
     });
 
-    expect(redis.unwatch).toHaveBeenCalledTimes(1);
+    expect(redis.unwatch).not.toHaveBeenCalled();
     expect(multi.set).not.toHaveBeenCalled();
     expect(multi.exec).not.toHaveBeenCalled();
     expect(redis.set).not.toHaveBeenCalled();
+    expect(mockedRunUserStateTransitionLua).not.toHaveBeenCalled();
   });
 
-  it('returns null when Redis CAS commit is lost', async () => {
+  it('option 기반 예매 콜백 전이는 임시 WATCH 호환 경로를 유지함', async () => {
+    const validate = jest.fn().mockResolvedValue(true);
     const { service, multi } = createService(
       {
         id: 1,
@@ -160,7 +323,12 @@ describe('AuthService FSM session transitions', () => {
       null,
     );
 
-    await expect(service.enterWaiting('sid-1', 3)).resolves.toBeNull();
+    await expect(
+      service.enterWaiting('sid-1', 3, {
+        watchKeys: ['waiting-queue:3'],
+        validate,
+      }),
+    ).resolves.toBeNull();
 
     expect(multi.set).toHaveBeenCalledWith(
       'user:sid-1',
@@ -168,9 +336,10 @@ describe('AuthService FSM session transitions', () => {
       'KEEPTTL',
     );
     expect(multi.exec).toHaveBeenCalledTimes(1);
+    expect(mockedRunUserStateTransitionLua).not.toHaveBeenCalled();
   });
 
-  it('throws when Redis EXEC contains a command-level error', async () => {
+  it('Redis EXEC에 명령 단위 오류가 있으면 throw함', async () => {
     const commandError = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
     const session = {
       id: 1,
@@ -202,7 +371,7 @@ describe('AuthService FSM session transitions', () => {
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('WRONGTYPE Operation'));
   });
 
-  it('does not write session or side effects when a watched transition validation fails', async () => {
+  it('WATCH 기반 전이 검증이 실패하면 세션과 부수 효과를 쓰지 않음', async () => {
     const validate = jest.fn().mockResolvedValue(false);
     const mutate = jest.fn();
     const { service, redis, multi } = createService({
@@ -227,7 +396,7 @@ describe('AuthService FSM session transitions', () => {
     expect(multi.exec).not.toHaveBeenCalled();
   });
 
-  it('does not expose legacy setUserStatus compatibility wrappers', () => {
+  it('기존 setUserStatus 호환 wrapper를 노출하지 않음', () => {
     const { service } = createService(null);
     const legacyWrapperNames = [
       'setUserStatusLogin',
@@ -243,32 +412,92 @@ describe('AuthService FSM session transitions', () => {
     }
   });
 
-  it('semantic login reset writes explicit null targetEvent with KEEPTTL', async () => {
+  it('raw setUserEventTarget 세션 패치를 노출하지 않음', () => {
+    const { service } = createService(null);
+
+    expect('setUserEventTarget' in service).toBe(false);
+    expect('getUserEventTarget' in service).toBe(true);
+  });
+
+  it('의미 기반 login reset은 명시적인 null targetEvent를 KEEPTTL로 전달함', async () => {
     const session = {
       id: 1,
       loginId: 'user1',
       userStatus: USER_STATUS.SELECTING_SEAT,
       targetEvent: 7,
     };
-    const { service, multi } = createService(session);
-
-    await expect(service.resetToLogin('sid-1', null)).resolves.toEqual({
+    const { service, redis, multi } = createService(session);
+    mockedRunUserStateTransitionLua.mockResolvedValue({
       ok: true,
+      code: 'OK',
       action: 'resetToLogin',
       from: USER_STATUS.SELECTING_SEAT,
       to: USER_STATUS.LOGIN,
     });
 
-    expect(multi.set).toHaveBeenCalledWith(
-      'user:sid-1',
-      JSON.stringify({ ...session, targetEvent: null, userStatus: USER_STATUS.LOGIN }),
-      'KEEPTTL',
+    await expect(service.resetToLogin('sid-1', null)).resolves.toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'resetToLogin',
+      from: USER_STATUS.SELECTING_SEAT,
+      to: USER_STATUS.LOGIN,
+    });
+
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      action: 'resetToLogin',
+      expectedFrom: USER_STATUS.SELECTING_SEAT,
+      nextTo: USER_STATUS.LOGIN,
+      targetEventPatch: { mode: 'clear' },
+      expectedTargetEvent: 7,
+    });
+    expect(multi.set).not.toHaveBeenCalled();
+  });
+
+  it('Redis Lua 인프라 실패를 로그로 남기고 다시 throw함', async () => {
+    const error = new Error('ERR Error running script');
+    const { service, logger } = createService({
+      id: 1,
+      loginId: 'user1',
+      userStatus: USER_STATUS.LOGIN,
+      targetEvent: null,
+    });
+    mockedRunUserStateTransitionLua.mockRejectedValue(error);
+
+    await expect(service.enterWaiting('sid-1', 7)).rejects.toThrow(error.message);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Redis Lua user state transition failed during enterWaiting'),
     );
   });
 });
 
-describe('AuthService session role persistence', () => {
-  it('stores explicit USER role membership for normal registered users', async () => {
+describe('AuthService 세션 역할 저장', () => {
+  it('비밀번호 검증이 실패하면 기존 세션을 제거하지 않음', async () => {
+    const { service, redis, userRepository } = createService(null);
+    redis.get.mockResolvedValue('old-session');
+    userRepository.findOne.mockResolvedValue({
+      id: 1,
+      loginId: 'user1',
+      loginPassword: 'hashed',
+      role: USER_ROLE.USER,
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    try {
+      await service.validateUser('user1', 'wrong-password');
+      throw new Error('validateUser가 실패해야 함');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppException);
+      expect((error as AppException).getCode()).toBe(AuthErrorCode.INVALID_CREDENTIALS);
+    }
+
+    expect(redis.unlink).not.toHaveBeenCalledWith('user:old-session');
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(redis.zadd).not.toHaveBeenCalled();
+  });
+
+  it('일반 가입 사용자는 USER 역할을 명시적으로 저장함', async () => {
     const { service, redis, userRepository } = createService(null);
     userRepository.findOne.mockResolvedValue({
       id: 1,
@@ -291,7 +520,7 @@ describe('AuthService session role persistence', () => {
     });
   });
 
-  it('stores explicit USER and ADMIN role membership for admin users', async () => {
+  it('관리자는 USER와 ADMIN 역할을 명시적으로 저장함', async () => {
     const { service, redis, userRepository } = createService(null);
     userRepository.findOne.mockResolvedValue({
       id: 2,
@@ -314,7 +543,7 @@ describe('AuthService session role persistence', () => {
     });
   });
 
-  it('stores explicit USER role membership for guest users', async () => {
+  it('게스트 사용자는 USER 역할을 명시적으로 저장함', async () => {
     const { service, redis, userRepository } = createService(null);
     userRepository.save.mockResolvedValue({
       id: 3,

--- a/back/src/auth/service/auth.service.spec.ts
+++ b/back/src/auth/service/auth.service.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 import * as bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -265,9 +268,7 @@ describe('AuthService FSM 세션 전이', () => {
       to: USER_STATUS.ENTERING,
     });
 
-    await expect(
-      service.enterBookingGate('sid-1', 7, { skipExpectedFromCheck: true }),
-    ).resolves.toEqual({
+    await expect(service.enterBookingGate('sid-1', 7, { skipExpectedFromCheck: true })).resolves.toEqual({
       ok: true,
       code: 'OK',
       action: 'enterBookingGate',
@@ -311,89 +312,37 @@ describe('AuthService FSM 세션 전이', () => {
     expect(mockedRunUserStateTransitionLua).not.toHaveBeenCalled();
   });
 
-  it('option 기반 예매 콜백 전이는 임시 WATCH 호환 경로를 유지함', async () => {
-    const validate = jest.fn().mockResolvedValue(true);
-    const { service, multi } = createService(
-      {
-        id: 1,
-        loginId: 'user1',
-        userStatus: USER_STATUS.LOGIN,
-        targetEvent: null,
-      },
-      null,
-    );
-
-    await expect(
-      service.enterWaiting('sid-1', 3, {
-        watchKeys: ['waiting-queue:3'],
-        validate,
-      }),
-    ).resolves.toBeNull();
-
-    expect(multi.set).toHaveBeenCalledWith(
-      'user:sid-1',
-      JSON.stringify({ id: 1, loginId: 'user1', userStatus: USER_STATUS.WAITING, targetEvent: 3 }),
-      'KEEPTTL',
-    );
-    expect(multi.exec).toHaveBeenCalledTimes(1);
-    expect(mockedRunUserStateTransitionLua).not.toHaveBeenCalled();
-  });
-
-  it('Redis EXEC에 명령 단위 오류가 있으면 throw함', async () => {
-    const commandError = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
-    const session = {
-      id: 1,
-      loginId: 'user1',
-      userStatus: USER_STATUS.LOGIN,
-      targetEvent: null,
-    };
-    const { service, logger, multi } = createService(session, [
-      [null, 1],
-      [commandError, null],
-    ]);
-
-    await expect(
-      service.enterBookingGate('sid-1', 7, {
-        watchKeys: ['entering:7'],
-        mutate: (multi) => {
-          multi.zadd('entering:7', 1234, 'sid-1');
-        },
-      }),
-    ).rejects.toThrow(commandError.message);
-
-    expect(multi.zadd).toHaveBeenCalledWith('entering:7', 1234, 'sid-1');
-    expect(multi.set).toHaveBeenCalledWith(
-      'user:sid-1',
-      JSON.stringify({ ...session, targetEvent: 7, userStatus: USER_STATUS.ENTERING }),
-      'KEEPTTL',
-    );
-    expect(multi.exec).toHaveBeenCalledTimes(1);
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('WRONGTYPE Operation'));
-  });
-
-  it('WATCH 기반 전이 검증이 실패하면 세션과 부수 효과를 쓰지 않음', async () => {
-    const validate = jest.fn().mockResolvedValue(false);
-    const mutate = jest.fn();
+  it('모든 전이가 Lua runner를 거치고 WATCH 트랜잭션을 열지 않음', async () => {
     const { service, redis, multi } = createService({
       id: 1,
       loginId: 'user1',
       userStatus: USER_STATUS.LOGIN,
       targetEvent: null,
     });
+    mockedRunUserStateTransitionLua.mockResolvedValue({
+      ok: true,
+      code: 'OK',
+      action: 'enterWaiting',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.WAITING,
+    });
 
-    await expect(
-      service.enterBookingGate('sid-1', 7, {
-        watchKeys: ['entering:7'],
-        validate,
-        mutate,
-      }),
-    ).resolves.toBeNull();
+    await service.enterWaiting('sid-1', 3);
 
-    expect(redis.watch).toHaveBeenCalledWith('user:sid-1', 'entering:7');
-    expect(validate).toHaveBeenCalledTimes(1);
-    expect(mutate).not.toHaveBeenCalled();
-    expect(multi.set).not.toHaveBeenCalled();
+    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledTimes(1);
+    expect(redis.watch).not.toHaveBeenCalled();
+    expect(redis.duplicate).not.toHaveBeenCalled();
     expect(multi.exec).not.toHaveBeenCalled();
+  });
+
+  it('AuthService에는 WATCH 기반 전이 경로가 남아 있지 않음', () => {
+    const source = readFileSync(join(__dirname, 'auth.service.ts'), 'utf8');
+
+    expect(source).not.toContain('executeWatchedUserStateTransition');
+    expect(source).not.toContain('watchKeys');
+    expect(source).not.toContain('.duplicate()');
+    expect(source).not.toContain('redis.watch');
+    expect(source).not.toContain("'KEEPTTL'");
   });
 
   it('기존 setUserStatus 호환 wrapper를 노출하지 않음', () => {

--- a/back/src/auth/service/auth.service.spec.ts
+++ b/back/src/auth/service/auth.service.spec.ts
@@ -110,148 +110,70 @@ const mockedRunUserStateTransitionLua = runUserStateTransitionLua as jest.Mocked
 >;
 
 describe('AuthService FSM 세션 전이', () => {
-  it('enterWaiting은 set targetEvent 패치 모드로 Lua를 호출함', async () => {
+  it('숫자 targetEvent는 set 패치 모드로 Lua에 전달함', async () => {
     const session = {
       id: 1,
       loginId: 'user1',
-      userStatus: USER_STATUS.LOGIN,
-      targetEvent: null,
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: 7,
       nickname: 'kept',
     };
     const { service, redis, multi } = createService(session);
     mockedRunUserStateTransitionLua.mockResolvedValue({
       ok: true,
       code: 'OK',
-      action: 'enterWaiting',
-      from: USER_STATUS.LOGIN,
-      to: USER_STATUS.WAITING,
+      action: 'resetToLogin',
+      from: USER_STATUS.WAITING,
+      to: USER_STATUS.LOGIN,
     });
 
-    await expect(service.enterWaiting('sid-1', 7)).resolves.toEqual({
+    await expect(service.resetToLogin('sid-1', 7)).resolves.toEqual({
       ok: true,
       code: 'OK',
-      action: 'enterWaiting',
-      from: USER_STATUS.LOGIN,
-      to: USER_STATUS.WAITING,
+      action: 'resetToLogin',
+      from: USER_STATUS.WAITING,
+      to: USER_STATUS.LOGIN,
     });
 
     expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
       sessionKey: 'user:sid-1',
-      action: 'enterWaiting',
-      expectedFrom: USER_STATUS.LOGIN,
-      nextTo: USER_STATUS.WAITING,
+      action: 'resetToLogin',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.LOGIN,
       targetEventPatch: { mode: 'set', eventId: 7 },
-      expectedTargetEvent: null,
+      expectedTargetEvent: 7,
     });
     expect(redis.watch).not.toHaveBeenCalled();
     expect(multi.set).not.toHaveBeenCalled();
     expect(redis.set).not.toHaveBeenCalled();
   });
 
-  it('enterBookingGate는 targetEvent를 유지하고 WAITING 시작 상태로 Lua를 호출함', async () => {
+  it('targetEvent를 생략하면 preserve 패치 모드로 현재 값을 기대값으로 전달함', async () => {
     const { service, redis, multi } = createService({
       id: 1,
       loginId: 'user1',
-      userStatus: USER_STATUS.WAITING,
+      userStatus: USER_STATUS.ENTERING,
       targetEvent: 7,
     });
     mockedRunUserStateTransitionLua.mockResolvedValue({
       ok: true,
       code: 'OK',
-      action: 'enterBookingGate',
-      from: USER_STATUS.WAITING,
-      to: USER_STATUS.ENTERING,
+      action: 'resetToLogin',
+      from: USER_STATUS.ENTERING,
+      to: USER_STATUS.LOGIN,
     });
 
-    await expect(service.enterBookingGate('sid-1')).resolves.toMatchObject({
-      ok: true,
-      code: 'OK',
-      action: 'enterBookingGate',
-      from: USER_STATUS.WAITING,
-      to: USER_STATUS.ENTERING,
-    });
+    await expect(service.resetToLogin('sid-1')).resolves.toMatchObject({ ok: true, code: 'OK' });
 
     expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
       sessionKey: 'user:sid-1',
-      action: 'enterBookingGate',
-      expectedFrom: USER_STATUS.WAITING,
-      nextTo: USER_STATUS.ENTERING,
+      action: 'resetToLogin',
+      expectedFrom: USER_STATUS.ENTERING,
+      nextTo: USER_STATUS.LOGIN,
       targetEventPatch: { mode: 'preserve' },
       expectedTargetEvent: 7,
     });
     expect(multi.set).not.toHaveBeenCalled();
-  });
-
-  it('WAITING에서 예매 진입 시 호출자 event를 expectedTargetEvent로 전달함', async () => {
-    const { service, redis } = createService({
-      id: 1,
-      loginId: 'user1',
-      userStatus: USER_STATUS.WAITING,
-      targetEvent: 8,
-    });
-    mockedRunUserStateTransitionLua.mockResolvedValue({
-      ok: false,
-      code: 'TARGET_EVENT_MISMATCH',
-      action: 'enterBookingGate',
-      expectedFrom: USER_STATUS.WAITING,
-      nextTo: USER_STATUS.ENTERING,
-      details: [8],
-    });
-
-    await expect(service.enterBookingGate('sid-1', 7)).resolves.toEqual({
-      ok: false,
-      code: 'TARGET_EVENT_MISMATCH',
-      action: 'enterBookingGate',
-      expectedFrom: USER_STATUS.WAITING,
-      nextTo: USER_STATUS.ENTERING,
-      details: [8],
-    });
-
-    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
-      sessionKey: 'user:sid-1',
-      action: 'enterBookingGate',
-      expectedFrom: USER_STATUS.WAITING,
-      nextTo: USER_STATUS.ENTERING,
-      targetEventPatch: { mode: 'set', eventId: 7 },
-      expectedTargetEvent: 7,
-    });
-  });
-
-  it.each([
-    ['startSeatSelection', USER_STATUS.ENTERING, USER_STATUS.SELECTING_SEAT],
-    ['markReconnectingSelection', USER_STATUS.SELECTING_SEAT, USER_STATUS.RECONNECTING_SELECTING],
-    ['restoreSeatSelection', USER_STATUS.RECONNECTING_SELECTING, USER_STATUS.SELECTING_SEAT],
-  ] as const)('%s는 targetEvent를 유지하며 Lua를 호출함', async (methodName, from, to) => {
-    const { service, redis } = createService({
-      id: 1,
-      loginId: 'user1',
-      userStatus: from,
-      targetEvent: 7,
-    });
-    mockedRunUserStateTransitionLua.mockResolvedValue({
-      ok: true,
-      code: 'OK',
-      action: methodName,
-      from,
-      to,
-    });
-
-    await expect(service[methodName]('sid-1')).resolves.toMatchObject({
-      ok: true,
-      code: 'OK',
-      action: methodName,
-      from,
-      to,
-    });
-
-    expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
-      sessionKey: 'user:sid-1',
-      action: methodName,
-      expectedFrom: from,
-      nextTo: to,
-      targetEventPatch: { mode: 'preserve' },
-      expectedTargetEvent: 7,
-    });
   });
 
   it('skipExpectedFromCheck가 명시되면 현재 상태 비교 없이 Lua 입력을 생성함', async () => {
@@ -264,21 +186,21 @@ describe('AuthService FSM 세션 전이', () => {
     mockedRunUserStateTransitionLua.mockResolvedValue({
       ok: true,
       code: 'OK',
-      action: 'enterBookingGate',
-      to: USER_STATUS.ENTERING,
+      action: 'resetToLogin',
+      to: USER_STATUS.LOGIN,
     });
 
-    await expect(service.enterBookingGate('sid-1', 7, { skipExpectedFromCheck: true })).resolves.toEqual({
+    await expect(service.resetToLogin('sid-1', 7, { skipExpectedFromCheck: true })).resolves.toEqual({
       ok: true,
       code: 'OK',
-      action: 'enterBookingGate',
-      to: USER_STATUS.ENTERING,
+      action: 'resetToLogin',
+      to: USER_STATUS.LOGIN,
     });
 
     expect(mockedRunUserStateTransitionLua).toHaveBeenCalledWith(redis, {
       sessionKey: 'user:sid-1',
-      action: 'enterBookingGate',
-      nextTo: USER_STATUS.ENTERING,
+      action: 'resetToLogin',
+      nextTo: USER_STATUS.LOGIN,
       targetEventPatch: { mode: 'set', eventId: 7 },
       expectedTargetEvent: 7,
     });
@@ -286,7 +208,7 @@ describe('AuthService FSM 세션 전이', () => {
   });
 
   it.each([
-    [USER_STATUS.SELECTING_SEAT, 'INVALID_TRANSITION'],
+    [USER_STATUS.LOGIN, 'INVALID_TRANSITION'],
     ['ADMIN', 'UNKNOWN_STATE'],
     ['BROKEN_STATE', 'UNKNOWN_STATE'],
   ])('%s에서 거부된 전이는 세션을 쓰지 않음', async (userStatus, reason) => {
@@ -297,42 +219,56 @@ describe('AuthService FSM 세션 전이', () => {
       targetEvent: 7,
     });
 
-    await expect(service.enterBookingGate('sid-1', 8)).resolves.toEqual({
+    await expect(service.resetToLogin('sid-1', 8)).resolves.toEqual({
       ok: false,
-      action: 'enterBookingGate',
+      action: 'resetToLogin',
       from: userStatus,
-      to: USER_STATUS.ENTERING,
+      to: USER_STATUS.LOGIN,
       reason,
     });
 
-    expect(redis.unwatch).not.toHaveBeenCalled();
     expect(multi.set).not.toHaveBeenCalled();
     expect(multi.exec).not.toHaveBeenCalled();
     expect(redis.set).not.toHaveBeenCalled();
     expect(mockedRunUserStateTransitionLua).not.toHaveBeenCalled();
   });
 
-  it('모든 전이가 Lua runner를 거치고 WATCH 트랜잭션을 열지 않음', async () => {
+  it('전이가 Lua runner를 거치고 WATCH 트랜잭션을 열지 않음', async () => {
     const { service, redis, multi } = createService({
       id: 1,
       loginId: 'user1',
-      userStatus: USER_STATUS.LOGIN,
-      targetEvent: null,
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: 3,
     });
     mockedRunUserStateTransitionLua.mockResolvedValue({
       ok: true,
       code: 'OK',
-      action: 'enterWaiting',
-      from: USER_STATUS.LOGIN,
-      to: USER_STATUS.WAITING,
+      action: 'resetToLogin',
+      from: USER_STATUS.WAITING,
+      to: USER_STATUS.LOGIN,
     });
 
-    await service.enterWaiting('sid-1', 3);
+    await service.resetToLogin('sid-1', null);
 
     expect(mockedRunUserStateTransitionLua).toHaveBeenCalledTimes(1);
     expect(redis.watch).not.toHaveBeenCalled();
     expect(redis.duplicate).not.toHaveBeenCalled();
     expect(multi.exec).not.toHaveBeenCalled();
+  });
+
+  it('예매 경로 전이 메서드를 노출하지 않음', () => {
+    const { service } = createService(null);
+    const bookingTransitionMethods = [
+      'enterWaiting',
+      'enterBookingGate',
+      'startSeatSelection',
+      'markReconnectingSelection',
+      'restoreSeatSelection',
+    ];
+
+    for (const methodName of bookingTransitionMethods) {
+      expect(methodName in service).toBe(false);
+    }
   });
 
   it('AuthService에는 WATCH 기반 전이 경로가 남아 있지 않음', () => {
@@ -408,15 +344,15 @@ describe('AuthService FSM 세션 전이', () => {
     const { service, logger } = createService({
       id: 1,
       loginId: 'user1',
-      userStatus: USER_STATUS.LOGIN,
-      targetEvent: null,
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: 7,
     });
     mockedRunUserStateTransitionLua.mockRejectedValue(error);
 
-    await expect(service.enterWaiting('sid-1', 7)).rejects.toThrow(error.message);
+    await expect(service.resetToLogin('sid-1', 7)).rejects.toThrow(error.message);
 
     expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Redis Lua user state transition failed during enterWaiting'),
+      expect.stringContaining('Redis Lua user state transition failed during resetToLogin'),
     );
   });
 });

--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -136,42 +136,13 @@ export class AuthService {
     }
   }
 
-  private async runSemanticUserStateTransition(
-    sid: string,
-    action: UserStateTransitionAction,
-    targetEvent?: number | null,
-    options?: TransitionOptions,
-  ): Promise<SemanticTransitionResult> {
+  async resetToLogin(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
     return this.runLuaBackedUserStateTransition(
       sid,
-      action,
+      'resetToLogin',
       this.buildTargetEventPatch(targetEvent),
       options,
     );
-  }
-
-  async enterWaiting(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'enterWaiting', targetEvent, options);
-  }
-
-  async enterBookingGate(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'enterBookingGate', targetEvent, options);
-  }
-
-  async startSeatSelection(sid: string, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'startSeatSelection', undefined, options);
-  }
-
-  async markReconnectingSelection(sid: string, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'markReconnectingSelection', undefined, options);
-  }
-
-  async restoreSeatSelection(sid: string, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'restoreSeatSelection', undefined, options);
-  }
-
-  async resetToLogin(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'resetToLogin', targetEvent, options);
   }
 
   async getUserIdFromSession(sid: string): Promise<[number | null, string | null]> {

--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -17,6 +17,11 @@ import { AUTH_EXPIRE_TIME } from '../const/authExpireTime.const';
 import { USER_STATUS } from '../const/userStatus.const';
 import { AuthErrorCode } from '../exception/auth-error-code';
 import {
+  buildLuaUserStateTransitionInput,
+  type LuaUserStateTransitionResult,
+  type TargetEventPatch,
+} from '../fsm/user-state-transition.contract';
+import {
   enterBookingGate as fsmEnterBookingGate,
   enterWaiting as fsmEnterWaiting,
   markReconnectingSelection as fsmMarkReconnectingSelection,
@@ -25,7 +30,9 @@ import {
   startSeatSelection as fsmStartSeatSelection,
   type SessionUserStatus,
   type TransitionResult,
+  type UserStateTransitionAction,
 } from '../fsm/user-state.fsm';
+import { runUserStateTransitionLua } from '../luaScripts/userStateTransitionLua';
 
 type RedisMulti = ReturnType<Redis['multi']>;
 type SuccessfulTransitionResult = Extract<TransitionResult, { ok: true }>;
@@ -43,7 +50,9 @@ type TransitionOptions = {
   watchKeys?: string[];
   validate?: TransitionValidation;
   mutate?: TransitionMutation;
+  skipExpectedFromCheck?: boolean;
 };
+type SemanticTransitionResult = TransitionResult | LuaUserStateTransitionResult | null;
 
 @Injectable()
 export class AuthService {
@@ -79,8 +88,39 @@ export class AuthService {
     return targetEvent === undefined ? {} : { targetEvent };
   }
 
+  private buildTargetEventPatch(targetEvent?: number | null): TargetEventPatch {
+    if (targetEvent === undefined) {
+      return { mode: 'preserve' };
+    }
+
+    if (targetEvent === null) {
+      return { mode: 'clear' };
+    }
+
+    return { mode: 'set', eventId: targetEvent };
+  }
+
   private buildSessionRoles(role: string) {
     return role === USER_ROLE.ADMIN ? [USER_ROLE.USER, USER_ROLE.ADMIN] : [USER_ROLE.USER];
+  }
+
+  private getSessionUserStatus(session: UserSessionRecord): SessionUserStatus | string {
+    return typeof session.userStatus === 'string' ? session.userStatus : String(session.userStatus);
+  }
+
+  private getSessionTargetEvent(session: UserSessionRecord): number | null {
+    return typeof session.targetEvent === 'number' ? session.targetEvent : null;
+  }
+
+  private buildExpectedTargetEvent(
+    session: UserSessionRecord,
+    targetEventPatch: TargetEventPatch,
+  ): number | null {
+    if (targetEventPatch.mode === 'set') {
+      return this.getSessionUserStatus(session) === USER_STATUS.LOGIN ? null : targetEventPatch.eventId;
+    }
+
+    return this.getSessionTargetEvent(session);
   }
 
   private extractExecCommandError(entry: unknown): Error | null {
@@ -114,7 +154,72 @@ export class AuthService {
     throw commandError;
   }
 
-  async executeUserStateTransition(
+  private async runLuaBackedUserStateTransition(
+    sid: string,
+    action: UserStateTransitionAction,
+    targetEventPatch: TargetEventPatch,
+    options?: Pick<TransitionOptions, 'skipExpectedFromCheck'>,
+  ): Promise<SemanticTransitionResult> {
+    const session = (await this.getParsedSession(sid)) as UserSessionRecord | null;
+    if (!session) {
+      return null;
+    }
+
+    const expectedFrom = options?.skipExpectedFromCheck ? undefined : this.getSessionUserStatus(session);
+    const inputOrResult = buildLuaUserStateTransitionInput({
+      sid,
+      action,
+      expectedFrom,
+      targetEventPatch,
+      expectedTargetEvent: this.buildExpectedTargetEvent(session, targetEventPatch),
+    });
+
+    if ('ok' in inputOrResult) {
+      return inputOrResult;
+    }
+
+    try {
+      return await runUserStateTransitionLua(this.redis, inputOrResult);
+    } catch (error) {
+      this.logger.error(
+        `Redis Lua user state transition failed during ${action}: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`,
+      );
+      throw error;
+    }
+  }
+
+  private hasWatchedTransitionOptions(options?: TransitionOptions): boolean {
+    return Boolean(options?.validate || options?.mutate || (options?.watchKeys?.length ?? 0) > 0);
+  }
+
+  private async runSemanticUserStateTransition(
+    sid: string,
+    action: UserStateTransitionAction,
+    transition: UserStateTransition,
+    targetEvent?: number | null,
+    options?: TransitionOptions,
+  ): Promise<SemanticTransitionResult> {
+    if (this.hasWatchedTransitionOptions(options)) {
+      return this.executeWatchedUserStateTransition(
+        sid,
+        transition,
+        this.buildTransitionPatch(targetEvent),
+        options,
+      );
+    }
+
+    return this.runLuaBackedUserStateTransition(
+      sid,
+      action,
+      this.buildTargetEventPatch(targetEvent),
+      options,
+    );
+  }
+
+  // Temporary boundary for booking callbacks until Phase 2-4 move those side effects into Lua scripts.
+  private async executeWatchedUserStateTransition(
     sid: string,
     transition: UserStateTransition,
     patch: Record<string, unknown> = {},
@@ -139,9 +244,7 @@ export class AuthService {
         return null;
       }
 
-      const currentStatus =
-        typeof session.userStatus === 'string' ? session.userStatus : String(session.userStatus);
-      const result = transition(currentStatus);
+      const result = transition(this.getSessionUserStatus(session));
       if (!result.ok) {
         await redis.unwatch();
         needsUnwatch = false;
@@ -187,42 +290,51 @@ export class AuthService {
   }
 
   async enterWaiting(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.executeUserStateTransition(
-      sid,
-      fsmEnterWaiting,
-      this.buildTransitionPatch(targetEvent),
-      options,
-    );
+    return this.runSemanticUserStateTransition(sid, 'enterWaiting', fsmEnterWaiting, targetEvent, options);
   }
 
   async enterBookingGate(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.executeUserStateTransition(
+    return this.runSemanticUserStateTransition(
       sid,
+      'enterBookingGate',
       fsmEnterBookingGate,
-      this.buildTransitionPatch(targetEvent),
+      targetEvent,
       options,
     );
   }
 
   async startSeatSelection(sid: string, options?: TransitionOptions) {
-    return this.executeUserStateTransition(sid, fsmStartSeatSelection, {}, options);
+    return this.runSemanticUserStateTransition(
+      sid,
+      'startSeatSelection',
+      fsmStartSeatSelection,
+      undefined,
+      options,
+    );
   }
 
   async markReconnectingSelection(sid: string, options?: TransitionOptions) {
-    return this.executeUserStateTransition(sid, fsmMarkReconnectingSelection, {}, options);
+    return this.runSemanticUserStateTransition(
+      sid,
+      'markReconnectingSelection',
+      fsmMarkReconnectingSelection,
+      undefined,
+      options,
+    );
   }
 
   async restoreSeatSelection(sid: string, options?: TransitionOptions) {
-    return this.executeUserStateTransition(sid, fsmRestoreSeatSelection, {}, options);
+    return this.runSemanticUserStateTransition(
+      sid,
+      'restoreSeatSelection',
+      fsmRestoreSeatSelection,
+      undefined,
+      options,
+    );
   }
 
   async resetToLogin(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.executeUserStateTransition(
-      sid,
-      fsmResetToLogin,
-      this.buildTransitionPatch(targetEvent),
-      options,
-    );
+    return this.runSemanticUserStateTransition(sid, 'resetToLogin', fsmResetToLogin, targetEvent, options);
   }
 
   async getUserIdFromSession(sid: string): Promise<[number | null, string | null]> {
@@ -243,12 +355,6 @@ export class AuthService {
   async validateUser(id: string, password: string) {
     try {
       const keyOfUserId = `user-id:${id}`;
-      const oldSessionId = await this.redis.get(keyOfUserId);
-
-      if (oldSessionId) {
-        await this.redis.unlink(`user:${oldSessionId}`);
-      }
-
       const user = await this.userRepository.findOne({ where: { loginId: id } });
       if (!user) {
         throw new AppException(AuthErrorCode.INVALID_CREDENTIALS);
@@ -271,9 +377,13 @@ export class AuthService {
       const userInfoDto: UserInfoDto = new UserInfoDto();
       userInfoDto.loginId = user.loginId;
 
+      const oldSessionId = await this.redis.get(keyOfUserId);
       await this.redis.set(`user-id:${id}`, sessionId, 'EX', AUTH_EXPIRE_TIME);
       await this.redis.set(`user:${sessionId}`, JSON.stringify(cachedUserInfo), 'EX', AUTH_EXPIRE_TIME);
       await this.redis.zadd('sessions:active', Date.now() + AUTH_EXPIRE_TIME * 1000, user.loginId);
+      if (oldSessionId) {
+        await this.redis.unlink(`user:${oldSessionId}`);
+      }
 
       return { sessionId: sessionId, userInfo: userInfoDto };
     } catch (err) {
@@ -312,15 +422,6 @@ export class AuthService {
       this.logger.error(err);
       throw new AppException(AuthErrorCode.LOGOUT_FAILED);
     }
-  }
-
-  async setUserEventTarget(sid: string, eventId: number) {
-    const session = await this.getParsedSession(sid);
-    if (!session) {
-      return;
-    }
-
-    await this.redis.set(`user:${sid}`, JSON.stringify({ ...session, targetEvent: eventId }), 'KEEPTTL');
   }
 
   async getUserEventTarget(sid: string) {

--- a/back/src/auth/service/auth.service.ts
+++ b/back/src/auth/service/auth.service.ts
@@ -22,34 +22,15 @@ import {
   type TargetEventPatch,
 } from '../fsm/user-state-transition.contract';
 import {
-  enterBookingGate as fsmEnterBookingGate,
-  enterWaiting as fsmEnterWaiting,
-  markReconnectingSelection as fsmMarkReconnectingSelection,
-  resetToLogin as fsmResetToLogin,
-  restoreSeatSelection as fsmRestoreSeatSelection,
-  startSeatSelection as fsmStartSeatSelection,
   type SessionUserStatus,
   type TransitionResult,
   type UserStateTransitionAction,
 } from '../fsm/user-state.fsm';
 import { runUserStateTransitionLua } from '../luaScripts/userStateTransitionLua';
 
-type RedisMulti = ReturnType<Redis['multi']>;
-type SuccessfulTransitionResult = Extract<TransitionResult, { ok: true }>;
 type UserSessionRecord = Record<string, unknown> & { targetEvent?: unknown; userStatus?: unknown };
-type UserStateTransition = (current: SessionUserStatus | string) => TransitionResult;
-type TransitionContext = {
-  session: UserSessionRecord;
-  sessionKey: string;
-  result: SuccessfulTransitionResult;
-};
-type TransitionMutation = (multi: RedisMulti, context: TransitionContext) => void | Promise<void>;
-type TransitionValidation = (redis: Redis, context: TransitionContext) => boolean | Promise<boolean>;
 
 type TransitionOptions = {
-  watchKeys?: string[];
-  validate?: TransitionValidation;
-  mutate?: TransitionMutation;
   skipExpectedFromCheck?: boolean;
 };
 type SemanticTransitionResult = TransitionResult | LuaUserStateTransitionResult | null;
@@ -82,10 +63,6 @@ export class AuthService {
 
   private async getParsedSession(sid: string) {
     return this.parseSessionData(await this.redis.get(`user:${sid}`));
-  }
-
-  private buildTransitionPatch(targetEvent?: number | null) {
-    return targetEvent === undefined ? {} : { targetEvent };
   }
 
   private buildTargetEventPatch(targetEvent?: number | null): TargetEventPatch {
@@ -121,37 +98,6 @@ export class AuthService {
     }
 
     return this.getSessionTargetEvent(session);
-  }
-
-  private extractExecCommandError(entry: unknown): Error | null {
-    if (!Array.isArray(entry) || !entry[0]) {
-      return null;
-    }
-
-    return entry[0] instanceof Error ? entry[0] : new Error(String(entry[0]));
-  }
-
-  private assertNoExecCommandErrors(
-    execResult: Awaited<ReturnType<RedisMulti['exec']>>,
-    action: string,
-    watchedKeyCount: number,
-  ) {
-    if (!Array.isArray(execResult)) {
-      return;
-    }
-
-    const commandError = execResult
-      .map((entry) => this.extractExecCommandError(entry))
-      .find((error): error is Error => error !== null);
-
-    if (!commandError) {
-      return;
-    }
-
-    this.logger.error(
-      `Redis EXEC command failed during ${action} with ${watchedKeyCount} watched keys: ${commandError.message}`,
-    );
-    throw commandError;
   }
 
   private async runLuaBackedUserStateTransition(
@@ -190,26 +136,12 @@ export class AuthService {
     }
   }
 
-  private hasWatchedTransitionOptions(options?: TransitionOptions): boolean {
-    return Boolean(options?.validate || options?.mutate || (options?.watchKeys?.length ?? 0) > 0);
-  }
-
   private async runSemanticUserStateTransition(
     sid: string,
     action: UserStateTransitionAction,
-    transition: UserStateTransition,
     targetEvent?: number | null,
     options?: TransitionOptions,
   ): Promise<SemanticTransitionResult> {
-    if (this.hasWatchedTransitionOptions(options)) {
-      return this.executeWatchedUserStateTransition(
-        sid,
-        transition,
-        this.buildTransitionPatch(targetEvent),
-        options,
-      );
-    }
-
     return this.runLuaBackedUserStateTransition(
       sid,
       action,
@@ -218,123 +150,28 @@ export class AuthService {
     );
   }
 
-  // Temporary boundary for booking callbacks until Phase 2-4 move those side effects into Lua scripts.
-  private async executeWatchedUserStateTransition(
-    sid: string,
-    transition: UserStateTransition,
-    patch: Record<string, unknown> = {},
-    options: TransitionOptions = {},
-  ): Promise<TransitionResult | null> {
-    const sessionKey = `user:${sid}`;
-    const watchKeys = [
-      sessionKey,
-      ...(options.watchKeys ?? []).filter((watchKey) => watchKey !== sessionKey),
-    ];
-    const redis = this.redis.duplicate();
-    let needsUnwatch = false;
-
-    try {
-      await redis.watch(...watchKeys);
-      needsUnwatch = true;
-
-      const session = this.parseSessionData(await redis.get(sessionKey)) as UserSessionRecord | null;
-      if (!session) {
-        await redis.unwatch();
-        needsUnwatch = false;
-        return null;
-      }
-
-      const result = transition(this.getSessionUserStatus(session));
-      if (!result.ok) {
-        await redis.unwatch();
-        needsUnwatch = false;
-        return result;
-      }
-
-      const context = { session, sessionKey, result };
-      const isValid = await options.validate?.(redis, context);
-      if (isValid === false) {
-        await redis.unwatch();
-        needsUnwatch = false;
-        return null;
-      }
-
-      const multi = redis.multi();
-      await options.mutate?.(multi, context);
-      multi.set(sessionKey, JSON.stringify({ ...session, ...patch, userStatus: result.to }), 'KEEPTTL');
-
-      const execResult = await multi.exec();
-      needsUnwatch = false;
-      if (execResult === null) {
-        return null;
-      }
-
-      this.assertNoExecCommandErrors(execResult, result.action, watchKeys.length);
-      return result;
-    } catch (error) {
-      if (needsUnwatch) {
-        try {
-          await redis.unwatch();
-        } catch (unwatchError) {
-          this.logger.warn(
-            `Failed to unwatch user state transition keys: ${
-              unwatchError instanceof Error ? unwatchError.message : 'unknown error'
-            }`,
-          );
-        }
-      }
-      throw error;
-    } finally {
-      redis.disconnect();
-    }
-  }
-
   async enterWaiting(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'enterWaiting', fsmEnterWaiting, targetEvent, options);
+    return this.runSemanticUserStateTransition(sid, 'enterWaiting', targetEvent, options);
   }
 
   async enterBookingGate(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(
-      sid,
-      'enterBookingGate',
-      fsmEnterBookingGate,
-      targetEvent,
-      options,
-    );
+    return this.runSemanticUserStateTransition(sid, 'enterBookingGate', targetEvent, options);
   }
 
   async startSeatSelection(sid: string, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(
-      sid,
-      'startSeatSelection',
-      fsmStartSeatSelection,
-      undefined,
-      options,
-    );
+    return this.runSemanticUserStateTransition(sid, 'startSeatSelection', undefined, options);
   }
 
   async markReconnectingSelection(sid: string, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(
-      sid,
-      'markReconnectingSelection',
-      fsmMarkReconnectingSelection,
-      undefined,
-      options,
-    );
+    return this.runSemanticUserStateTransition(sid, 'markReconnectingSelection', undefined, options);
   }
 
   async restoreSeatSelection(sid: string, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(
-      sid,
-      'restoreSeatSelection',
-      fsmRestoreSeatSelection,
-      undefined,
-      options,
-    );
+    return this.runSemanticUserStateTransition(sid, 'restoreSeatSelection', undefined, options);
   }
 
   async resetToLogin(sid: string, targetEvent?: number | null, options?: TransitionOptions) {
-    return this.runSemanticUserStateTransition(sid, 'resetToLogin', fsmResetToLogin, targetEvent, options);
+    return this.runSemanticUserStateTransition(sid, 'resetToLogin', targetEvent, options);
   }
 
   async getUserIdFromSession(sid: string): Promise<[number | null, string | null]> {

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
@@ -4,15 +4,19 @@ import { join } from 'path';
 import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
-import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { USER_STATE_TRANSITIONS, USER_STATUS } from '../../../auth/fsm/user-state.fsm';
 
 import {
   IMMEDIATE_ADMISSION_BUSINESS_CODES,
+  IMMEDIATE_ADMISSION_TRANSITION,
   WAITING_HEAD_PROMOTION_BUSINESS_CODES,
+  WAITING_HEAD_PROMOTION_TRANSITION,
+  immediateAdmissionLua,
   mapImmediateAdmissionLuaResult,
   mapWaitingHeadPromotionLuaResult,
   runImmediateAdmissionLua,
   runWaitingHeadPromotionLua,
+  waitingHeadPromotionLua,
 } from './admissionCapacityLua';
 
 type RedisWithAdmissionCommands = Redis & {
@@ -30,6 +34,8 @@ type ImmediateAdmissionCommandArgs = [
   defaultMaxSizeKey: string,
   defaultMaxSize: string,
   nowMs: string,
+  expectedFrom: string,
+  nextTo: string,
 ];
 
 type WaitingHeadPromotionCommandArgs = [
@@ -43,6 +49,8 @@ type WaitingHeadPromotionCommandArgs = [
   userKeyPrefix: string,
   defaultMaxSize: string,
   nowMs: string,
+  expectedFrom: string,
+  nextTo: string,
 ];
 
 const admissionKeys = {
@@ -99,6 +107,8 @@ async function emulateImmediateAdmissionCommand(
     defaultMaxSizeKey,
     defaultMaxSize,
     nowMs,
+    expectedFrom,
+    nextTo,
   ]: ImmediateAdmissionCommandArgs
 ) {
   const raw = await redis.get(sessionKey);
@@ -107,7 +117,7 @@ async function emulateImmediateAdmissionCommand(
   }
 
   const session = JSON.parse(raw) as Record<string, unknown>;
-  if (session.userStatus !== USER_STATUS.LOGIN) {
+  if (session.userStatus !== expectedFrom) {
     return ['STATE_MISMATCH', session.userStatus];
   }
 
@@ -124,7 +134,7 @@ async function emulateImmediateAdmissionCommand(
     return ['CAPACITY_FULL'];
   }
 
-  session.userStatus = USER_STATUS.ENTERING;
+  session.userStatus = nextTo;
   session.targetEvent = Number(eventId);
 
   const ttl = await redis.pttl(sessionKey);
@@ -157,6 +167,8 @@ async function emulateWaitingHeadPromotionCommand(
     userKeyPrefix,
     defaultMaxSize,
     nowMs,
+    expectedFrom,
+    nextTo,
   ]: WaitingHeadPromotionCommandArgs
 ) {
   const head = await redis.lindex(waitingQueueKey, 0);
@@ -184,7 +196,7 @@ async function emulateWaitingHeadPromotionCommand(
   }
 
   const session = JSON.parse(raw) as Record<string, unknown>;
-  if (session.userStatus !== USER_STATUS.WAITING) {
+  if (session.userStatus !== expectedFrom) {
     await redis.lpop(waitingQueueKey);
     return ['STALE_STATE_MISMATCH', session.userStatus];
   }
@@ -194,7 +206,7 @@ async function emulateWaitingHeadPromotionCommand(
     return ['STALE_TARGET_EVENT_MISMATCH', session.targetEvent];
   }
 
-  session.userStatus = USER_STATUS.ENTERING;
+  session.userStatus = nextTo;
 
   const ttl = await redis.pttl(sessionKey);
   if (ttl === -2 || ttl === 0) {
@@ -383,6 +395,8 @@ describe('admissionCapacityLua 계약', () => {
       'in-booking:default-max-size',
       '500',
       '1700000000123',
+      USER_STATUS.LOGIN,
+      USER_STATUS.ENTERING,
     );
   });
 
@@ -409,6 +423,8 @@ describe('admissionCapacityLua 계약', () => {
       'user:',
       '500',
       '1700000000456',
+      USER_STATUS.WAITING,
+      USER_STATUS.ENTERING,
     );
   });
 
@@ -738,5 +754,26 @@ describe('runWaitingHeadPromotionLua 대기열 head 승격 동작', () => {
     await expect(runWaitingHeadPromotion()).rejects.toThrow();
     expect(await redis.lindex('waiting-queue:42', 0)).toBe(JSON.stringify(head));
     expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(waitingSession);
+  });
+});
+
+describe('admissionCapacityLua 전이 출처', () => {
+  it('from/to를 스크립트에 적어두지 않고 FSM 전이 테이블에서 유도함', () => {
+    expect(USER_STATE_TRANSITIONS).toContainEqual(IMMEDIATE_ADMISSION_TRANSITION);
+    expect(USER_STATE_TRANSITIONS).toContainEqual(WAITING_HEAD_PROMOTION_TRANSITION);
+    expect(IMMEDIATE_ADMISSION_TRANSITION.from).toBe(USER_STATUS.LOGIN);
+    expect(WAITING_HEAD_PROMOTION_TRANSITION.from).toBe(USER_STATUS.WAITING);
+  });
+
+  it('Lua 본문에 상태 문자열을 박아두지 않고 ARGV로 받음', () => {
+    for (const script of [immediateAdmissionLua, waitingHeadPromotionLua]) {
+      expect(script).toContain('local expectedFrom = ARGV[5]');
+      expect(script).toContain('local nextTo = ARGV[6]');
+      expect(script).toContain('session.userStatus ~= expectedFrom');
+      expect(script).toContain('session.userStatus = nextTo');
+      for (const state of Object.values(USER_STATUS)) {
+        expect(script).not.toContain(`'${state}'`);
+      }
+    }
   });
 });

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
@@ -1,0 +1,735 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+
+import {
+  IMMEDIATE_ADMISSION_BUSINESS_CODES,
+  WAITING_HEAD_PROMOTION_BUSINESS_CODES,
+  mapImmediateAdmissionLuaResult,
+  mapWaitingHeadPromotionLuaResult,
+  runImmediateAdmissionLua,
+  runWaitingHeadPromotionLua,
+} from './admissionCapacityLua';
+
+type RedisWithAdmissionCommands = Redis & {
+  admitBookingGateImmediate?: jest.Mock;
+  promoteWaitingQueueHead?: jest.Mock;
+};
+
+type ImmediateAdmissionCommandArgs = [
+  sessionKey: string,
+  enteringKey: string,
+  inBookingSessionsKey: string,
+  reconnectingKey: string,
+  maxSizeKey: string,
+  eventId: string,
+  defaultMaxSizeKey: string,
+  defaultMaxSize: string,
+  nowMs: string,
+];
+
+type WaitingHeadPromotionCommandArgs = [
+  waitingQueueKey: string,
+  enteringKey: string,
+  inBookingSessionsKey: string,
+  reconnectingKey: string,
+  maxSizeKey: string,
+  defaultMaxSizeKey: string,
+  eventId: string,
+  userKeyPrefix: string,
+  defaultMaxSize: string,
+  nowMs: string,
+];
+
+const admissionKeys = {
+  enteringKey: 'entering:42',
+  inBookingSessionsKey: 'in-booking:42:sessions',
+  reconnectingKey: 'reconnecting:42',
+  maxSizeKey: 'in-booking:42:max-size',
+  defaultMaxSizeKey: 'in-booking:default-max-size',
+};
+
+const baseSession = {
+  id: 1,
+  loginId: 'guest-1',
+  roles: ['USER'],
+  targetEvent: null,
+  userStatus: USER_STATUS.LOGIN,
+};
+
+function createAdmissionCommandRedis(rawResult: unknown = ['OK']): RedisWithAdmissionCommands {
+  return {
+    defineCommand: jest.fn(function (this: RedisWithAdmissionCommands, name: string) {
+      this[name as 'admitBookingGateImmediate' | 'promoteWaitingQueueHead'] = jest
+        .fn()
+        .mockResolvedValue(rawResult);
+      return this;
+    }),
+  } as unknown as RedisWithAdmissionCommands;
+}
+
+async function getAdmissionMaxSize(
+  redis: Redis,
+  maxSizeKey: string,
+  defaultMaxSizeKey: string,
+  defaultMaxSize: string,
+): Promise<number> {
+  const eventMaxSize = await redis.get(maxSizeKey);
+  if (eventMaxSize) {
+    return Number(eventMaxSize);
+  }
+
+  const redisDefaultMaxSize = await redis.get(defaultMaxSizeKey);
+  return redisDefaultMaxSize ? Number(redisDefaultMaxSize) : Number(defaultMaxSize);
+}
+
+async function emulateImmediateAdmissionCommand(
+  redis: Redis,
+  ...[
+    sessionKey,
+    enteringKey,
+    inBookingSessionsKey,
+    reconnectingKey,
+    maxSizeKey,
+    eventId,
+    defaultMaxSizeKey,
+    defaultMaxSize,
+    nowMs,
+  ]: ImmediateAdmissionCommandArgs
+) {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return ['SESSION_MISSING'];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+  if (session.userStatus !== USER_STATUS.LOGIN) {
+    return ['STATE_MISMATCH', session.userStatus];
+  }
+
+  if (session.targetEvent !== null) {
+    return ['TARGET_EVENT_MISMATCH', session.targetEvent];
+  }
+
+  const inBookingCount = await redis.hlen(inBookingSessionsKey);
+  const reconnectingCount = await redis.zcard(reconnectingKey);
+  const enteringCount = await redis.zcard(enteringKey);
+  const maxSize = await getAdmissionMaxSize(redis, maxSizeKey, defaultMaxSizeKey, defaultMaxSize);
+
+  if (inBookingCount + reconnectingCount + enteringCount >= maxSize) {
+    return ['CAPACITY_FULL'];
+  }
+
+  session.userStatus = USER_STATUS.ENTERING;
+  session.targetEvent = Number(eventId);
+
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  await redis.zadd(enteringKey, nowMs, sessionKey.replace(/^user:/, ''));
+  if (ttl > 0) {
+    await redis.set(sessionKey, JSON.stringify(session), 'PX', ttl);
+  } else if (ttl === -1) {
+    await redis.set(sessionKey, JSON.stringify(session));
+  } else {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  return ['OK'];
+}
+
+async function emulateWaitingHeadPromotionCommand(
+  redis: Redis,
+  ...[
+    waitingQueueKey,
+    enteringKey,
+    inBookingSessionsKey,
+    reconnectingKey,
+    maxSizeKey,
+    defaultMaxSizeKey,
+    eventId,
+    userKeyPrefix,
+    defaultMaxSize,
+    nowMs,
+  ]: WaitingHeadPromotionCommandArgs
+) {
+  const head = await redis.lindex(waitingQueueKey, 0);
+  if (!head) {
+    return ['QUEUE_EMPTY'];
+  }
+
+  const item = JSON.parse(head) as Record<string, unknown>;
+  const sid = item.sid as string;
+
+  const inBookingCount = await redis.hlen(inBookingSessionsKey);
+  const reconnectingCount = await redis.zcard(reconnectingKey);
+  const enteringCount = await redis.zcard(enteringKey);
+  const maxSize = await getAdmissionMaxSize(redis, maxSizeKey, defaultMaxSizeKey, defaultMaxSize);
+
+  if (inBookingCount + reconnectingCount + enteringCount >= maxSize) {
+    return ['CAPACITY_FULL'];
+  }
+
+  const sessionKey = `${userKeyPrefix}${sid}`;
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    await redis.lpop(waitingQueueKey);
+    return ['STALE_SESSION_MISSING', sid];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+  if (session.userStatus !== USER_STATUS.WAITING) {
+    await redis.lpop(waitingQueueKey);
+    return ['STALE_STATE_MISMATCH', session.userStatus];
+  }
+
+  if (session.targetEvent !== Number(eventId)) {
+    await redis.lpop(waitingQueueKey);
+    return ['STALE_TARGET_EVENT_MISMATCH', session.targetEvent];
+  }
+
+  session.userStatus = USER_STATUS.ENTERING;
+
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  await redis.zadd(enteringKey, nowMs, sid);
+  await redis.lpop(waitingQueueKey);
+  if (ttl > 0) {
+    await redis.set(sessionKey, JSON.stringify(session), 'PX', ttl);
+  } else if (ttl === -1) {
+    await redis.set(sessionKey, JSON.stringify(session));
+  } else {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+  return ['OK'];
+}
+
+function installAdmissionCommandStub(redis: Redis): jest.SpyInstance {
+  return jest.spyOn(redis, 'defineCommand').mockImplementation(function (
+    this: RedisWithAdmissionCommands,
+    name: string,
+  ) {
+    if (name === 'admitBookingGateImmediate') {
+      this.admitBookingGateImmediate = jest.fn((...args: ImmediateAdmissionCommandArgs) =>
+        emulateImmediateAdmissionCommand(redis, ...args),
+      );
+    }
+
+    if (name === 'promoteWaitingQueueHead') {
+      this.promoteWaitingQueueHead = jest.fn((...args: WaitingHeadPromotionCommandArgs) =>
+        emulateWaitingHeadPromotionCommand(redis, ...args),
+      );
+    }
+
+    return this;
+  } as never);
+}
+
+describe('admissionCapacityLua 계약', () => {
+  it('즉시 입장과 대기열 head 승격 business code를 path별로 제한함', () => {
+    expect(IMMEDIATE_ADMISSION_BUSINESS_CODES).toEqual(['CAPACITY_FULL']);
+    expect(WAITING_HEAD_PROMOTION_BUSINESS_CODES).toEqual([
+      'CAPACITY_FULL',
+      'QUEUE_EMPTY',
+      'STALE_SESSION_MISSING',
+      'STALE_STATE_MISMATCH',
+      'STALE_TARGET_EVENT_MISMATCH',
+    ]);
+  });
+
+  it('즉시 입장 CAPACITY_FULL을 LOGIN에서 ENTERING 전이의 내부 결과로 매핑함', () => {
+    expect(mapImmediateAdmissionLuaResult(['CAPACITY_FULL'])).toEqual({
+      ok: false,
+      code: 'CAPACITY_FULL',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.ENTERING,
+      details: [],
+    });
+  });
+
+  it('대기열 head 승격 stale 결과를 WAITING에서 ENTERING 전이의 내부 결과로 매핑함', () => {
+    expect(mapWaitingHeadPromotionLuaResult(['STALE_STATE_MISMATCH', USER_STATUS.LOGIN])).toEqual({
+      ok: false,
+      code: 'STALE_STATE_MISMATCH',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.ENTERING,
+      details: [USER_STATUS.LOGIN],
+    });
+  });
+
+  it('선언하지 않은 입장 Lua 결과 코드는 인프라 계약 오류로 throw함', () => {
+    const undeclaredCode = ['STALE_SESSION_MISSING'] as never;
+
+    expect(() => mapImmediateAdmissionLuaResult(undeclaredCode)).toThrow(
+      'Unknown Lua user state transition code',
+    );
+  });
+
+  it('입장 Lua 소스는 malformed-session business code와 mock JSON fallback을 도입하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+    const removedHotPathTerms = [
+      'MALFORMED_' + 'SESSION',
+      'MOCK_JSON_' + 'NULL',
+      'decodeSession' + 'Json',
+      'replaceJson' + 'Field',
+      'has' + 'Cjson',
+    ];
+
+    for (const removedTerm of removedHotPathTerms) {
+      expect(source).not.toContain(removedTerm);
+    }
+  });
+
+  it('공유 Lua helper는 Redis-side capacity 계산과 TTL 보존 쓰기를 제공함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+
+    expect(source).toContain('local function hasAdmissionCapacity');
+    expect(source).toContain("redis.call('HLEN', inBookingSessionsKey)");
+    expect(source).toContain('local function prepareSessionWrite');
+    expect(source).toContain('local function writePreparedSessionPreservingTtl');
+    expect(source).toContain("redis.call('PTTL', sessionKey)");
+    expect(source).toContain("redis.call('PSETEX', sessionKey, ttl, encodedSession)");
+  });
+
+  it('즉시 입장과 대기열 head 승격 Lua 명령을 같은 Redis 인스턴스에 한 번만 등록함', async () => {
+    const redis = createAdmissionCommandRedis();
+
+    await runImmediateAdmissionLua(redis, {
+      sessionKey: 'user:sid-1',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: 500,
+      nowMs: 1_700_000_000_001,
+    });
+    await runWaitingHeadPromotionLua(redis, {
+      waitingQueueKey: 'waiting-queue:42',
+      userKeyPrefix: 'user:',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: 500,
+      nowMs: 1_700_000_000_002,
+    });
+    await runImmediateAdmissionLua(redis, {
+      sessionKey: 'user:sid-2',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: 500,
+      nowMs: 1_700_000_000_003,
+    });
+    await runWaitingHeadPromotionLua(redis, {
+      waitingQueueKey: 'waiting-queue:42',
+      userKeyPrefix: 'user:',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: 500,
+      nowMs: 1_700_000_000_004,
+    });
+
+    expect(redis.defineCommand).toHaveBeenCalledTimes(2);
+    expect(redis.defineCommand).toHaveBeenCalledWith('admitBookingGateImmediate', {
+      numberOfKeys: 5,
+      lua: expect.stringContaining('local function hasAdmissionCapacity'),
+    });
+    expect(redis.defineCommand).toHaveBeenCalledWith('promoteWaitingQueueHead', {
+      numberOfKeys: 6,
+      lua: expect.stringContaining('local function hasAdmissionCapacity'),
+    });
+  });
+
+  it('입장 Lua runner는 script-body eval 없이 path별 defineCommand 이름을 사용함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+
+    expect(source).not.toMatch(/redis\.eval/);
+    expect(source).toContain("redis.defineCommand('admitBookingGateImmediate'");
+    expect(source).toContain("redis.defineCommand('promoteWaitingQueueHead'");
+  });
+
+  it('즉시 입장 runner는 앱에서 받은 nowMs를 entering zset score 인자로 전달함', async () => {
+    const redis = createAdmissionCommandRedis();
+
+    await runImmediateAdmissionLua(redis, {
+      sessionKey: 'user:sid-1',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: 500,
+      nowMs: 1_700_000_000_123,
+    });
+
+    expect(redis.admitBookingGateImmediate).toHaveBeenCalledWith(
+      'user:sid-1',
+      'entering:42',
+      'in-booking:42:sessions',
+      'reconnecting:42',
+      'in-booking:42:max-size',
+      '42',
+      'in-booking:default-max-size',
+      '500',
+      '1700000000123',
+    );
+  });
+
+  it('대기열 head 승격 runner는 앱에서 받은 nowMs를 entering zset score 인자로 전달함', async () => {
+    const redis = createAdmissionCommandRedis();
+
+    await runWaitingHeadPromotionLua(redis, {
+      waitingQueueKey: 'waiting-queue:42',
+      userKeyPrefix: 'user:',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: 500,
+      nowMs: 1_700_000_000_456,
+    });
+
+    expect(redis.promoteWaitingQueueHead).toHaveBeenCalledWith(
+      'waiting-queue:42',
+      'entering:42',
+      'in-booking:42:sessions',
+      'reconnecting:42',
+      'in-booking:42:max-size',
+      'in-booking:default-max-size',
+      '42',
+      'user:',
+      '500',
+      '1700000000456',
+    );
+  });
+
+  it('Lua는 Redis TIME 대신 app-provided nowMs를 entering score로 사용함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+
+    expect(source).toContain('Date.now()');
+    expect(source).toContain('local nowMs = tonumber(ARGV[4])');
+    expect(source).toContain("redis.call('ZADD', enteringKey, nowMs,");
+    expect(source).not.toContain("redis.call('TIME'");
+    expect(source).not.toContain('redis.call("TIME"');
+  });
+
+  it('즉시 입장 성공 경로는 entering zset 쓰기 이후 세션을 최종 저장함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+    const immediateScriptStart = source.indexOf('export const immediateAdmissionLua');
+    const zaddIndex = source.indexOf("redis.call('ZADD', enteringKey, nowMs, sid)", immediateScriptStart);
+    const writeIndex = source.indexOf(
+      'writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)',
+      immediateScriptStart,
+    );
+
+    expect(zaddIndex).toBeGreaterThan(immediateScriptStart);
+    expect(writeIndex).toBeGreaterThan(zaddIndex);
+  });
+
+  it('즉시 입장 Lua는 capacity 판단 전에 세션 상태와 targetEvent를 검증함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+    const immediateScriptStart = source.indexOf('export const immediateAdmissionLua');
+    const sessionReadIndex = source.indexOf("redis.call('GET', sessionKey)", immediateScriptStart);
+    const capacityIndex = source.indexOf('hasAdmissionCapacity(', immediateScriptStart);
+
+    expect(sessionReadIndex).toBeGreaterThan(immediateScriptStart);
+    expect(capacityIndex).toBeGreaterThan(sessionReadIndex);
+  });
+
+  it('대기열 head 승격 Lua는 head JSON을 먼저 해석해 깨진 queue item을 CAPACITY_FULL로 숨기지 않음', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+    const promotionScriptStart = source.indexOf('export const waitingHeadPromotionLua');
+    const decodeIndex = source.indexOf('local item = cjson.decode(head)', promotionScriptStart);
+    const capacityIndex = source.indexOf('hasAdmissionCapacity(', promotionScriptStart);
+
+    expect(decodeIndex).toBeGreaterThan(promotionScriptStart);
+    expect(capacityIndex).toBeGreaterThan(decodeIndex);
+  });
+
+  it('대기열 head 승격 성공 경로는 entering zset과 queue pop 이후 세션을 최종 저장함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+    const promotionScriptStart = source.indexOf('export const waitingHeadPromotionLua');
+    const zaddIndex = source.indexOf("redis.call('ZADD', enteringKey, nowMs, sid)", promotionScriptStart);
+    const lpopIndex = source.indexOf("redis.call('LPOP', waitingQueueKey)", zaddIndex);
+    const writeIndex = source.indexOf(
+      'writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)',
+      promotionScriptStart,
+    );
+
+    expect(zaddIndex).toBeGreaterThan(promotionScriptStart);
+    expect(lpopIndex).toBeGreaterThan(zaddIndex);
+    expect(writeIndex).toBeGreaterThan(lpopIndex);
+  });
+});
+
+describe('runImmediateAdmissionLua 즉시 입장 동작', () => {
+  let redis: Redis;
+
+  async function runImmediateAdmission(overrides: Partial<{ nowMs: number; defaultMaxSize: number }> = {}) {
+    return runImmediateAdmissionLua(redis, {
+      sessionKey: 'user:sid-1',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: overrides.defaultMaxSize ?? 500,
+      nowMs: overrides.nowMs ?? 1_700_000_000_123,
+    });
+  }
+
+  beforeEach(() => {
+    redis = new RedisMock() as unknown as Redis;
+    installAdmissionCommandStub(redis);
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('성공 시 entering zset과 세션을 LOGIN에서 ENTERING으로 한 번에 갱신함', async () => {
+    await redis.set('user:sid-1', JSON.stringify(baseSession), 'PX', 5000);
+    const beforeTtl = await redis.pttl('user:sid-1');
+
+    const result = await runImmediateAdmission();
+
+    expect(result).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.ENTERING,
+    });
+    expect(await redis.zscore('entering:42', 'sid-1')).toBe('1700000000123');
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual({
+      ...baseSession,
+      targetEvent: 42,
+      userStatus: USER_STATUS.ENTERING,
+    });
+
+    const afterTtl = await redis.pttl('user:sid-1');
+    expect(beforeTtl).toBeGreaterThan(0);
+    expect(afterTtl).toBeGreaterThan(0);
+    expect(afterTtl).toBeLessThanOrEqual(beforeTtl);
+  });
+
+  it('정원이 가득 차면 세션과 entering zset을 변경하지 않고 CAPACITY_FULL을 반환함', async () => {
+    await redis.set('user:sid-1', JSON.stringify(baseSession));
+    await redis.hset('in-booking:42:sessions', 'occupied-sid', '{}');
+
+    const result = await runImmediateAdmission({ defaultMaxSize: 1 });
+
+    expect(result).toMatchObject({ ok: false, code: 'CAPACITY_FULL' });
+    expect(await redis.zscore('entering:42', 'sid-1')).toBeNull();
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(baseSession);
+  });
+
+  it('세션이 없으면 SESSION_MISSING을 반환하고 entering zset을 변경하지 않음', async () => {
+    const result = await runImmediateAdmission();
+
+    expect(result).toMatchObject({ ok: false, code: 'SESSION_MISSING' });
+    expect(await redis.zcard('entering:42')).toBe(0);
+  });
+
+  it('현재 상태가 LOGIN이 아니면 STATE_MISMATCH를 반환하고 쓰지 않음', async () => {
+    const waitingSession = { ...baseSession, userStatus: USER_STATUS.WAITING };
+    await redis.set('user:sid-1', JSON.stringify(waitingSession));
+
+    const result = await runImmediateAdmission();
+
+    expect(result).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(await redis.zscore('entering:42', 'sid-1')).toBeNull();
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(waitingSession);
+  });
+
+  it('이미 다른 targetEvent가 있으면 TARGET_EVENT_MISMATCH를 반환하고 쓰지 않음', async () => {
+    const targetingSession = { ...baseSession, targetEvent: 99 };
+    await redis.set('user:sid-1', JSON.stringify(targetingSession));
+
+    const result = await runImmediateAdmission();
+
+    expect(result).toMatchObject({ ok: false, code: 'TARGET_EVENT_MISMATCH' });
+    expect(await redis.zscore('entering:42', 'sid-1')).toBeNull();
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(targetingSession);
+  });
+
+  it('깨진 세션 JSON은 typed business denial로 바꾸지 않고 인프라 실패로 throw함', async () => {
+    await redis.set('user:sid-1', '{broken-json');
+
+    await expect(runImmediateAdmission()).rejects.toThrow();
+    expect(await redis.zscore('entering:42', 'sid-1')).toBeNull();
+  });
+
+  it('entering 키 타입이 깨져 ZADD가 실패하면 세션을 ENTERING으로 저장하지 않음', async () => {
+    await redis.set('user:sid-1', JSON.stringify(baseSession));
+    await redis.set('entering:42', 'wrong-type');
+
+    await expect(runImmediateAdmission()).rejects.toThrow();
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(baseSession);
+  });
+});
+
+describe('runWaitingHeadPromotionLua 대기열 head 승격 동작', () => {
+  let redis: Redis;
+
+  const waitingSession = {
+    ...baseSession,
+    targetEvent: 42,
+    userStatus: USER_STATUS.WAITING,
+  };
+
+  async function runWaitingHeadPromotion(overrides: Partial<{ nowMs: number; defaultMaxSize: number }> = {}) {
+    return runWaitingHeadPromotionLua(redis, {
+      waitingQueueKey: 'waiting-queue:42',
+      userKeyPrefix: 'user:',
+      eventId: 42,
+      keys: admissionKeys,
+      defaultMaxSize: overrides.defaultMaxSize ?? 500,
+      nowMs: overrides.nowMs ?? 1_700_000_000_456,
+    });
+  }
+
+  async function pushQueueItems(...items: Array<{ sid: string; order: number }>) {
+    for (const item of items) {
+      await redis.rpush('waiting-queue:42', JSON.stringify(item));
+    }
+  }
+
+  beforeEach(() => {
+    redis = new RedisMock() as unknown as Redis;
+    installAdmissionCommandStub(redis);
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('성공 시 head만 pop하고 entering zset과 세션을 WAITING에서 ENTERING으로 갱신함', async () => {
+    await pushQueueItems({ sid: 'sid-1', order: 7 }, { sid: 'sid-2', order: 8 });
+    await redis.set('user:sid-1', JSON.stringify(waitingSession), 'PX', 5000);
+    const beforeTtl = await redis.pttl('user:sid-1');
+
+    const result = await runWaitingHeadPromotion();
+
+    expect(result).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      from: USER_STATUS.WAITING,
+      to: USER_STATUS.ENTERING,
+    });
+    expect(await redis.lrange('waiting-queue:42', 0, -1)).toEqual([
+      JSON.stringify({ sid: 'sid-2', order: 8 }),
+    ]);
+    expect(await redis.zscore('entering:42', 'sid-1')).toBe('1700000000456');
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual({
+      ...waitingSession,
+      userStatus: USER_STATUS.ENTERING,
+    });
+
+    const afterTtl = await redis.pttl('user:sid-1');
+    expect(beforeTtl).toBeGreaterThan(0);
+    expect(afterTtl).toBeGreaterThan(0);
+    expect(afterTtl).toBeLessThanOrEqual(beforeTtl);
+  });
+
+  it('대기열이 비어 있으면 QUEUE_EMPTY를 반환하고 queue와 entering을 변경하지 않음', async () => {
+    const result = await runWaitingHeadPromotion();
+
+    expect(result).toMatchObject({ ok: false, code: 'QUEUE_EMPTY' });
+    expect(await redis.llen('waiting-queue:42')).toBe(0);
+    expect(await redis.zcard('entering:42')).toBe(0);
+  });
+
+  it('정원이 가득 차면 head와 세션을 보존하고 CAPACITY_FULL을 반환함', async () => {
+    const head = { sid: 'sid-1', order: 7 };
+    await pushQueueItems(head);
+    await redis.set('user:sid-1', JSON.stringify(waitingSession));
+    await redis.hset('in-booking:42:sessions', 'occupied-sid', '{}');
+
+    const result = await runWaitingHeadPromotion({ defaultMaxSize: 1 });
+
+    expect(result).toMatchObject({ ok: false, code: 'CAPACITY_FULL' });
+    expect(await redis.lrange('waiting-queue:42', 0, -1)).toEqual([JSON.stringify(head)]);
+    expect(await redis.zscore('entering:42', 'sid-1')).toBeNull();
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(waitingSession);
+  });
+
+  it('head 세션이 없으면 stale head만 제거하고 다음 후보를 남김', async () => {
+    await pushQueueItems({ sid: 'sid-1', order: 7 }, { sid: 'sid-2', order: 8 });
+
+    const result = await runWaitingHeadPromotion();
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'STALE_SESSION_MISSING',
+      details: ['sid-1'],
+    });
+    expect(await redis.lrange('waiting-queue:42', 0, -1)).toEqual([
+      JSON.stringify({ sid: 'sid-2', order: 8 }),
+    ]);
+  });
+
+  it('head 세션 상태가 WAITING이 아니면 stale head만 제거함', async () => {
+    await pushQueueItems({ sid: 'sid-1', order: 7 }, { sid: 'sid-2', order: 8 });
+    await redis.set('user:sid-1', JSON.stringify(baseSession));
+
+    const result = await runWaitingHeadPromotion();
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'STALE_STATE_MISMATCH',
+      details: [USER_STATUS.LOGIN],
+    });
+    expect(await redis.lrange('waiting-queue:42', 0, -1)).toEqual([
+      JSON.stringify({ sid: 'sid-2', order: 8 }),
+    ]);
+  });
+
+  it('head 세션 targetEvent가 다르면 stale head만 제거함', async () => {
+    await pushQueueItems({ sid: 'sid-1', order: 7 }, { sid: 'sid-2', order: 8 });
+    await redis.set('user:sid-1', JSON.stringify({ ...waitingSession, targetEvent: 99 }));
+
+    const result = await runWaitingHeadPromotion();
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'STALE_TARGET_EVENT_MISMATCH',
+      details: [99],
+    });
+    expect(await redis.lrange('waiting-queue:42', 0, -1)).toEqual([
+      JSON.stringify({ sid: 'sid-2', order: 8 }),
+    ]);
+  });
+
+  it('깨진 queue item JSON은 typed business denial로 바꾸지 않고 queue head를 보존함', async () => {
+    await redis.rpush('waiting-queue:42', '{broken-json');
+    await redis.hset('in-booking:42:sessions', 'occupied-sid', '{}');
+
+    await expect(runWaitingHeadPromotion({ defaultMaxSize: 1 })).rejects.toThrow();
+    expect(await redis.lindex('waiting-queue:42', 0)).toBe('{broken-json');
+    expect(await redis.zcard('entering:42')).toBe(0);
+  });
+
+  it('깨진 세션 JSON은 typed business denial로 바꾸지 않고 queue head를 보존함', async () => {
+    const head = { sid: 'sid-1', order: 7 };
+    await pushQueueItems(head);
+    await redis.set('user:sid-1', '{broken-json');
+
+    await expect(runWaitingHeadPromotion()).rejects.toThrow();
+    expect(await redis.lindex('waiting-queue:42', 0)).toBe(JSON.stringify(head));
+    expect(await redis.zcard('entering:42')).toBe(0);
+  });
+
+  it('entering 키 타입이 깨져 ZADD가 실패하면 queue head와 세션을 보존함', async () => {
+    const head = { sid: 'sid-1', order: 7 };
+    await pushQueueItems(head);
+    await redis.set('user:sid-1', JSON.stringify(waitingSession));
+    await redis.set('entering:42', 'wrong-type');
+
+    await expect(runWaitingHeadPromotion()).rejects.toThrow();
+    expect(await redis.lindex('waiting-queue:42', 0)).toBe(JSON.stringify(head));
+    expect(JSON.parse((await redis.get('user:sid-1')) ?? '{}')).toEqual(waitingSession);
+  });
+});

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
@@ -412,14 +412,14 @@ describe('admissionCapacityLua 계약', () => {
     );
   });
 
-  it('Lua는 Redis TIME 대신 app-provided nowMs를 entering score로 사용함', () => {
+  it('Lua 모듈은 시각을 직접 읽지 않고 app-provided nowMs를 entering score로 사용함', () => {
     const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
 
-    expect(source).toContain('Date.now()');
     expect(source).toContain('local nowMs = tonumber(ARGV[4])');
     expect(source).toContain("redis.call('ZADD', enteringKey, nowMs,");
     expect(source).not.toContain("redis.call('TIME'");
     expect(source).not.toContain('redis.call("TIME"');
+    expect(source).not.toContain('Date.now()');
   });
 
   it('즉시 입장 성공 경로는 entering zset 쓰기 이후 세션을 최종 저장함', () => {

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.spec.ts
@@ -291,15 +291,22 @@ describe('admissionCapacityLua 계약', () => {
     }
   });
 
-  it('공유 Lua helper는 Redis-side capacity 계산과 TTL 보존 쓰기를 제공함', () => {
+  it('공유 Lua helper는 Redis-side capacity 계산을 제공함', () => {
     const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
 
     expect(source).toContain('local function hasAdmissionCapacity');
     expect(source).toContain("redis.call('HLEN', inBookingSessionsKey)");
-    expect(source).toContain('local function prepareSessionWrite');
-    expect(source).toContain('local function writePreparedSessionPreservingTtl');
-    expect(source).toContain("redis.call('PTTL', sessionKey)");
-    expect(source).toContain("redis.call('PSETEX', sessionKey, ttl, encodedSession)");
+  });
+
+  it('TTL 보존 쓰기를 자체 구현하지 않고 공용 helper에 위임함', () => {
+    const source = readFileSync(join(__dirname, 'admissionCapacityLua.ts'), 'utf8');
+
+    expect(source).toContain('sessionWriteLuaHelpers');
+    expect(source).toContain('prepareSessionWrite(sessionKey, session)');
+    expect(source).toContain('writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)');
+    expect(source).not.toContain('local function prepareSessionWrite');
+    expect(source).not.toContain("redis.call('PSETEX'");
+    expect(source).not.toContain("redis.call('PTTL'");
   });
 
   it('즉시 입장과 대기열 head 승격 Lua 명령을 같은 Redis 인스턴스에 한 번만 등록함', async () => {

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.ts
@@ -1,0 +1,347 @@
+import Redis from 'ioredis';
+
+import {
+  mapLuaUserStateTransitionResult,
+  type LuaUserStateTransitionRawResult,
+  type LuaUserStateTransitionResult,
+} from '../../../auth/fsm/user-state-transition.contract';
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+
+export type ImmediateAdmissionBusinessCode = 'CAPACITY_FULL';
+
+export type WaitingHeadPromotionBusinessCode =
+  | 'CAPACITY_FULL'
+  | 'QUEUE_EMPTY'
+  | 'STALE_SESSION_MISSING'
+  | 'STALE_STATE_MISMATCH'
+  | 'STALE_TARGET_EVENT_MISMATCH';
+
+export const IMMEDIATE_ADMISSION_BUSINESS_CODES = [
+  'CAPACITY_FULL',
+] as const satisfies readonly ImmediateAdmissionBusinessCode[];
+
+export const WAITING_HEAD_PROMOTION_BUSINESS_CODES = [
+  'CAPACITY_FULL',
+  'QUEUE_EMPTY',
+  'STALE_SESSION_MISSING',
+  'STALE_STATE_MISMATCH',
+  'STALE_TARGET_EVENT_MISMATCH',
+] as const satisfies readonly WaitingHeadPromotionBusinessCode[];
+
+export type ImmediateAdmissionLuaResult = LuaUserStateTransitionResult<ImmediateAdmissionBusinessCode>;
+
+export type WaitingHeadPromotionLuaResult = LuaUserStateTransitionResult<WaitingHeadPromotionBusinessCode>;
+
+export type AdmissionCapacityKeys = {
+  enteringKey: string;
+  inBookingSessionsKey: string;
+  reconnectingKey: string;
+  maxSizeKey: string;
+  defaultMaxSizeKey: string;
+};
+
+export type ImmediateAdmissionLuaInput = {
+  sessionKey: string;
+  eventId: number;
+  keys: AdmissionCapacityKeys;
+  defaultMaxSize: number;
+  nowMs: number;
+};
+
+export type WaitingHeadPromotionLuaInput = {
+  waitingQueueKey: string;
+  userKeyPrefix: string;
+  eventId: number;
+  keys: AdmissionCapacityKeys;
+  defaultMaxSize: number;
+  nowMs: number;
+};
+
+export const admissionCapacityLuaHelpers = `
+  local function readPositiveNumber(key)
+    local raw = redis.call('GET', key)
+    if raw then
+      return tonumber(raw)
+    end
+    return nil
+  end
+
+  local function getMaxSize(maxSizeKey, defaultMaxSizeKey, defaultMaxSizeFallback)
+    local eventMaxSize = readPositiveNumber(maxSizeKey)
+    if eventMaxSize then
+      return eventMaxSize
+    end
+
+    local defaultMaxSize = readPositiveNumber(defaultMaxSizeKey)
+    if defaultMaxSize then
+      return defaultMaxSize
+    end
+
+    return tonumber(defaultMaxSizeFallback)
+  end
+
+  local function hasAdmissionCapacity(
+    inBookingSessionsKey,
+    reconnectingKey,
+    enteringKey,
+    maxSizeKey,
+    defaultMaxSizeKey,
+    defaultMaxSizeFallback
+  )
+    local inBookingCount = redis.call('HLEN', inBookingSessionsKey)
+    local reconnectingCount = redis.call('ZCARD', reconnectingKey)
+    local enteringCount = redis.call('ZCARD', enteringKey)
+    local maxSize = getMaxSize(maxSizeKey, defaultMaxSizeKey, defaultMaxSizeFallback)
+
+    return inBookingCount + reconnectingCount + enteringCount < maxSize
+  end
+
+  local function prepareSessionWrite(sessionKey, session)
+    local encodedSession = cjson.encode(session)
+    local ttl = redis.call('PTTL', sessionKey)
+    if ttl == -2 or ttl == 0 then
+      return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'
+    end
+
+    if ttl > 0 or ttl == -1 then
+      return encodedSession, ttl, 'OK'
+    end
+
+    return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'
+  end
+
+  local function writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+    if ttl > 0 then
+      redis.call('PSETEX', sessionKey, ttl, encodedSession)
+      return
+    end
+
+    redis.call('SET', sessionKey, encodedSession)
+  end
+`;
+
+export const immediateAdmissionLua = `
+  ${admissionCapacityLuaHelpers}
+
+  local sessionKey = KEYS[1]
+  local enteringKey = KEYS[2]
+  local inBookingSessionsKey = KEYS[3]
+  local reconnectingKey = KEYS[4]
+  local maxSizeKey = KEYS[5]
+
+  local eventId = tonumber(ARGV[1])
+  local defaultMaxSizeKey = ARGV[2]
+  local defaultMaxSizeFallback = ARGV[3]
+  local nowMs = tonumber(ARGV[4])
+
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    return {'SESSION_MISSING'}
+  end
+
+  local session = cjson.decode(raw)
+  if session.userStatus ~= 'LOGIN' then
+    return {'STATE_MISMATCH', session.userStatus}
+  end
+
+  if session.targetEvent ~= cjson.null then
+    return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+  end
+
+  if not hasAdmissionCapacity(
+    inBookingSessionsKey,
+    reconnectingKey,
+    enteringKey,
+    maxSizeKey,
+    defaultMaxSizeKey,
+    defaultMaxSizeFallback
+  ) then
+    return {'CAPACITY_FULL'}
+  end
+
+  session.userStatus = 'ENTERING'
+  session.targetEvent = eventId
+
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
+  end
+
+  local sid = string.sub(sessionKey, string.len('user:') + 1)
+  redis.call('ZADD', enteringKey, nowMs, sid)
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+
+  return {'OK'}
+`;
+
+export const waitingHeadPromotionLua = `
+  ${admissionCapacityLuaHelpers}
+
+  local waitingQueueKey = KEYS[1]
+  local enteringKey = KEYS[2]
+  local inBookingSessionsKey = KEYS[3]
+  local reconnectingKey = KEYS[4]
+  local maxSizeKey = KEYS[5]
+  local defaultMaxSizeKey = KEYS[6]
+
+  local eventId = tonumber(ARGV[1])
+  local userKeyPrefix = ARGV[2]
+  local defaultMaxSizeFallback = ARGV[3]
+  local nowMs = tonumber(ARGV[4])
+
+  local head = redis.call('LINDEX', waitingQueueKey, 0)
+  if not head then
+    return {'QUEUE_EMPTY'}
+  end
+
+  local item = cjson.decode(head)
+  local sid = item.sid
+
+  if not hasAdmissionCapacity(
+    inBookingSessionsKey,
+    reconnectingKey,
+    enteringKey,
+    maxSizeKey,
+    defaultMaxSizeKey,
+    defaultMaxSizeFallback
+  ) then
+    return {'CAPACITY_FULL'}
+  end
+
+  local sessionKey = userKeyPrefix .. sid
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    redis.call('LPOP', waitingQueueKey)
+    return {'STALE_SESSION_MISSING', sid}
+  end
+
+  local session = cjson.decode(raw)
+  if session.userStatus ~= 'WAITING' then
+    redis.call('LPOP', waitingQueueKey)
+    return {'STALE_STATE_MISMATCH', session.userStatus}
+  end
+
+  if session.targetEvent ~= eventId then
+    redis.call('LPOP', waitingQueueKey)
+    return {'STALE_TARGET_EVENT_MISMATCH', session.targetEvent}
+  end
+
+  session.userStatus = 'ENTERING'
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
+  end
+
+  redis.call('ZADD', enteringKey, nowMs, sid)
+  redis.call('LPOP', waitingQueueKey)
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+  return {'OK'}
+`;
+
+type RedisWithAdmissionCapacityCommands = Redis & {
+  admitBookingGateImmediate(
+    sessionKey: string,
+    enteringKey: string,
+    inBookingSessionsKey: string,
+    reconnectingKey: string,
+    maxSizeKey: string,
+    eventId: string,
+    defaultMaxSizeKey: string,
+    defaultMaxSize: string,
+    nowMs: string,
+  ): Promise<LuaUserStateTransitionRawResult<ImmediateAdmissionBusinessCode>>;
+
+  promoteWaitingQueueHead(
+    waitingQueueKey: string,
+    enteringKey: string,
+    inBookingSessionsKey: string,
+    reconnectingKey: string,
+    maxSizeKey: string,
+    defaultMaxSizeKey: string,
+    eventId: string,
+    userKeyPrefix: string,
+    defaultMaxSize: string,
+    nowMs: string,
+  ): Promise<LuaUserStateTransitionRawResult<WaitingHeadPromotionBusinessCode>>;
+};
+
+const commandRegisteredRedisSet = new WeakSet<object>();
+
+function getAdmissionCapacityCommandRedis(redis: Redis): RedisWithAdmissionCapacityCommands {
+  if (!commandRegisteredRedisSet.has(redis)) {
+    redis.defineCommand('admitBookingGateImmediate', {
+      numberOfKeys: 5,
+      lua: immediateAdmissionLua,
+    });
+    redis.defineCommand('promoteWaitingQueueHead', {
+      numberOfKeys: 6,
+      lua: waitingHeadPromotionLua,
+    });
+    commandRegisteredRedisSet.add(redis);
+  }
+
+  return redis as RedisWithAdmissionCapacityCommands;
+}
+
+export function mapImmediateAdmissionLuaResult(
+  raw: LuaUserStateTransitionRawResult<ImmediateAdmissionBusinessCode>,
+): ImmediateAdmissionLuaResult {
+  return mapLuaUserStateTransitionResult(raw, {
+    action: 'enterBookingGate',
+    expectedFrom: USER_STATUS.LOGIN,
+    nextTo: USER_STATUS.ENTERING,
+    businessCodes: IMMEDIATE_ADMISSION_BUSINESS_CODES,
+  });
+}
+
+export function mapWaitingHeadPromotionLuaResult(
+  raw: LuaUserStateTransitionRawResult<WaitingHeadPromotionBusinessCode>,
+): WaitingHeadPromotionLuaResult {
+  return mapLuaUserStateTransitionResult(raw, {
+    action: 'enterBookingGate',
+    expectedFrom: USER_STATUS.WAITING,
+    nextTo: USER_STATUS.ENTERING,
+    businessCodes: WAITING_HEAD_PROMOTION_BUSINESS_CODES,
+  });
+}
+
+export async function runImmediateAdmissionLua(
+  redis: Redis,
+  input: ImmediateAdmissionLuaInput,
+): Promise<ImmediateAdmissionLuaResult> {
+  const commandRedis = getAdmissionCapacityCommandRedis(redis);
+  const rawResult = await commandRedis.admitBookingGateImmediate(
+    input.sessionKey,
+    input.keys.enteringKey,
+    input.keys.inBookingSessionsKey,
+    input.keys.reconnectingKey,
+    input.keys.maxSizeKey,
+    String(input.eventId),
+    input.keys.defaultMaxSizeKey,
+    String(input.defaultMaxSize),
+    String(input.nowMs),
+  );
+
+  return mapImmediateAdmissionLuaResult(rawResult);
+}
+
+export async function runWaitingHeadPromotionLua(
+  redis: Redis,
+  input: WaitingHeadPromotionLuaInput,
+): Promise<WaitingHeadPromotionLuaResult> {
+  const commandRedis = getAdmissionCapacityCommandRedis(redis);
+  const rawResult = await commandRedis.promoteWaitingQueueHead(
+    input.waitingQueueKey,
+    input.keys.enteringKey,
+    input.keys.inBookingSessionsKey,
+    input.keys.reconnectingKey,
+    input.keys.maxSizeKey,
+    input.keys.defaultMaxSizeKey,
+    String(input.eventId),
+    input.userKeyPrefix,
+    String(input.defaultMaxSize),
+    String(input.nowMs),
+  );
+
+  return mapWaitingHeadPromotionLuaResult(rawResult);
+}

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.ts
@@ -6,6 +6,7 @@ import {
   type LuaUserStateTransitionResult,
 } from '../../../auth/fsm/user-state-transition.contract';
 import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { sessionWriteLuaHelpers } from '../../../auth/luaScripts/sessionLuaHelpers';
 
 export type ImmediateAdmissionBusinessCode = 'CAPACITY_FULL';
 
@@ -58,6 +59,8 @@ export type WaitingHeadPromotionLuaInput = {
 };
 
 export const admissionCapacityLuaHelpers = `
+  ${sessionWriteLuaHelpers}
+
   local function readPositiveNumber(key)
     local raw = redis.call('GET', key)
     if raw then
@@ -94,29 +97,6 @@ export const admissionCapacityLuaHelpers = `
     local maxSize = getMaxSize(maxSizeKey, defaultMaxSizeKey, defaultMaxSizeFallback)
 
     return inBookingCount + reconnectingCount + enteringCount < maxSize
-  end
-
-  local function prepareSessionWrite(sessionKey, session)
-    local encodedSession = cjson.encode(session)
-    local ttl = redis.call('PTTL', sessionKey)
-    if ttl == -2 or ttl == 0 then
-      return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'
-    end
-
-    if ttl > 0 or ttl == -1 then
-      return encodedSession, ttl, 'OK'
-    end
-
-    return nil, nil, 'SESSION_EXPIRED_DURING_WRITE'
-  end
-
-  local function writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
-    if ttl > 0 then
-      redis.call('PSETEX', sessionKey, ttl, encodedSession)
-      return
-    end
-
-    redis.call('SET', sessionKey, encodedSession)
   end
 `;
 

--- a/back/src/domains/booking/luaScripts/admissionCapacityLua.ts
+++ b/back/src/domains/booking/luaScripts/admissionCapacityLua.ts
@@ -2,6 +2,7 @@ import Redis from 'ioredis';
 
 import {
   mapLuaUserStateTransitionResult,
+  resolveUserStateTransition,
   type LuaUserStateTransitionRawResult,
   type LuaUserStateTransitionResult,
 } from '../../../auth/fsm/user-state-transition.contract';
@@ -28,6 +29,16 @@ export const WAITING_HEAD_PROMOTION_BUSINESS_CODES = [
   'STALE_STATE_MISMATCH',
   'STALE_TARGET_EVENT_MISMATCH',
 ] as const satisfies readonly WaitingHeadPromotionBusinessCode[];
+
+export const IMMEDIATE_ADMISSION_TRANSITION = resolveUserStateTransition(
+  'enterBookingGate',
+  USER_STATUS.LOGIN,
+);
+
+export const WAITING_HEAD_PROMOTION_TRANSITION = resolveUserStateTransition(
+  'enterBookingGate',
+  USER_STATUS.WAITING,
+);
 
 export type ImmediateAdmissionLuaResult = LuaUserStateTransitionResult<ImmediateAdmissionBusinessCode>;
 
@@ -113,6 +124,8 @@ export const immediateAdmissionLua = `
   local defaultMaxSizeKey = ARGV[2]
   local defaultMaxSizeFallback = ARGV[3]
   local nowMs = tonumber(ARGV[4])
+  local expectedFrom = ARGV[5]
+  local nextTo = ARGV[6]
 
   local raw = redis.call('GET', sessionKey)
   if not raw then
@@ -120,7 +133,7 @@ export const immediateAdmissionLua = `
   end
 
   local session = cjson.decode(raw)
-  if session.userStatus ~= 'LOGIN' then
+  if session.userStatus ~= expectedFrom then
     return {'STATE_MISMATCH', session.userStatus}
   end
 
@@ -139,7 +152,7 @@ export const immediateAdmissionLua = `
     return {'CAPACITY_FULL'}
   end
 
-  session.userStatus = 'ENTERING'
+  session.userStatus = nextTo
   session.targetEvent = eventId
 
   local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
@@ -168,6 +181,8 @@ export const waitingHeadPromotionLua = `
   local userKeyPrefix = ARGV[2]
   local defaultMaxSizeFallback = ARGV[3]
   local nowMs = tonumber(ARGV[4])
+  local expectedFrom = ARGV[5]
+  local nextTo = ARGV[6]
 
   local head = redis.call('LINDEX', waitingQueueKey, 0)
   if not head then
@@ -196,7 +211,7 @@ export const waitingHeadPromotionLua = `
   end
 
   local session = cjson.decode(raw)
-  if session.userStatus ~= 'WAITING' then
+  if session.userStatus ~= expectedFrom then
     redis.call('LPOP', waitingQueueKey)
     return {'STALE_STATE_MISMATCH', session.userStatus}
   end
@@ -206,7 +221,7 @@ export const waitingHeadPromotionLua = `
     return {'STALE_TARGET_EVENT_MISMATCH', session.targetEvent}
   end
 
-  session.userStatus = 'ENTERING'
+  session.userStatus = nextTo
   local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
   if prepareCode ~= 'OK' then
     return {prepareCode}
@@ -229,6 +244,8 @@ type RedisWithAdmissionCapacityCommands = Redis & {
     defaultMaxSizeKey: string,
     defaultMaxSize: string,
     nowMs: string,
+    expectedFrom: string,
+    nextTo: string,
   ): Promise<LuaUserStateTransitionRawResult<ImmediateAdmissionBusinessCode>>;
 
   promoteWaitingQueueHead(
@@ -242,6 +259,8 @@ type RedisWithAdmissionCapacityCommands = Redis & {
     userKeyPrefix: string,
     defaultMaxSize: string,
     nowMs: string,
+    expectedFrom: string,
+    nextTo: string,
   ): Promise<LuaUserStateTransitionRawResult<WaitingHeadPromotionBusinessCode>>;
 };
 
@@ -267,9 +286,9 @@ export function mapImmediateAdmissionLuaResult(
   raw: LuaUserStateTransitionRawResult<ImmediateAdmissionBusinessCode>,
 ): ImmediateAdmissionLuaResult {
   return mapLuaUserStateTransitionResult(raw, {
-    action: 'enterBookingGate',
-    expectedFrom: USER_STATUS.LOGIN,
-    nextTo: USER_STATUS.ENTERING,
+    action: IMMEDIATE_ADMISSION_TRANSITION.action,
+    expectedFrom: IMMEDIATE_ADMISSION_TRANSITION.from,
+    nextTo: IMMEDIATE_ADMISSION_TRANSITION.to,
     businessCodes: IMMEDIATE_ADMISSION_BUSINESS_CODES,
   });
 }
@@ -278,9 +297,9 @@ export function mapWaitingHeadPromotionLuaResult(
   raw: LuaUserStateTransitionRawResult<WaitingHeadPromotionBusinessCode>,
 ): WaitingHeadPromotionLuaResult {
   return mapLuaUserStateTransitionResult(raw, {
-    action: 'enterBookingGate',
-    expectedFrom: USER_STATUS.WAITING,
-    nextTo: USER_STATUS.ENTERING,
+    action: WAITING_HEAD_PROMOTION_TRANSITION.action,
+    expectedFrom: WAITING_HEAD_PROMOTION_TRANSITION.from,
+    nextTo: WAITING_HEAD_PROMOTION_TRANSITION.to,
     businessCodes: WAITING_HEAD_PROMOTION_BUSINESS_CODES,
   });
 }
@@ -300,6 +319,8 @@ export async function runImmediateAdmissionLua(
     input.keys.defaultMaxSizeKey,
     String(input.defaultMaxSize),
     String(input.nowMs),
+    IMMEDIATE_ADMISSION_TRANSITION.from,
+    IMMEDIATE_ADMISSION_TRANSITION.to,
   );
 
   return mapImmediateAdmissionLuaResult(rawResult);
@@ -321,6 +342,8 @@ export async function runWaitingHeadPromotionLua(
     input.userKeyPrefix,
     String(input.defaultMaxSize),
     String(input.nowMs),
+    WAITING_HEAD_PROMOTION_TRANSITION.from,
+    WAITING_HEAD_PROMOTION_TRANSITION.to,
   );
 
   return mapWaitingHeadPromotionLuaResult(rawResult);

--- a/back/src/domains/booking/luaScripts/inBookingSessionLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/inBookingSessionLua.spec.ts
@@ -1,0 +1,366 @@
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+
+import { installInBookingSessionCommandMock } from '../../../testing/redis/in-booking-session-command-mock';
+
+import {
+  addBookedSeatLua,
+  flushBookedSeatsLua,
+  inBookingSessionLuaHelpers,
+  removeBookedSeatLua,
+  runAddBookedSeatLua,
+  runFlushBookedSeatsLua,
+  runRemoveBookedSeatLua,
+  runSetInBookingSavedLua,
+  runSetSubscribedSectionLua,
+  setInBookingSavedLua,
+  setSubscribedSectionLua,
+  type Seat,
+} from './inBookingSessionLua';
+
+const EVENT_ID = 42;
+const SID = 'sid-1';
+const IN_BOOKING_KEY = `in-booking:${EVENT_ID}:sessions`;
+
+function inBookingSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sid: SID,
+    bookingAmount: 2,
+    bookedSeats: [] as Seat[],
+    saved: false,
+    subscribedSection: null,
+    ...overrides,
+  };
+}
+
+/** 운영 Lua와 같은 계약을 emulate하는 테스트용 command mock을 그대로 사용함. */
+function createCommandRedis(): Redis {
+  const redis = new RedisMock() as unknown as Redis;
+  installInBookingSessionCommandMock(redis);
+  return redis;
+}
+
+async function seedSession(redis: Redis, overrides: Partial<Record<string, unknown>> = {}) {
+  await redis.hset(IN_BOOKING_KEY, SID, JSON.stringify(inBookingSession(overrides)));
+}
+
+async function readSession(redis: Redis): Promise<Record<string, unknown> | null> {
+  const raw = await redis.hget(IN_BOOKING_KEY, SID);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+describe('in-booking 좌석 추가 Lua', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('세션이 없으면 SESSION_NOT_FOUND를 반환함', async () => {
+    const result = await runAddBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      enforceQuota: true,
+    });
+
+    expect(result.code).toBe('SESSION_NOT_FOUND');
+  });
+
+  it('예매 수량을 넘어서면 QUOTA_EXCEEDED를 반환하고 좌석을 추가하지 않음', async () => {
+    await seedSession(redis, { bookingAmount: 1, bookedSeats: [[0, 0]] });
+
+    const result = await runAddBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      enforceQuota: true,
+    });
+
+    expect(result.code).toBe('QUOTA_EXCEEDED');
+    expect(await readSession(redis)).toMatchObject({ bookedSeats: [[0, 0]] });
+  });
+
+  it('롤백처럼 수량 검사를 끄면 정원을 넘겨도 되돌려 넣음', async () => {
+    await seedSession(redis, { bookingAmount: 1, bookedSeats: [[0, 0]] });
+
+    const result = await runAddBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      enforceQuota: false,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(await readSession(redis)).toMatchObject({
+      bookedSeats: [
+        [0, 0],
+        [1, 2],
+      ],
+    });
+  });
+
+  it('빈 좌석 목록에 추가해도 다른 필드를 보존함', async () => {
+    await seedSession(redis, { subscribedSection: 3 });
+
+    await runAddBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      enforceQuota: true,
+    });
+
+    expect(await readSession(redis)).toEqual({
+      sid: SID,
+      bookingAmount: 2,
+      bookedSeats: [[1, 2]],
+      saved: false,
+      subscribedSection: 3,
+    });
+  });
+});
+
+describe('in-booking 좌석 제거 Lua', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('좌석이 없는데 취소를 요구하면 CANCEL_EMPTY를 반환함', async () => {
+    await seedSession(redis);
+
+    const result = await runRemoveBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      requireBooked: true,
+    });
+
+    expect(result.code).toBe('CANCEL_EMPTY');
+  });
+
+  it('점유하지 않은 좌석을 취소하면 SEAT_NOT_BOOKED를 반환함', async () => {
+    await seedSession(redis, { bookedSeats: [[0, 0]] });
+
+    const result = await runRemoveBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      requireBooked: true,
+    });
+
+    expect(result.code).toBe('SEAT_NOT_BOOKED');
+    expect(await readSession(redis)).toMatchObject({ bookedSeats: [[0, 0]] });
+  });
+
+  it('취소하면 해당 좌석만 빼고 나머지를 보존함', async () => {
+    await seedSession(redis, {
+      bookedSeats: [
+        [0, 0],
+        [1, 2],
+      ],
+    });
+
+    const result = await runRemoveBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [0, 0],
+      requireBooked: true,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(await readSession(redis)).toMatchObject({ bookedSeats: [[1, 2]] });
+  });
+
+  it('롤백 모드는 없는 좌석을 지워도 실패로 보지 않음', async () => {
+    await seedSession(redis);
+
+    const result = await runRemoveBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      requireBooked: false,
+    });
+
+    expect(result.code).toBe('OK');
+  });
+
+  it('마지막 좌석을 빼도 좌석 목록이 배열로 유지됨', async () => {
+    await seedSession(redis, { bookedSeats: [[1, 2]] });
+
+    await runRemoveBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      requireBooked: true,
+    });
+
+    const session = await readSession(redis);
+    expect(Array.isArray(session?.bookedSeats)).toBe(true);
+    expect(session?.bookedSeats).toEqual([]);
+  });
+});
+
+describe('in-booking 좌석 회수 Lua', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('좌석 목록을 한 번에 꺼내면서 비움', async () => {
+    await seedSession(redis, {
+      bookedSeats: [
+        [0, 0],
+        [1, 2],
+      ],
+    });
+
+    const result = await runFlushBookedSeatsLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(result.seats).toEqual([
+      [0, 0],
+      [1, 2],
+    ]);
+    expect(await readSession(redis)).toMatchObject({ bookedSeats: [] });
+  });
+
+  it('예매 수량을 함께 지정하면 좌석을 비우고 수량을 바꿈', async () => {
+    await seedSession(redis, { bookedSeats: [[0, 0]] });
+
+    const result = await runFlushBookedSeatsLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      bookingAmount: 5,
+    });
+
+    expect(result.seats).toEqual([[0, 0]]);
+    expect(await readSession(redis)).toMatchObject({ bookedSeats: [], bookingAmount: 5 });
+  });
+
+  it('이미 예매가 확정된 세션은 좌석을 회수하지 않음', async () => {
+    await seedSession(redis, { bookedSeats: [[0, 0]], saved: true });
+
+    const result = await runFlushBookedSeatsLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      onlyWhenUnsaved: true,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(result.seats).toEqual([]);
+    expect(await readSession(redis)).toMatchObject({ bookedSeats: [[0, 0]] });
+  });
+
+  it('세션이 없으면 좌석 목록을 빈 배열로 돌려줌', async () => {
+    const result = await runFlushBookedSeatsLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+    });
+
+    expect(result.code).toBe('SESSION_NOT_FOUND');
+    expect(result.seats).toEqual([]);
+  });
+});
+
+describe('in-booking 스칼라 필드 Lua', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('예매 확정 표시는 좌석 목록을 건드리지 않음', async () => {
+    await seedSession(redis, { bookedSeats: [[0, 0]] });
+
+    const result = await runSetInBookingSavedLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      saved: true,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(await readSession(redis)).toMatchObject({ saved: true, bookedSeats: [[0, 0]] });
+  });
+
+  it('구독 섹션 갱신은 좌석 목록을 건드리지 않음', async () => {
+    await seedSession(redis, { bookedSeats: [[0, 0]] });
+
+    const result = await runSetSubscribedSectionLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      sectionIndex: 3,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(await readSession(redis)).toMatchObject({ subscribedSection: 3, bookedSeats: [[0, 0]] });
+  });
+
+  it('구독 섹션을 비우면 null로 저장함', async () => {
+    await seedSession(redis, { subscribedSection: 3 });
+
+    await runSetSubscribedSectionLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      sectionIndex: null,
+    });
+
+    expect(await readSession(redis)).toMatchObject({ subscribedSection: null });
+  });
+});
+
+describe('in-booking 세션 Lua 정적 계약', () => {
+  it('빈 좌석 목록이 객체로 인코딩되지 않도록 되돌림', () => {
+    expect(inBookingSessionLuaHelpers).toContain(
+      `string.gsub(encoded, '"bookedSeats":{}', '"bookedSeats":[]')`,
+    );
+  });
+
+  it('세션 인코딩은 helper 한 곳에서만 수행함', () => {
+    for (const script of [
+      addBookedSeatLua,
+      removeBookedSeatLua,
+      flushBookedSeatsLua,
+      setInBookingSavedLua,
+      setSubscribedSectionLua,
+    ]) {
+      expect(script).toContain('writeInBookingSession(inBookingSessionsKey, sid, session)');
+      // helper 정의 1회 외에 스크립트 본문에서 직접 encode하지 않음
+      expect(script.split('cjson.encode(session)')).toHaveLength(2);
+    }
+  });
+
+  it('회수한 좌석 목록은 항상 배열 형태로 직렬화함', () => {
+    expect(inBookingSessionLuaHelpers).toContain("return '[' .. table.concat(parts, ',') .. ']'");
+    expect(flushBookedSeatsLua).toContain('encodeSeatList(session.bookedSeats)');
+  });
+
+  it('스크립트 본문 직접 eval 대신 script cache 명령으로 등록함', () => {
+    expect(addBookedSeatLua).not.toMatch(/redis\.eval\(/);
+  });
+});

--- a/back/src/domains/booking/luaScripts/inBookingSessionLua.ts
+++ b/back/src/domains/booking/luaScripts/inBookingSessionLua.ts
@@ -1,0 +1,363 @@
+import Redis from 'ioredis';
+
+export type Seat = [number, number];
+
+export type InBookingSessionLuaCode =
+  | 'OK'
+  | 'SESSION_NOT_FOUND'
+  | 'QUOTA_EXCEEDED'
+  | 'CANCEL_EMPTY'
+  | 'SEAT_NOT_BOOKED';
+
+export type InBookingSessionLuaResult = { code: InBookingSessionLuaCode };
+
+export type FlushedSeatsLuaResult = { code: InBookingSessionLuaCode; seats: Seat[] };
+
+const IN_BOOKING_SESSION_CODES: readonly InBookingSessionLuaCode[] = [
+  'OK',
+  'SESSION_NOT_FOUND',
+  'QUOTA_EXCEEDED',
+  'CANCEL_EMPTY',
+  'SEAT_NOT_BOOKED',
+];
+
+/** cjson은 빈 테이블을 배열이 아닌 객체(`{}`)로 인코딩하므로 좌석 목록 형태를 되돌린다. */
+export const inBookingSessionLuaHelpers = `
+  local function readInBookingSession(inBookingSessionsKey, sid)
+    local raw = redis.call('HGET', inBookingSessionsKey, sid)
+    if not raw then
+      return nil
+    end
+    return cjson.decode(raw)
+  end
+
+  local function encodeInBookingSession(session)
+    local encoded = cjson.encode(session)
+    return (string.gsub(encoded, '"bookedSeats":{}', '"bookedSeats":[]'))
+  end
+
+  local function writeInBookingSession(inBookingSessionsKey, sid, session)
+    redis.call('HSET', inBookingSessionsKey, sid, encodeInBookingSession(session))
+  end
+
+  local function encodeSeatList(seats)
+    local parts = {}
+    for i = 1, #seats do
+      parts[i] = '[' .. seats[i][1] .. ',' .. seats[i][2] .. ']'
+    end
+    return '[' .. table.concat(parts, ',') .. ']'
+  end
+
+  local function findSeatIndex(bookedSeats, sectionIndex, seatIndex)
+    for i = 1, #bookedSeats do
+      local seat = bookedSeats[i]
+      if seat[1] == sectionIndex and seat[2] == seatIndex then
+        return i
+      end
+    end
+    return nil
+  end
+`;
+
+export const addBookedSeatLua = `
+  ${inBookingSessionLuaHelpers}
+
+  local inBookingSessionsKey = KEYS[1]
+
+  local sid = ARGV[1]
+  local sectionIndex = tonumber(ARGV[2])
+  local seatIndex = tonumber(ARGV[3])
+  local enforceQuota = ARGV[4] == '1'
+
+  local session = readInBookingSession(inBookingSessionsKey, sid)
+  if not session then
+    return {'SESSION_NOT_FOUND'}
+  end
+
+  if enforceQuota and session.bookingAmount <= #session.bookedSeats then
+    return {'QUOTA_EXCEEDED'}
+  end
+
+  table.insert(session.bookedSeats, {sectionIndex, seatIndex})
+  writeInBookingSession(inBookingSessionsKey, sid, session)
+
+  return {'OK'}
+`;
+
+export const removeBookedSeatLua = `
+  ${inBookingSessionLuaHelpers}
+
+  local inBookingSessionsKey = KEYS[1]
+
+  local sid = ARGV[1]
+  local sectionIndex = tonumber(ARGV[2])
+  local seatIndex = tonumber(ARGV[3])
+  local requireBooked = ARGV[4] == '1'
+
+  local session = readInBookingSession(inBookingSessionsKey, sid)
+  if not session then
+    if requireBooked then
+      return {'CANCEL_EMPTY'}
+    end
+    return {'SESSION_NOT_FOUND'}
+  end
+
+  if requireBooked and #session.bookedSeats == 0 then
+    return {'CANCEL_EMPTY'}
+  end
+
+  local foundIndex = findSeatIndex(session.bookedSeats, sectionIndex, seatIndex)
+  if not foundIndex then
+    if requireBooked then
+      return {'SEAT_NOT_BOOKED'}
+    end
+    return {'OK'}
+  end
+
+  table.remove(session.bookedSeats, foundIndex)
+  writeInBookingSession(inBookingSessionsKey, sid, session)
+
+  return {'OK'}
+`;
+
+export const flushBookedSeatsLua = `
+  ${inBookingSessionLuaHelpers}
+
+  local inBookingSessionsKey = KEYS[1]
+
+  local sid = ARGV[1]
+  local setBookingAmount = ARGV[2] == '1'
+  local bookingAmount = tonumber(ARGV[3])
+  local onlyWhenUnsaved = ARGV[4] == '1'
+
+  local session = readInBookingSession(inBookingSessionsKey, sid)
+  if not session then
+    return {'SESSION_NOT_FOUND', '[]'}
+  end
+
+  if onlyWhenUnsaved and session.saved then
+    return {'OK', '[]'}
+  end
+
+  local flushedSeats = encodeSeatList(session.bookedSeats)
+  session.bookedSeats = {}
+
+  if setBookingAmount then
+    session.bookingAmount = bookingAmount
+  end
+
+  writeInBookingSession(inBookingSessionsKey, sid, session)
+
+  return {'OK', flushedSeats}
+`;
+
+export const setInBookingSavedLua = `
+  ${inBookingSessionLuaHelpers}
+
+  local inBookingSessionsKey = KEYS[1]
+
+  local sid = ARGV[1]
+  local saved = ARGV[2] == '1'
+
+  local session = readInBookingSession(inBookingSessionsKey, sid)
+  if not session then
+    return {'SESSION_NOT_FOUND'}
+  end
+
+  session.saved = saved
+  writeInBookingSession(inBookingSessionsKey, sid, session)
+
+  return {'OK'}
+`;
+
+export const setSubscribedSectionLua = `
+  ${inBookingSessionLuaHelpers}
+
+  local inBookingSessionsKey = KEYS[1]
+
+  local sid = ARGV[1]
+  local hasSection = ARGV[2] == '1'
+  local sectionIndex = tonumber(ARGV[3])
+
+  local session = readInBookingSession(inBookingSessionsKey, sid)
+  if not session then
+    return {'SESSION_NOT_FOUND'}
+  end
+
+  if hasSection then
+    session.subscribedSection = sectionIndex
+  else
+    session.subscribedSection = cjson.null
+  end
+
+  writeInBookingSession(inBookingSessionsKey, sid, session)
+
+  return {'OK'}
+`;
+
+type InBookingSessionRawResult = [InBookingSessionLuaCode, ...unknown[]] | InBookingSessionLuaCode;
+
+type RedisWithInBookingSessionCommands = Redis & {
+  addInBookingBookedSeat(
+    inBookingSessionsKey: string,
+    sid: string,
+    sectionIndex: string,
+    seatIndex: string,
+    enforceQuota: string,
+  ): Promise<InBookingSessionRawResult>;
+
+  removeInBookingBookedSeat(
+    inBookingSessionsKey: string,
+    sid: string,
+    sectionIndex: string,
+    seatIndex: string,
+    requireBooked: string,
+  ): Promise<InBookingSessionRawResult>;
+
+  flushInBookingBookedSeats(
+    inBookingSessionsKey: string,
+    sid: string,
+    setBookingAmount: string,
+    bookingAmount: string,
+    onlyWhenUnsaved: string,
+  ): Promise<InBookingSessionRawResult>;
+
+  setInBookingSaved(
+    inBookingSessionsKey: string,
+    sid: string,
+    saved: string,
+  ): Promise<InBookingSessionRawResult>;
+
+  setInBookingSubscribedSection(
+    inBookingSessionsKey: string,
+    sid: string,
+    hasSection: string,
+    sectionIndex: string,
+  ): Promise<InBookingSessionRawResult>;
+};
+
+const commandRegisteredRedisSet = new WeakSet<object>();
+
+function getInBookingSessionCommandRedis(redis: Redis): RedisWithInBookingSessionCommands {
+  if (!commandRegisteredRedisSet.has(redis)) {
+    redis.defineCommand('addInBookingBookedSeat', { numberOfKeys: 1, lua: addBookedSeatLua });
+    redis.defineCommand('removeInBookingBookedSeat', { numberOfKeys: 1, lua: removeBookedSeatLua });
+    redis.defineCommand('flushInBookingBookedSeats', { numberOfKeys: 1, lua: flushBookedSeatsLua });
+    redis.defineCommand('setInBookingSaved', { numberOfKeys: 1, lua: setInBookingSavedLua });
+    redis.defineCommand('setInBookingSubscribedSection', {
+      numberOfKeys: 1,
+      lua: setSubscribedSectionLua,
+    });
+    commandRegisteredRedisSet.add(redis);
+  }
+
+  return redis as RedisWithInBookingSessionCommands;
+}
+
+function parseCode(raw: InBookingSessionRawResult): InBookingSessionLuaCode {
+  const code = Array.isArray(raw) ? raw[0] : raw;
+
+  if (!IN_BOOKING_SESSION_CODES.includes(code)) {
+    throw new TypeError(`Unknown in-booking session Lua code: ${String(code)}`);
+  }
+
+  return code;
+}
+
+export function mapInBookingSessionLuaResult(raw: InBookingSessionRawResult): InBookingSessionLuaResult {
+  return { code: parseCode(raw) };
+}
+
+export function mapFlushedSeatsLuaResult(raw: InBookingSessionRawResult): FlushedSeatsLuaResult {
+  const code = parseCode(raw);
+  const encodedSeats = Array.isArray(raw) ? raw[1] : undefined;
+
+  if (typeof encodedSeats !== 'string') {
+    throw new TypeError('좌석 회수 Lua는 좌석 목록 JSON을 함께 반환해야 함');
+  }
+
+  return { code, seats: JSON.parse(encodedSeats) as Seat[] };
+}
+
+export async function runAddBookedSeatLua(
+  redis: Redis,
+  input: { inBookingSessionsKey: string; sid: string; seat: Seat; enforceQuota: boolean },
+): Promise<InBookingSessionLuaResult> {
+  const commandRedis = getInBookingSessionCommandRedis(redis);
+  const rawResult = await commandRedis.addInBookingBookedSeat(
+    input.inBookingSessionsKey,
+    input.sid,
+    String(input.seat[0]),
+    String(input.seat[1]),
+    input.enforceQuota ? '1' : '0',
+  );
+
+  return mapInBookingSessionLuaResult(rawResult);
+}
+
+export async function runRemoveBookedSeatLua(
+  redis: Redis,
+  input: { inBookingSessionsKey: string; sid: string; seat: Seat; requireBooked: boolean },
+): Promise<InBookingSessionLuaResult> {
+  const commandRedis = getInBookingSessionCommandRedis(redis);
+  const rawResult = await commandRedis.removeInBookingBookedSeat(
+    input.inBookingSessionsKey,
+    input.sid,
+    String(input.seat[0]),
+    String(input.seat[1]),
+    input.requireBooked ? '1' : '0',
+  );
+
+  return mapInBookingSessionLuaResult(rawResult);
+}
+
+export async function runFlushBookedSeatsLua(
+  redis: Redis,
+  input: {
+    inBookingSessionsKey: string;
+    sid: string;
+    bookingAmount?: number;
+    onlyWhenUnsaved?: boolean;
+  },
+): Promise<FlushedSeatsLuaResult> {
+  const commandRedis = getInBookingSessionCommandRedis(redis);
+  const setBookingAmount = input.bookingAmount !== undefined;
+  const rawResult = await commandRedis.flushInBookingBookedSeats(
+    input.inBookingSessionsKey,
+    input.sid,
+    setBookingAmount ? '1' : '0',
+    String(input.bookingAmount ?? 0),
+    input.onlyWhenUnsaved ? '1' : '0',
+  );
+
+  return mapFlushedSeatsLuaResult(rawResult);
+}
+
+export async function runSetInBookingSavedLua(
+  redis: Redis,
+  input: { inBookingSessionsKey: string; sid: string; saved: boolean },
+): Promise<InBookingSessionLuaResult> {
+  const commandRedis = getInBookingSessionCommandRedis(redis);
+  const rawResult = await commandRedis.setInBookingSaved(
+    input.inBookingSessionsKey,
+    input.sid,
+    input.saved ? '1' : '0',
+  );
+
+  return mapInBookingSessionLuaResult(rawResult);
+}
+
+export async function runSetSubscribedSectionLua(
+  redis: Redis,
+  input: { inBookingSessionsKey: string; sid: string; sectionIndex: number | null },
+): Promise<InBookingSessionLuaResult> {
+  const commandRedis = getInBookingSessionCommandRedis(redis);
+  const rawResult = await commandRedis.setInBookingSubscribedSection(
+    input.inBookingSessionsKey,
+    input.sid,
+    input.sectionIndex === null ? '0' : '1',
+    String(input.sectionIndex ?? 0),
+  );
+
+  return mapInBookingSessionLuaResult(rawResult);
+}

--- a/back/src/domains/booking/luaScripts/reconnectingTransitionLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/reconnectingTransitionLua.spec.ts
@@ -4,10 +4,12 @@ import { join } from 'path';
 import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
-import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { USER_STATE_TRANSITIONS, USER_STATUS } from '../../../auth/fsm/user-state.fsm';
 import { installReconnectingTransitionCommandMock } from '../../../testing/redis/reconnecting-transition-command-mock';
 
 import {
+  MARK_RECONNECTING_TRANSITION,
+  RESTORE_SELECTING_TRANSITION,
   mapMarkReconnectingLuaResult,
   mapRestoreSelectingLuaResult,
   markReconnectingLua,
@@ -195,11 +197,21 @@ describe('재연결 전이 Lua 결과 매핑', () => {
 });
 
 describe('재연결 전이 Lua 정적 계약', () => {
-  it('상태 문자열을 FSM 상수에서 주입해 literal 드리프트를 막음', () => {
-    expect(markReconnectingLua).toContain(`session.userStatus ~= '${USER_STATUS.SELECTING_SEAT}'`);
-    expect(markReconnectingLua).toContain(`session.userStatus = '${USER_STATUS.RECONNECTING_SELECTING}'`);
-    expect(restoreSelectingLua).toContain(`session.userStatus ~= '${USER_STATUS.RECONNECTING_SELECTING}'`);
-    expect(restoreSelectingLua).toContain(`session.userStatus = '${USER_STATUS.SELECTING_SEAT}'`);
+  it('from/to를 스크립트에 적어두지 않고 FSM 전이 테이블에서 유도함', () => {
+    expect(USER_STATE_TRANSITIONS).toContainEqual(MARK_RECONNECTING_TRANSITION);
+    expect(USER_STATE_TRANSITIONS).toContainEqual(RESTORE_SELECTING_TRANSITION);
+    expect(MARK_RECONNECTING_TRANSITION.from).toBe(USER_STATUS.SELECTING_SEAT);
+    expect(RESTORE_SELECTING_TRANSITION.from).toBe(USER_STATUS.RECONNECTING_SELECTING);
+  });
+
+  it('Lua 본문에 상태 문자열을 박아두지 않고 ARGV로 받음', () => {
+    for (const script of [markReconnectingLua, restoreSelectingLua]) {
+      expect(script).toContain('session.userStatus ~= expectedFrom');
+      expect(script).toContain('session.userStatus = nextTo');
+      for (const state of Object.values(USER_STATUS)) {
+        expect(script).not.toContain(`'${state}'`);
+      }
+    }
   });
 
   it('세션 쓰기 전에 재연결 풀 변경을 끝내 부분 반영을 만들지 않음', () => {

--- a/back/src/domains/booking/luaScripts/reconnectingTransitionLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/reconnectingTransitionLua.spec.ts
@@ -1,0 +1,240 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { installReconnectingTransitionCommandMock } from '../../../testing/redis/reconnecting-transition-command-mock';
+
+import {
+  mapMarkReconnectingLuaResult,
+  mapRestoreSelectingLuaResult,
+  markReconnectingLua,
+  restoreSelectingLua,
+  runMarkReconnectingLua,
+  runRestoreSelectingLua,
+} from './reconnectingTransitionLua';
+
+const EVENT_ID = 42;
+const SID = 'sid-1';
+const SESSION_KEY = `user:${SID}`;
+const RECONNECTING_KEY = `reconnecting:${EVENT_ID}`;
+
+const baseSession = {
+  id: 1,
+  loginId: 'guest-1',
+  roles: ['USER'],
+  targetEvent: EVENT_ID,
+  userStatus: USER_STATUS.SELECTING_SEAT,
+};
+
+const markInput = {
+  sessionKey: SESSION_KEY,
+  reconnectingKey: RECONNECTING_KEY,
+  eventId: EVENT_ID,
+  sid: SID,
+  nowMs: 1_700_000_000_000,
+};
+
+const restoreInput = {
+  sessionKey: SESSION_KEY,
+  reconnectingKey: RECONNECTING_KEY,
+  eventId: EVENT_ID,
+  sid: SID,
+};
+
+/** 운영 Lua와 같은 계약을 emulate하는 테스트용 command mock을 그대로 사용함. */
+function createCommandRedis(): Redis {
+  const redis = new RedisMock() as unknown as Redis;
+  installReconnectingTransitionCommandMock(redis);
+  return redis;
+}
+
+async function readSession(redis: Redis): Promise<Record<string, unknown> | null> {
+  const raw = await redis.get(SESSION_KEY);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+describe('재연결 표시 Lua 실행', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('세션이 없으면 SESSION_MISSING을 반환하고 재연결 풀을 건드리지 않음', async () => {
+    const result = await runMarkReconnectingLua(redis, markInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'SESSION_MISSING' });
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).toBeNull();
+  });
+
+  it('SELECTING_SEAT가 아니면 STATE_MISMATCH를 반환하고 세션과 재연결 풀을 그대로 둠', async () => {
+    const session = { ...baseSession, userStatus: USER_STATUS.ENTERING };
+    await redis.set(SESSION_KEY, JSON.stringify(session));
+
+    const result = await runMarkReconnectingLua(redis, markInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(await readSession(redis)).toEqual(session);
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).toBeNull();
+  });
+
+  it('세션이 다른 이벤트를 보고 있으면 TARGET_EVENT_MISMATCH를 반환함', async () => {
+    const session = { ...baseSession, targetEvent: 99 };
+    await redis.set(SESSION_KEY, JSON.stringify(session));
+
+    const result = await runMarkReconnectingLua(redis, markInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'TARGET_EVENT_MISMATCH' });
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).toBeNull();
+  });
+
+  it('성공하면 재연결 풀 등록과 상태 전이를 함께 반영함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(baseSession));
+
+    const result = await runMarkReconnectingLua(redis, markInput);
+
+    expect(result).toMatchObject({ ok: true, code: 'OK', to: USER_STATUS.RECONNECTING_SELECTING });
+    expect(await readSession(redis)).toMatchObject({
+      userStatus: USER_STATUS.RECONNECTING_SELECTING,
+      targetEvent: EVENT_ID,
+    });
+    expect(Number(await redis.zscore(RECONNECTING_KEY, SID))).toBe(markInput.nowMs);
+  });
+
+  it('성공해도 세션 TTL을 갱신하지 않고 남은 시간을 보존함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(baseSession), 'PX', 60_000);
+
+    await runMarkReconnectingLua(redis, markInput);
+
+    const ttl = await redis.pttl(SESSION_KEY);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe('재연결 복원 Lua 실행', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('재연결 풀 멤버면 풀에서 제거하고 SELECTING_SEAT로 되돌림', async () => {
+    await redis.set(
+      SESSION_KEY,
+      JSON.stringify({ ...baseSession, userStatus: USER_STATUS.RECONNECTING_SELECTING }),
+    );
+    await redis.zadd(RECONNECTING_KEY, 1, SID);
+
+    const result = await runRestoreSelectingLua(redis, restoreInput);
+
+    expect(result).toMatchObject({ ok: true, code: 'OK', to: USER_STATUS.SELECTING_SEAT });
+    expect(await readSession(redis)).toMatchObject({ userStatus: USER_STATUS.SELECTING_SEAT });
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).toBeNull();
+  });
+
+  it('재연결 풀에 없으면 NOT_RECONNECTING을 반환하고 상태를 전이하지 않음', async () => {
+    const session = { ...baseSession, userStatus: USER_STATUS.RECONNECTING_SELECTING };
+    await redis.set(SESSION_KEY, JSON.stringify(session));
+
+    const result = await runRestoreSelectingLua(redis, restoreInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'NOT_RECONNECTING' });
+    expect(await readSession(redis)).toEqual(session);
+  });
+
+  it('RECONNECTING_SELECTING이 아니면 재연결 풀을 건드리지 않고 STATE_MISMATCH를 반환함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(baseSession));
+    await redis.zadd(RECONNECTING_KEY, 1, SID);
+
+    const result = await runRestoreSelectingLua(redis, restoreInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).not.toBeNull();
+  });
+});
+
+describe('재연결 전이 Lua 결과 매핑', () => {
+  it('표시 결과는 SELECTING_SEAT에서 RECONNECTING_SELECTING 전이로 해석함', () => {
+    expect(mapMarkReconnectingLuaResult(['OK'])).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'markReconnectingSelection',
+      from: USER_STATUS.SELECTING_SEAT,
+      to: USER_STATUS.RECONNECTING_SELECTING,
+    });
+  });
+
+  it('복원 결과는 RECONNECTING_SELECTING에서 SELECTING_SEAT 전이로 해석함', () => {
+    expect(mapRestoreSelectingLuaResult(['OK'])).toEqual({
+      ok: true,
+      code: 'OK',
+      action: 'restoreSeatSelection',
+      from: USER_STATUS.RECONNECTING_SELECTING,
+      to: USER_STATUS.SELECTING_SEAT,
+    });
+  });
+
+  it('선언하지 않은 결과 코드는 업무 거부로 위장하지 않고 throw함', () => {
+    expect(() => mapMarkReconnectingLuaResult(['NOT_RECONNECTING' as never])).toThrow(TypeError);
+    expect(() => mapRestoreSelectingLuaResult(['UNDECLARED' as never])).toThrow(TypeError);
+  });
+});
+
+describe('재연결 전이 Lua 정적 계약', () => {
+  it('상태 문자열을 FSM 상수에서 주입해 literal 드리프트를 막음', () => {
+    expect(markReconnectingLua).toContain(`session.userStatus ~= '${USER_STATUS.SELECTING_SEAT}'`);
+    expect(markReconnectingLua).toContain(`session.userStatus = '${USER_STATUS.RECONNECTING_SELECTING}'`);
+    expect(restoreSelectingLua).toContain(`session.userStatus ~= '${USER_STATUS.RECONNECTING_SELECTING}'`);
+    expect(restoreSelectingLua).toContain(`session.userStatus = '${USER_STATUS.SELECTING_SEAT}'`);
+  });
+
+  it('세션 쓰기 전에 재연결 풀 변경을 끝내 부분 반영을 만들지 않음', () => {
+    // 공용 helper 정의가 앞에 붙으므로 호출 지점은 마지막 등장 위치로 찾음.
+    const markZaddIndex = markReconnectingLua.indexOf("redis.call('ZADD', reconnectingKey");
+    const markWriteIndex = markReconnectingLua.lastIndexOf('writePreparedSessionPreservingTtl(sessionKey');
+    expect(markZaddIndex).toBeGreaterThan(-1);
+    expect(markWriteIndex).toBeGreaterThan(markZaddIndex);
+
+    const restoreZremIndex = restoreSelectingLua.indexOf("redis.call('ZREM', reconnectingKey");
+    const restoreWriteIndex = restoreSelectingLua.lastIndexOf('writePreparedSessionPreservingTtl(sessionKey');
+    expect(restoreZremIndex).toBeGreaterThan(-1);
+    expect(restoreWriteIndex).toBeGreaterThan(restoreZremIndex);
+  });
+
+  it('복원은 ZREM 반환값으로 멤버십을 확인해 별도 조회를 하지 않음', () => {
+    expect(restoreSelectingLua).toContain("if redis.call('ZREM', reconnectingKey, sid) ~= 1 then");
+    expect(restoreSelectingLua).not.toContain('ZSCORE');
+  });
+
+  it('TTL 보존 쓰기를 자체 구현하지 않고 공용 helper에 위임함', () => {
+    const source = readFileSync(join(__dirname, 'reconnectingTransitionLua.ts'), 'utf8');
+
+    expect(source).toContain('sessionWriteLuaHelpers');
+    expect(source).not.toContain('local function prepareSessionWrite');
+    expect(source).not.toContain("redis.call('PSETEX'");
+    expect(source).not.toContain("redis.call('PTTL'");
+  });
+
+  it('스크립트 본문 직접 eval 대신 script cache 명령으로 등록함', () => {
+    const source = readFileSync(join(__dirname, 'reconnectingTransitionLua.ts'), 'utf8');
+
+    expect(source).not.toMatch(/redis\.eval\(/);
+    expect(source).toContain("redis.defineCommand('markReconnectingSelecting'");
+    expect(source).toContain("redis.defineCommand('restoreSelectingSeat'");
+    expect(source).toContain('numberOfKeys: 2');
+  });
+});

--- a/back/src/domains/booking/luaScripts/reconnectingTransitionLua.ts
+++ b/back/src/domains/booking/luaScripts/reconnectingTransitionLua.ts
@@ -1,0 +1,197 @@
+import Redis from 'ioredis';
+
+import {
+  mapLuaUserStateTransitionResult,
+  type LuaUserStateTransitionRawResult,
+  type LuaUserStateTransitionResult,
+} from '../../../auth/fsm/user-state-transition.contract';
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { sessionWriteLuaHelpers } from '../../../auth/luaScripts/sessionLuaHelpers';
+
+export type RestoreSelectingBusinessCode = 'NOT_RECONNECTING';
+
+export const RESTORE_SELECTING_BUSINESS_CODES = [
+  'NOT_RECONNECTING',
+] as const satisfies readonly RestoreSelectingBusinessCode[];
+
+export type MarkReconnectingLuaResult = LuaUserStateTransitionResult;
+
+export type RestoreSelectingLuaResult = LuaUserStateTransitionResult<RestoreSelectingBusinessCode>;
+
+export type MarkReconnectingLuaInput = {
+  sessionKey: string;
+  reconnectingKey: string;
+  eventId: number;
+  sid: string;
+  nowMs: number;
+};
+
+export type RestoreSelectingLuaInput = {
+  sessionKey: string;
+  reconnectingKey: string;
+  eventId: number;
+  sid: string;
+};
+
+export const markReconnectingLua = `
+  ${sessionWriteLuaHelpers}
+
+  local sessionKey = KEYS[1]
+  local reconnectingKey = KEYS[2]
+
+  local eventId = tonumber(ARGV[1])
+  local sid = ARGV[2]
+  local nowMs = tonumber(ARGV[3])
+
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    return {'SESSION_MISSING'}
+  end
+
+  local session = cjson.decode(raw)
+  if session.userStatus ~= '${USER_STATUS.SELECTING_SEAT}' then
+    return {'STATE_MISMATCH', session.userStatus}
+  end
+
+  if session.targetEvent ~= eventId then
+    return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+  end
+
+  session.userStatus = '${USER_STATUS.RECONNECTING_SELECTING}'
+
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
+  end
+
+  redis.call('ZADD', reconnectingKey, nowMs, sid)
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+
+  return {'OK'}
+`;
+
+export const restoreSelectingLua = `
+  ${sessionWriteLuaHelpers}
+
+  local sessionKey = KEYS[1]
+  local reconnectingKey = KEYS[2]
+
+  local eventId = tonumber(ARGV[1])
+  local sid = ARGV[2]
+
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    return {'SESSION_MISSING'}
+  end
+
+  local session = cjson.decode(raw)
+  if session.userStatus ~= '${USER_STATUS.RECONNECTING_SELECTING}' then
+    return {'STATE_MISMATCH', session.userStatus}
+  end
+
+  if session.targetEvent ~= eventId then
+    return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+  end
+
+  session.userStatus = '${USER_STATUS.SELECTING_SEAT}'
+
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
+  end
+
+  if redis.call('ZREM', reconnectingKey, sid) ~= 1 then
+    return {'NOT_RECONNECTING'}
+  end
+
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+
+  return {'OK'}
+`;
+
+type RedisWithReconnectingTransitionCommands = Redis & {
+  markReconnectingSelecting(
+    sessionKey: string,
+    reconnectingKey: string,
+    eventId: string,
+    sid: string,
+    nowMs: string,
+  ): Promise<LuaUserStateTransitionRawResult>;
+
+  restoreSelectingSeat(
+    sessionKey: string,
+    reconnectingKey: string,
+    eventId: string,
+    sid: string,
+  ): Promise<LuaUserStateTransitionRawResult<RestoreSelectingBusinessCode>>;
+};
+
+const commandRegisteredRedisSet = new WeakSet<object>();
+
+function getReconnectingTransitionCommandRedis(redis: Redis): RedisWithReconnectingTransitionCommands {
+  if (!commandRegisteredRedisSet.has(redis)) {
+    redis.defineCommand('markReconnectingSelecting', {
+      numberOfKeys: 2,
+      lua: markReconnectingLua,
+    });
+    redis.defineCommand('restoreSelectingSeat', {
+      numberOfKeys: 2,
+      lua: restoreSelectingLua,
+    });
+    commandRegisteredRedisSet.add(redis);
+  }
+
+  return redis as RedisWithReconnectingTransitionCommands;
+}
+
+export function mapMarkReconnectingLuaResult(
+  raw: LuaUserStateTransitionRawResult,
+): MarkReconnectingLuaResult {
+  return mapLuaUserStateTransitionResult(raw, {
+    action: 'markReconnectingSelection',
+    expectedFrom: USER_STATUS.SELECTING_SEAT,
+    nextTo: USER_STATUS.RECONNECTING_SELECTING,
+  });
+}
+
+export function mapRestoreSelectingLuaResult(
+  raw: LuaUserStateTransitionRawResult<RestoreSelectingBusinessCode>,
+): RestoreSelectingLuaResult {
+  return mapLuaUserStateTransitionResult(raw, {
+    action: 'restoreSeatSelection',
+    expectedFrom: USER_STATUS.RECONNECTING_SELECTING,
+    nextTo: USER_STATUS.SELECTING_SEAT,
+    businessCodes: RESTORE_SELECTING_BUSINESS_CODES,
+  });
+}
+
+export async function runMarkReconnectingLua(
+  redis: Redis,
+  input: MarkReconnectingLuaInput,
+): Promise<MarkReconnectingLuaResult> {
+  const commandRedis = getReconnectingTransitionCommandRedis(redis);
+  const rawResult = await commandRedis.markReconnectingSelecting(
+    input.sessionKey,
+    input.reconnectingKey,
+    String(input.eventId),
+    input.sid,
+    String(input.nowMs),
+  );
+
+  return mapMarkReconnectingLuaResult(rawResult);
+}
+
+export async function runRestoreSelectingLua(
+  redis: Redis,
+  input: RestoreSelectingLuaInput,
+): Promise<RestoreSelectingLuaResult> {
+  const commandRedis = getReconnectingTransitionCommandRedis(redis);
+  const rawResult = await commandRedis.restoreSelectingSeat(
+    input.sessionKey,
+    input.reconnectingKey,
+    String(input.eventId),
+    input.sid,
+  );
+
+  return mapRestoreSelectingLuaResult(rawResult);
+}

--- a/back/src/domains/booking/luaScripts/reconnectingTransitionLua.ts
+++ b/back/src/domains/booking/luaScripts/reconnectingTransitionLua.ts
@@ -2,6 +2,7 @@ import Redis from 'ioredis';
 
 import {
   mapLuaUserStateTransitionResult,
+  resolveUserStateTransition,
   type LuaUserStateTransitionRawResult,
   type LuaUserStateTransitionResult,
 } from '../../../auth/fsm/user-state-transition.contract';
@@ -13,6 +14,16 @@ export type RestoreSelectingBusinessCode = 'NOT_RECONNECTING';
 export const RESTORE_SELECTING_BUSINESS_CODES = [
   'NOT_RECONNECTING',
 ] as const satisfies readonly RestoreSelectingBusinessCode[];
+
+export const MARK_RECONNECTING_TRANSITION = resolveUserStateTransition(
+  'markReconnectingSelection',
+  USER_STATUS.SELECTING_SEAT,
+);
+
+export const RESTORE_SELECTING_TRANSITION = resolveUserStateTransition(
+  'restoreSeatSelection',
+  USER_STATUS.RECONNECTING_SELECTING,
+);
 
 export type MarkReconnectingLuaResult = LuaUserStateTransitionResult;
 
@@ -42,6 +53,8 @@ export const markReconnectingLua = `
   local eventId = tonumber(ARGV[1])
   local sid = ARGV[2]
   local nowMs = tonumber(ARGV[3])
+  local expectedFrom = ARGV[4]
+  local nextTo = ARGV[5]
 
   local raw = redis.call('GET', sessionKey)
   if not raw then
@@ -49,7 +62,7 @@ export const markReconnectingLua = `
   end
 
   local session = cjson.decode(raw)
-  if session.userStatus ~= '${USER_STATUS.SELECTING_SEAT}' then
+  if session.userStatus ~= expectedFrom then
     return {'STATE_MISMATCH', session.userStatus}
   end
 
@@ -57,7 +70,7 @@ export const markReconnectingLua = `
     return {'TARGET_EVENT_MISMATCH', session.targetEvent}
   end
 
-  session.userStatus = '${USER_STATUS.RECONNECTING_SELECTING}'
+  session.userStatus = nextTo
 
   local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
   if prepareCode ~= 'OK' then
@@ -78,6 +91,8 @@ export const restoreSelectingLua = `
 
   local eventId = tonumber(ARGV[1])
   local sid = ARGV[2]
+  local expectedFrom = ARGV[3]
+  local nextTo = ARGV[4]
 
   local raw = redis.call('GET', sessionKey)
   if not raw then
@@ -85,7 +100,7 @@ export const restoreSelectingLua = `
   end
 
   local session = cjson.decode(raw)
-  if session.userStatus ~= '${USER_STATUS.RECONNECTING_SELECTING}' then
+  if session.userStatus ~= expectedFrom then
     return {'STATE_MISMATCH', session.userStatus}
   end
 
@@ -93,7 +108,7 @@ export const restoreSelectingLua = `
     return {'TARGET_EVENT_MISMATCH', session.targetEvent}
   end
 
-  session.userStatus = '${USER_STATUS.SELECTING_SEAT}'
+  session.userStatus = nextTo
 
   local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
   if prepareCode ~= 'OK' then
@@ -116,6 +131,8 @@ type RedisWithReconnectingTransitionCommands = Redis & {
     eventId: string,
     sid: string,
     nowMs: string,
+    expectedFrom: string,
+    nextTo: string,
   ): Promise<LuaUserStateTransitionRawResult>;
 
   restoreSelectingSeat(
@@ -123,6 +140,8 @@ type RedisWithReconnectingTransitionCommands = Redis & {
     reconnectingKey: string,
     eventId: string,
     sid: string,
+    expectedFrom: string,
+    nextTo: string,
   ): Promise<LuaUserStateTransitionRawResult<RestoreSelectingBusinessCode>>;
 };
 
@@ -148,9 +167,9 @@ export function mapMarkReconnectingLuaResult(
   raw: LuaUserStateTransitionRawResult,
 ): MarkReconnectingLuaResult {
   return mapLuaUserStateTransitionResult(raw, {
-    action: 'markReconnectingSelection',
-    expectedFrom: USER_STATUS.SELECTING_SEAT,
-    nextTo: USER_STATUS.RECONNECTING_SELECTING,
+    action: MARK_RECONNECTING_TRANSITION.action,
+    expectedFrom: MARK_RECONNECTING_TRANSITION.from,
+    nextTo: MARK_RECONNECTING_TRANSITION.to,
   });
 }
 
@@ -158,9 +177,9 @@ export function mapRestoreSelectingLuaResult(
   raw: LuaUserStateTransitionRawResult<RestoreSelectingBusinessCode>,
 ): RestoreSelectingLuaResult {
   return mapLuaUserStateTransitionResult(raw, {
-    action: 'restoreSeatSelection',
-    expectedFrom: USER_STATUS.RECONNECTING_SELECTING,
-    nextTo: USER_STATUS.SELECTING_SEAT,
+    action: RESTORE_SELECTING_TRANSITION.action,
+    expectedFrom: RESTORE_SELECTING_TRANSITION.from,
+    nextTo: RESTORE_SELECTING_TRANSITION.to,
     businessCodes: RESTORE_SELECTING_BUSINESS_CODES,
   });
 }
@@ -176,6 +195,8 @@ export async function runMarkReconnectingLua(
     String(input.eventId),
     input.sid,
     String(input.nowMs),
+    MARK_RECONNECTING_TRANSITION.from,
+    MARK_RECONNECTING_TRANSITION.to,
   );
 
   return mapMarkReconnectingLuaResult(rawResult);
@@ -191,6 +212,8 @@ export async function runRestoreSelectingLua(
     input.reconnectingKey,
     String(input.eventId),
     input.sid,
+    RESTORE_SELECTING_TRANSITION.from,
+    RESTORE_SELECTING_TRANSITION.to,
   );
 
   return mapRestoreSelectingLuaResult(rawResult);

--- a/back/src/domains/booking/luaScripts/startSeatSelectionLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/startSeatSelectionLua.spec.ts
@@ -1,0 +1,221 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { installStartSeatSelectionCommandMock } from '../../../testing/redis/start-seat-selection-command-mock';
+
+import {
+  buildInBookingSessionFragments,
+  runStartSeatSelectionLua,
+  startSeatSelectionLua,
+} from './startSeatSelectionLua';
+
+const EVENT_ID = 42;
+const SID = 'sid-1';
+const SESSION_KEY = `user:${SID}`;
+const ENTERING_KEY = `entering:${EVENT_ID}`;
+const IN_BOOKING_KEY = `in-booking:${EVENT_ID}:sessions`;
+const AMOUNT_KEY = `entering:${SID}:temp-booking-amount`;
+
+const enteringSession = {
+  id: 1,
+  loginId: 'guest-1',
+  roles: ['USER'],
+  targetEvent: EVENT_ID,
+  userStatus: USER_STATUS.ENTERING,
+};
+
+const startInput = {
+  sessionKey: SESSION_KEY,
+  enteringKey: ENTERING_KEY,
+  inBookingSessionsKey: IN_BOOKING_KEY,
+  bookingAmountKey: AMOUNT_KEY,
+  eventId: EVENT_ID,
+  sid: SID,
+};
+
+/** 운영 Lua와 같은 계약을 emulate하는 테스트용 command mock을 그대로 사용함. */
+function createCommandRedis(): Redis {
+  const redis = new RedisMock() as unknown as Redis;
+  installStartSeatSelectionCommandMock(redis);
+  return redis;
+}
+
+async function readInBookingSession(redis: Redis): Promise<Record<string, unknown> | null> {
+  const raw = await redis.hget(IN_BOOKING_KEY, SID);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+describe('in-booking 세션 JSON 조각', () => {
+  it('예매 수량을 끼워 넣으면 기존 in-booking 세션 형태와 같아짐', () => {
+    const { prefix, suffix } = buildInBookingSessionFragments(SID);
+
+    expect(JSON.parse(`${prefix}3${suffix}`)).toEqual({
+      sid: SID,
+      bookingAmount: 3,
+      bookedSeats: [],
+      saved: false,
+      subscribedSection: null,
+    });
+  });
+
+  it('빈 좌석 목록이 객체가 아니라 배열로 직렬화됨', () => {
+    const { prefix, suffix } = buildInBookingSessionFragments(SID);
+    const parsed = JSON.parse(`${prefix}0${suffix}`) as { bookedSeats: unknown };
+
+    expect(Array.isArray(parsed.bookedSeats)).toBe(true);
+  });
+
+  it('따옴표가 필요한 sid도 안전하게 직렬화됨', () => {
+    const { prefix, suffix } = buildInBookingSessionFragments('sid"with\\quote');
+    const parsed = JSON.parse(`${prefix}0${suffix}`) as { sid: string };
+
+    expect(parsed.sid).toBe('sid"with\\quote');
+  });
+});
+
+describe('좌석 선택 진입 Lua 실행', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('세션이 없으면 SESSION_MISSING을 반환하고 in-booking에 넣지 않음', async () => {
+    const result = await runStartSeatSelectionLua(redis, startInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'SESSION_MISSING' });
+    expect(await readInBookingSession(redis)).toBeNull();
+  });
+
+  it('ENTERING이 아니면 STATE_MISMATCH를 반환하고 entering 풀을 건드리지 않음', async () => {
+    await redis.set(
+      SESSION_KEY,
+      JSON.stringify({ ...enteringSession, userStatus: USER_STATUS.SELECTING_SEAT }),
+    );
+    await redis.zadd(ENTERING_KEY, 1, SID);
+
+    const result = await runStartSeatSelectionLua(redis, startInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(await redis.zscore(ENTERING_KEY, SID)).not.toBeNull();
+    expect(await readInBookingSession(redis)).toBeNull();
+  });
+
+  it('entering 풀 멤버가 아니면 NOT_ENTERING을 반환하고 아무것도 쓰지 않음', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(enteringSession));
+    await redis.set(AMOUNT_KEY, '2');
+
+    const result = await runStartSeatSelectionLua(redis, startInput);
+
+    expect(result).toMatchObject({ ok: false, code: 'NOT_ENTERING' });
+    expect(await readInBookingSession(redis)).toBeNull();
+    expect(await redis.get(AMOUNT_KEY)).toBe('2');
+    expect(JSON.parse((await redis.get(SESSION_KEY)) ?? '{}')).toMatchObject({
+      userStatus: USER_STATUS.ENTERING,
+    });
+  });
+
+  it('성공하면 entering 제거, 임시 수량 삭제, in-booking 생성, 상태 전이를 함께 반영함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(enteringSession));
+    await redis.zadd(ENTERING_KEY, 1, SID);
+    await redis.set(AMOUNT_KEY, '3');
+
+    const result = await runStartSeatSelectionLua(redis, startInput);
+
+    expect(result).toMatchObject({ ok: true, code: 'OK', to: USER_STATUS.SELECTING_SEAT });
+    expect(await redis.zscore(ENTERING_KEY, SID)).toBeNull();
+    expect(await redis.get(AMOUNT_KEY)).toBeNull();
+    expect(await readInBookingSession(redis)).toEqual({
+      sid: SID,
+      bookingAmount: 3,
+      bookedSeats: [],
+      saved: false,
+      subscribedSection: null,
+    });
+    expect(JSON.parse((await redis.get(SESSION_KEY)) ?? '{}')).toMatchObject({
+      userStatus: USER_STATUS.SELECTING_SEAT,
+    });
+  });
+
+  it('임시 예매 수량이 없으면 0으로 in-booking 세션을 만듦', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(enteringSession));
+    await redis.zadd(ENTERING_KEY, 1, SID);
+
+    await runStartSeatSelectionLua(redis, startInput);
+
+    expect(await readInBookingSession(redis)).toMatchObject({ bookingAmount: 0 });
+  });
+
+  it('임시 예매 수량이 숫자가 아니면 업무 거부가 아니라 throw로 드러남', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(enteringSession));
+    await redis.zadd(ENTERING_KEY, 1, SID);
+    await redis.set(AMOUNT_KEY, 'not-a-number');
+
+    await expect(runStartSeatSelectionLua(redis, startInput)).rejects.toThrow(TypeError);
+  });
+
+  it('성공해도 세션 TTL을 갱신하지 않고 남은 시간을 보존함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(enteringSession), 'PX', 60_000);
+    await redis.zadd(ENTERING_KEY, 1, SID);
+
+    await runStartSeatSelectionLua(redis, startInput);
+
+    const ttl = await redis.pttl(SESSION_KEY);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe('좌석 선택 진입 Lua 정적 계약', () => {
+  it('in-booking 세션 JSON을 cjson으로 만들지 않아 빈 배열 인코딩 문제를 피함', () => {
+    expect(startSeatSelectionLua).not.toContain('cjson.encode({');
+    expect(startSeatSelectionLua).toContain(
+      'inBookingSessionPrefix .. bookingAmount .. inBookingSessionSuffix',
+    );
+  });
+
+  it('상태 문자열을 FSM 상수에서 주입해 literal 드리프트를 막음', () => {
+    expect(startSeatSelectionLua).toContain(`session.userStatus ~= '${USER_STATUS.ENTERING}'`);
+    expect(startSeatSelectionLua).toContain(`session.userStatus = '${USER_STATUS.SELECTING_SEAT}'`);
+  });
+
+  it('entering 멤버십을 ZREM 반환값으로 확인해 별도 조회를 하지 않음', () => {
+    expect(startSeatSelectionLua).toContain("if redis.call('ZREM', enteringKey, sid) ~= 1 then");
+    expect(startSeatSelectionLua).not.toContain('ZSCORE');
+  });
+
+  it('멤버십 확인 실패 시 예매 수량 키와 in-booking 해시를 건드리지 않음', () => {
+    const zremIndex = startSeatSelectionLua.indexOf("redis.call('ZREM', enteringKey");
+    const delIndex = startSeatSelectionLua.indexOf("redis.call('DEL', bookingAmountKey)");
+    const hsetIndex = startSeatSelectionLua.indexOf("'HSET',");
+
+    expect(zremIndex).toBeGreaterThan(-1);
+    expect(delIndex).toBeGreaterThan(zremIndex);
+    expect(hsetIndex).toBeGreaterThan(zremIndex);
+  });
+
+  it('세션 쓰기는 예매 자료구조 변경 뒤에 마지막으로 수행함', () => {
+    // 공용 helper 정의가 앞에 붙으므로 호출 지점은 마지막 등장 위치로 찾음.
+    const hsetIndex = startSeatSelectionLua.indexOf("'HSET',");
+    const writeIndex = startSeatSelectionLua.lastIndexOf('writePreparedSessionPreservingTtl(sessionKey');
+
+    expect(writeIndex).toBeGreaterThan(hsetIndex);
+  });
+
+  it('스크립트 본문 직접 eval 대신 script cache 명령으로 등록함', () => {
+    const source = readFileSync(join(__dirname, 'startSeatSelectionLua.ts'), 'utf8');
+
+    expect(source).not.toMatch(/redis\.eval\(/);
+    expect(source).toContain("redis.defineCommand('startSeatSelectionFromEntering'");
+    expect(source).toContain('numberOfKeys: 4');
+  });
+});

--- a/back/src/domains/booking/luaScripts/startSeatSelectionLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/startSeatSelectionLua.spec.ts
@@ -4,10 +4,11 @@ import { join } from 'path';
 import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
-import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { USER_STATE_TRANSITIONS, USER_STATUS } from '../../../auth/fsm/user-state.fsm';
 import { installStartSeatSelectionCommandMock } from '../../../testing/redis/start-seat-selection-command-mock';
 
 import {
+  START_SEAT_SELECTION_TRANSITION,
   buildInBookingSessionFragments,
   runStartSeatSelectionLua,
   startSeatSelectionLua,
@@ -183,9 +184,17 @@ describe('좌석 선택 진입 Lua 정적 계약', () => {
     );
   });
 
-  it('상태 문자열을 FSM 상수에서 주입해 literal 드리프트를 막음', () => {
-    expect(startSeatSelectionLua).toContain(`session.userStatus ~= '${USER_STATUS.ENTERING}'`);
-    expect(startSeatSelectionLua).toContain(`session.userStatus = '${USER_STATUS.SELECTING_SEAT}'`);
+  it('from/to를 스크립트에 적어두지 않고 FSM 전이 테이블에서 유도함', () => {
+    expect(USER_STATE_TRANSITIONS).toContainEqual(START_SEAT_SELECTION_TRANSITION);
+    expect(START_SEAT_SELECTION_TRANSITION.from).toBe(USER_STATUS.ENTERING);
+  });
+
+  it('Lua 본문에 상태 문자열을 박아두지 않고 ARGV로 받음', () => {
+    expect(startSeatSelectionLua).toContain('session.userStatus ~= expectedFrom');
+    expect(startSeatSelectionLua).toContain('session.userStatus = nextTo');
+    for (const state of Object.values(USER_STATUS)) {
+      expect(startSeatSelectionLua).not.toContain(`'${state}'`);
+    }
   });
 
   it('entering 멤버십을 ZREM 반환값으로 확인해 별도 조회를 하지 않음', () => {

--- a/back/src/domains/booking/luaScripts/startSeatSelectionLua.ts
+++ b/back/src/domains/booking/luaScripts/startSeatSelectionLua.ts
@@ -1,0 +1,157 @@
+import Redis from 'ioredis';
+
+import {
+  mapLuaUserStateTransitionResult,
+  type LuaUserStateTransitionRawResult,
+  type LuaUserStateTransitionResult,
+} from '../../../auth/fsm/user-state-transition.contract';
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { sessionWriteLuaHelpers } from '../../../auth/luaScripts/sessionLuaHelpers';
+
+export type StartSeatSelectionBusinessCode = 'NOT_ENTERING';
+
+export const START_SEAT_SELECTION_BUSINESS_CODES = [
+  'NOT_ENTERING',
+] as const satisfies readonly StartSeatSelectionBusinessCode[];
+
+export type StartSeatSelectionLuaResult = LuaUserStateTransitionResult<StartSeatSelectionBusinessCode>;
+
+export type StartSeatSelectionLuaInput = {
+  sessionKey: string;
+  enteringKey: string;
+  inBookingSessionsKey: string;
+  bookingAmountKey: string;
+  eventId: number;
+  sid: string;
+};
+
+/**
+ * in-booking 세션 JSON을 Lua에서 cjson으로 만들지 않는 이유:
+ * Redis cjson은 빈 테이블을 배열이 아닌 객체(`{}`)로 인코딩해 `bookedSeats: []`가 깨진다.
+ * 형태는 TypeScript가 정의하고 Lua는 조회한 예매 수량만 끼워 넣는다.
+ */
+export function buildInBookingSessionFragments(sid: string): { prefix: string; suffix: string } {
+  return {
+    prefix: `{"sid":${JSON.stringify(sid)},"bookingAmount":`,
+    suffix: ',"bookedSeats":[],"saved":false,"subscribedSection":null}',
+  };
+}
+
+export const startSeatSelectionLua = `
+  ${sessionWriteLuaHelpers}
+
+  local sessionKey = KEYS[1]
+  local enteringKey = KEYS[2]
+  local inBookingSessionsKey = KEYS[3]
+  local bookingAmountKey = KEYS[4]
+
+  local eventId = tonumber(ARGV[1])
+  local sid = ARGV[2]
+  local inBookingSessionPrefix = ARGV[3]
+  local inBookingSessionSuffix = ARGV[4]
+
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    return {'SESSION_MISSING'}
+  end
+
+  local session = cjson.decode(raw)
+  if session.userStatus ~= '${USER_STATUS.ENTERING}' then
+    return {'STATE_MISMATCH', session.userStatus}
+  end
+
+  if session.targetEvent ~= eventId then
+    return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+  end
+
+  local bookingAmount = 0
+  local rawBookingAmount = redis.call('GET', bookingAmountKey)
+  if rawBookingAmount then
+    local parsedBookingAmount = tonumber(rawBookingAmount)
+    if not parsedBookingAmount then
+      -- 우리 코드만 쓰는 키이므로 숫자가 아니면 업무 거부가 아니라 시스템 불변식 위반으로 다룸.
+      return {'CORRUPTED_BOOKING_AMOUNT'}
+    end
+    bookingAmount = math.floor(parsedBookingAmount)
+  end
+
+  session.userStatus = '${USER_STATUS.SELECTING_SEAT}'
+
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
+  end
+
+  if redis.call('ZREM', enteringKey, sid) ~= 1 then
+    return {'NOT_ENTERING'}
+  end
+
+  redis.call('DEL', bookingAmountKey)
+  redis.call(
+    'HSET',
+    inBookingSessionsKey,
+    sid,
+    inBookingSessionPrefix .. bookingAmount .. inBookingSessionSuffix
+  )
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+
+  return {'OK'}
+`;
+
+type RedisWithStartSeatSelectionCommand = Redis & {
+  startSeatSelectionFromEntering(
+    sessionKey: string,
+    enteringKey: string,
+    inBookingSessionsKey: string,
+    bookingAmountKey: string,
+    eventId: string,
+    sid: string,
+    inBookingSessionPrefix: string,
+    inBookingSessionSuffix: string,
+  ): Promise<LuaUserStateTransitionRawResult<StartSeatSelectionBusinessCode>>;
+};
+
+const commandRegisteredRedisSet = new WeakSet<object>();
+
+function getStartSeatSelectionCommandRedis(redis: Redis): RedisWithStartSeatSelectionCommand {
+  if (!commandRegisteredRedisSet.has(redis)) {
+    redis.defineCommand('startSeatSelectionFromEntering', {
+      numberOfKeys: 4,
+      lua: startSeatSelectionLua,
+    });
+    commandRegisteredRedisSet.add(redis);
+  }
+
+  return redis as RedisWithStartSeatSelectionCommand;
+}
+
+export function mapStartSeatSelectionLuaResult(
+  raw: LuaUserStateTransitionRawResult<StartSeatSelectionBusinessCode>,
+): StartSeatSelectionLuaResult {
+  return mapLuaUserStateTransitionResult(raw, {
+    action: 'startSeatSelection',
+    expectedFrom: USER_STATUS.ENTERING,
+    nextTo: USER_STATUS.SELECTING_SEAT,
+    businessCodes: START_SEAT_SELECTION_BUSINESS_CODES,
+  });
+}
+
+export async function runStartSeatSelectionLua(
+  redis: Redis,
+  input: StartSeatSelectionLuaInput,
+): Promise<StartSeatSelectionLuaResult> {
+  const commandRedis = getStartSeatSelectionCommandRedis(redis);
+  const { prefix, suffix } = buildInBookingSessionFragments(input.sid);
+  const rawResult = await commandRedis.startSeatSelectionFromEntering(
+    input.sessionKey,
+    input.enteringKey,
+    input.inBookingSessionsKey,
+    input.bookingAmountKey,
+    String(input.eventId),
+    input.sid,
+    prefix,
+    suffix,
+  );
+
+  return mapStartSeatSelectionLuaResult(rawResult);
+}

--- a/back/src/domains/booking/luaScripts/startSeatSelectionLua.ts
+++ b/back/src/domains/booking/luaScripts/startSeatSelectionLua.ts
@@ -2,6 +2,7 @@ import Redis from 'ioredis';
 
 import {
   mapLuaUserStateTransitionResult,
+  resolveUserStateTransition,
   type LuaUserStateTransitionRawResult,
   type LuaUserStateTransitionResult,
 } from '../../../auth/fsm/user-state-transition.contract';
@@ -13,6 +14,11 @@ export type StartSeatSelectionBusinessCode = 'NOT_ENTERING';
 export const START_SEAT_SELECTION_BUSINESS_CODES = [
   'NOT_ENTERING',
 ] as const satisfies readonly StartSeatSelectionBusinessCode[];
+
+export const START_SEAT_SELECTION_TRANSITION = resolveUserStateTransition(
+  'startSeatSelection',
+  USER_STATUS.ENTERING,
+);
 
 export type StartSeatSelectionLuaResult = LuaUserStateTransitionResult<StartSeatSelectionBusinessCode>;
 
@@ -49,6 +55,8 @@ export const startSeatSelectionLua = `
   local sid = ARGV[2]
   local inBookingSessionPrefix = ARGV[3]
   local inBookingSessionSuffix = ARGV[4]
+  local expectedFrom = ARGV[5]
+  local nextTo = ARGV[6]
 
   local raw = redis.call('GET', sessionKey)
   if not raw then
@@ -56,7 +64,7 @@ export const startSeatSelectionLua = `
   end
 
   local session = cjson.decode(raw)
-  if session.userStatus ~= '${USER_STATUS.ENTERING}' then
+  if session.userStatus ~= expectedFrom then
     return {'STATE_MISMATCH', session.userStatus}
   end
 
@@ -75,7 +83,7 @@ export const startSeatSelectionLua = `
     bookingAmount = math.floor(parsedBookingAmount)
   end
 
-  session.userStatus = '${USER_STATUS.SELECTING_SEAT}'
+  session.userStatus = nextTo
 
   local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
   if prepareCode ~= 'OK' then
@@ -108,6 +116,8 @@ type RedisWithStartSeatSelectionCommand = Redis & {
     sid: string,
     inBookingSessionPrefix: string,
     inBookingSessionSuffix: string,
+    expectedFrom: string,
+    nextTo: string,
   ): Promise<LuaUserStateTransitionRawResult<StartSeatSelectionBusinessCode>>;
 };
 
@@ -129,9 +139,9 @@ export function mapStartSeatSelectionLuaResult(
   raw: LuaUserStateTransitionRawResult<StartSeatSelectionBusinessCode>,
 ): StartSeatSelectionLuaResult {
   return mapLuaUserStateTransitionResult(raw, {
-    action: 'startSeatSelection',
-    expectedFrom: USER_STATUS.ENTERING,
-    nextTo: USER_STATUS.SELECTING_SEAT,
+    action: START_SEAT_SELECTION_TRANSITION.action,
+    expectedFrom: START_SEAT_SELECTION_TRANSITION.from,
+    nextTo: START_SEAT_SELECTION_TRANSITION.to,
     businessCodes: START_SEAT_SELECTION_BUSINESS_CODES,
   });
 }
@@ -151,6 +161,8 @@ export async function runStartSeatSelectionLua(
     input.sid,
     prefix,
     suffix,
+    START_SEAT_SELECTION_TRANSITION.from,
+    START_SEAT_SELECTION_TRANSITION.to,
   );
 
   return mapStartSeatSelectionLuaResult(rawResult);

--- a/back/src/domains/booking/luaScripts/waitingQueueEntryLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/waitingQueueEntryLua.spec.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { installWaitingQueueEntryCommandMock } from '../../../testing/redis/waiting-queue-entry-command-mock';
+
+import {
+  mapWaitingQueueEntryLuaResult,
+  runWaitingQueueEntryLua,
+  waitingQueueEntryLua,
+} from './waitingQueueEntryLua';
+
+const EVENT_ID = 42;
+const SID = 'sid-1';
+const SESSION_KEY = `user:${SID}`;
+const QUEUE_KEY = `waiting-queue:${EVENT_ID}`;
+const ORDER_KEY = `waiting-queue:${EVENT_ID}:order`;
+
+const loginSession = {
+  id: 1,
+  loginId: 'guest-1',
+  roles: ['USER'],
+  targetEvent: null,
+  userStatus: USER_STATUS.LOGIN,
+};
+
+const entryInput = {
+  sessionKey: SESSION_KEY,
+  waitingQueueKey: QUEUE_KEY,
+  waitingOrderKey: ORDER_KEY,
+  eventId: EVENT_ID,
+  sid: SID,
+};
+
+/** 운영 Lua와 같은 계약을 emulate하는 테스트용 command mock을 그대로 사용함. */
+function createCommandRedis(): Redis {
+  const redis = new RedisMock() as unknown as Redis;
+  installWaitingQueueEntryCommandMock(redis);
+  return redis;
+}
+
+describe('대기열 진입 Lua 실행', () => {
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = createCommandRedis();
+  });
+
+  afterEach(async () => {
+    await redis.flushall();
+    redis.disconnect();
+  });
+
+  it('세션이 없으면 SESSION_MISSING을 반환하고 순번을 발급하지 않음', async () => {
+    const { transition, order } = await runWaitingQueueEntryLua(redis, entryInput);
+
+    expect(transition).toMatchObject({ ok: false, code: 'SESSION_MISSING' });
+    expect(order).toBeNull();
+    expect(await redis.get(ORDER_KEY)).toBeNull();
+    expect(await redis.llen(QUEUE_KEY)).toBe(0);
+  });
+
+  it('LOGIN이 아니면 STATE_MISMATCH를 반환하고 큐를 건드리지 않음', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify({ ...loginSession, userStatus: USER_STATUS.WAITING }));
+
+    const { transition, order } = await runWaitingQueueEntryLua(redis, entryInput);
+
+    expect(transition).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(order).toBeNull();
+    expect(await redis.llen(QUEUE_KEY)).toBe(0);
+  });
+
+  it('이미 다른 이벤트를 보고 있으면 TARGET_EVENT_MISMATCH를 반환함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify({ ...loginSession, targetEvent: 7 }));
+
+    const { transition, order } = await runWaitingQueueEntryLua(redis, entryInput);
+
+    expect(transition).toMatchObject({ ok: false, code: 'TARGET_EVENT_MISMATCH' });
+    expect(order).toBeNull();
+    expect(await redis.llen(QUEUE_KEY)).toBe(0);
+  });
+
+  it('성공하면 순번 발급, 큐 적재, 상태 전이를 함께 반영함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(loginSession));
+
+    const { transition, order } = await runWaitingQueueEntryLua(redis, entryInput);
+
+    expect(transition).toMatchObject({ ok: true, code: 'OK', to: USER_STATUS.WAITING });
+    expect(order).toBe(1);
+    expect(JSON.parse((await redis.lindex(QUEUE_KEY, 0)) ?? '{}')).toEqual({ sid: SID, order: 1 });
+    expect(JSON.parse((await redis.get(SESSION_KEY)) ?? '{}')).toMatchObject({
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: EVENT_ID,
+      waitingOrder: 1,
+    });
+  });
+
+  it('여러 사용자가 진입해도 순번이 겹치지 않고 증가함', async () => {
+    const orders: Array<number | null> = [];
+
+    for (const sid of ['sid-1', 'sid-2', 'sid-3']) {
+      await redis.set(`user:${sid}`, JSON.stringify(loginSession));
+      const { order } = await runWaitingQueueEntryLua(redis, {
+        ...entryInput,
+        sessionKey: `user:${sid}`,
+        sid,
+      });
+      orders.push(order);
+    }
+
+    expect(orders).toEqual([1, 2, 3]);
+    expect(await redis.llen(QUEUE_KEY)).toBe(3);
+  });
+
+  it('성공해도 세션 TTL을 갱신하지 않고 남은 시간을 보존함', async () => {
+    await redis.set(SESSION_KEY, JSON.stringify(loginSession), 'PX', 60_000);
+
+    await runWaitingQueueEntryLua(redis, entryInput);
+
+    const ttl = await redis.pttl(SESSION_KEY);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe('대기열 진입 Lua 결과 매핑', () => {
+  it('성공 결과에서 순번을 함께 꺼냄', () => {
+    expect(mapWaitingQueueEntryLuaResult(['OK', 12])).toEqual({
+      transition: {
+        ok: true,
+        code: 'OK',
+        action: 'enterWaiting',
+        from: USER_STATUS.LOGIN,
+        to: USER_STATUS.WAITING,
+      },
+      order: 12,
+    });
+  });
+
+  it('성공인데 순번이 없으면 조용히 넘기지 않고 throw함', () => {
+    expect(() => mapWaitingQueueEntryLuaResult(['OK'])).toThrow(TypeError);
+  });
+
+  it('거부 결과는 순번 없이 전달함', () => {
+    expect(mapWaitingQueueEntryLuaResult(['STATE_MISMATCH', USER_STATUS.WAITING])).toMatchObject({
+      transition: { ok: false, code: 'STATE_MISMATCH' },
+      order: null,
+    });
+  });
+});
+
+describe('대기열 진입 Lua 정적 계약', () => {
+  it('순번을 INCR로 발급해 전역 카운터 read-modify-write를 만들지 않음', () => {
+    expect(waitingQueueEntryLua).toContain("redis.call('INCR', waitingOrderKey)");
+    expect(waitingQueueEntryLua).not.toContain("redis.call('SET', waitingOrderKey");
+    expect(waitingQueueEntryLua).not.toContain("redis.call('GET', waitingOrderKey)");
+  });
+
+  it('상태 문자열을 FSM 상수에서 주입해 literal 드리프트를 막음', () => {
+    expect(waitingQueueEntryLua).toContain(`session.userStatus ~= '${USER_STATUS.LOGIN}'`);
+    expect(waitingQueueEntryLua).toContain(`session.userStatus = '${USER_STATUS.WAITING}'`);
+  });
+
+  it('세션 쓰기 전에 큐 적재를 끝내 부분 반영을 만들지 않음', () => {
+    // 공용 helper 정의가 앞에 붙으므로 호출 지점은 마지막 등장 위치로 찾음.
+    const rpushIndex = waitingQueueEntryLua.indexOf("redis.call('RPUSH', waitingQueueKey");
+    const writeIndex = waitingQueueEntryLua.lastIndexOf('writePreparedSessionPreservingTtl(sessionKey');
+
+    expect(rpushIndex).toBeGreaterThan(-1);
+    expect(writeIndex).toBeGreaterThan(rpushIndex);
+  });
+
+  it('발급한 순번을 세션에도 남겨 조회가 큐 전체 스캔에 의존하지 않게 함', () => {
+    expect(waitingQueueEntryLua).toContain('session.waitingOrder = order');
+  });
+
+  it('TTL 보존 쓰기를 자체 구현하지 않고 공용 helper에 위임함', () => {
+    const source = readFileSync(join(__dirname, 'waitingQueueEntryLua.ts'), 'utf8');
+
+    expect(source).toContain('sessionWriteLuaHelpers');
+    expect(source).not.toContain('local function prepareSessionWrite');
+    expect(source).not.toContain("redis.call('PSETEX'");
+  });
+
+  it('스크립트 본문 직접 eval 대신 script cache 명령으로 등록함', () => {
+    const source = readFileSync(join(__dirname, 'waitingQueueEntryLua.ts'), 'utf8');
+
+    expect(source).not.toMatch(/redis\.eval\(/);
+    expect(source).toContain("redis.defineCommand('enterWaitingQueue'");
+    expect(source).toContain('numberOfKeys: 3');
+  });
+});

--- a/back/src/domains/booking/luaScripts/waitingQueueEntryLua.spec.ts
+++ b/back/src/domains/booking/luaScripts/waitingQueueEntryLua.spec.ts
@@ -4,10 +4,11 @@ import { join } from 'path';
 import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
-import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { USER_STATE_TRANSITIONS, USER_STATUS } from '../../../auth/fsm/user-state.fsm';
 import { installWaitingQueueEntryCommandMock } from '../../../testing/redis/waiting-queue-entry-command-mock';
 
 import {
+  ENTER_WAITING_TRANSITION,
   mapWaitingQueueEntryLuaResult,
   runWaitingQueueEntryLua,
   waitingQueueEntryLua,
@@ -159,9 +160,17 @@ describe('대기열 진입 Lua 정적 계약', () => {
     expect(waitingQueueEntryLua).not.toContain("redis.call('GET', waitingOrderKey)");
   });
 
-  it('상태 문자열을 FSM 상수에서 주입해 literal 드리프트를 막음', () => {
-    expect(waitingQueueEntryLua).toContain(`session.userStatus ~= '${USER_STATUS.LOGIN}'`);
-    expect(waitingQueueEntryLua).toContain(`session.userStatus = '${USER_STATUS.WAITING}'`);
+  it('from/to를 스크립트에 적어두지 않고 FSM 전이 테이블에서 유도함', () => {
+    expect(USER_STATE_TRANSITIONS).toContainEqual(ENTER_WAITING_TRANSITION);
+    expect(ENTER_WAITING_TRANSITION.from).toBe(USER_STATUS.LOGIN);
+  });
+
+  it('Lua 본문에 상태 문자열을 박아두지 않고 ARGV로 받음', () => {
+    expect(waitingQueueEntryLua).toContain('session.userStatus ~= expectedFrom');
+    expect(waitingQueueEntryLua).toContain('session.userStatus = nextTo');
+    for (const state of Object.values(USER_STATUS)) {
+      expect(waitingQueueEntryLua).not.toContain(`'${state}'`);
+    }
   });
 
   it('세션 쓰기 전에 큐 적재를 끝내 부분 반영을 만들지 않음', () => {

--- a/back/src/domains/booking/luaScripts/waitingQueueEntryLua.ts
+++ b/back/src/domains/booking/luaScripts/waitingQueueEntryLua.ts
@@ -1,0 +1,126 @@
+import Redis from 'ioredis';
+
+import {
+  mapLuaUserStateTransitionResult,
+  type LuaUserStateTransitionRawResult,
+  type LuaUserStateTransitionResult,
+} from '../../../auth/fsm/user-state-transition.contract';
+import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
+import { sessionWriteLuaHelpers } from '../../../auth/luaScripts/sessionLuaHelpers';
+
+export type WaitingQueueEntryLuaInput = {
+  sessionKey: string;
+  waitingQueueKey: string;
+  waitingOrderKey: string;
+  eventId: number;
+  sid: string;
+};
+
+export type WaitingQueueEntryLuaResult = {
+  transition: LuaUserStateTransitionResult;
+  order: number | null;
+};
+
+export const waitingQueueEntryLua = `
+  ${sessionWriteLuaHelpers}
+
+  local sessionKey = KEYS[1]
+  local waitingQueueKey = KEYS[2]
+  local waitingOrderKey = KEYS[3]
+
+  local eventId = tonumber(ARGV[1])
+  local sid = ARGV[2]
+
+  local raw = redis.call('GET', sessionKey)
+  if not raw then
+    return {'SESSION_MISSING'}
+  end
+
+  local session = cjson.decode(raw)
+  if session.userStatus ~= '${USER_STATUS.LOGIN}' then
+    return {'STATE_MISMATCH', session.userStatus}
+  end
+
+  if session.targetEvent ~= cjson.null then
+    return {'TARGET_EVENT_MISMATCH', session.targetEvent}
+  end
+
+  local order = redis.call('INCR', waitingOrderKey)
+
+  session.userStatus = '${USER_STATUS.WAITING}'
+  session.targetEvent = eventId
+  session.waitingOrder = order
+
+  local encodedSession, ttl, prepareCode = prepareSessionWrite(sessionKey, session)
+  if prepareCode ~= 'OK' then
+    return {prepareCode}
+  end
+
+  redis.call('RPUSH', waitingQueueKey, cjson.encode({sid = sid, order = order}))
+  writePreparedSessionPreservingTtl(sessionKey, encodedSession, ttl)
+
+  return {'OK', order}
+`;
+
+type RedisWithWaitingQueueEntryCommand = Redis & {
+  enterWaitingQueue(
+    sessionKey: string,
+    waitingQueueKey: string,
+    waitingOrderKey: string,
+    eventId: string,
+    sid: string,
+  ): Promise<LuaUserStateTransitionRawResult>;
+};
+
+const commandRegisteredRedisSet = new WeakSet<object>();
+
+function getWaitingQueueEntryCommandRedis(redis: Redis): RedisWithWaitingQueueEntryCommand {
+  if (!commandRegisteredRedisSet.has(redis)) {
+    redis.defineCommand('enterWaitingQueue', {
+      numberOfKeys: 3,
+      lua: waitingQueueEntryLua,
+    });
+    commandRegisteredRedisSet.add(redis);
+  }
+
+  return redis as RedisWithWaitingQueueEntryCommand;
+}
+
+export function mapWaitingQueueEntryLuaResult(
+  raw: LuaUserStateTransitionRawResult,
+): WaitingQueueEntryLuaResult {
+  const transition = mapLuaUserStateTransitionResult(raw, {
+    action: 'enterWaiting',
+    expectedFrom: USER_STATUS.LOGIN,
+    nextTo: USER_STATUS.WAITING,
+  });
+
+  if (!transition.ok) {
+    return { transition, order: null };
+  }
+
+  const rawOrder = Array.isArray(raw) ? raw[1] : undefined;
+  const order = Number(rawOrder);
+
+  if (!Number.isInteger(order)) {
+    throw new TypeError('대기열 진입 Lua는 성공 시 정수 순번을 함께 반환해야 함');
+  }
+
+  return { transition, order };
+}
+
+export async function runWaitingQueueEntryLua(
+  redis: Redis,
+  input: WaitingQueueEntryLuaInput,
+): Promise<WaitingQueueEntryLuaResult> {
+  const commandRedis = getWaitingQueueEntryCommandRedis(redis);
+  const rawResult = await commandRedis.enterWaitingQueue(
+    input.sessionKey,
+    input.waitingQueueKey,
+    input.waitingOrderKey,
+    String(input.eventId),
+    input.sid,
+  );
+
+  return mapWaitingQueueEntryLuaResult(rawResult);
+}

--- a/back/src/domains/booking/luaScripts/waitingQueueEntryLua.ts
+++ b/back/src/domains/booking/luaScripts/waitingQueueEntryLua.ts
@@ -2,11 +2,14 @@ import Redis from 'ioredis';
 
 import {
   mapLuaUserStateTransitionResult,
+  resolveUserStateTransition,
   type LuaUserStateTransitionRawResult,
   type LuaUserStateTransitionResult,
 } from '../../../auth/fsm/user-state-transition.contract';
 import { USER_STATUS } from '../../../auth/fsm/user-state.fsm';
 import { sessionWriteLuaHelpers } from '../../../auth/luaScripts/sessionLuaHelpers';
+
+export const ENTER_WAITING_TRANSITION = resolveUserStateTransition('enterWaiting', USER_STATUS.LOGIN);
 
 export type WaitingQueueEntryLuaInput = {
   sessionKey: string;
@@ -30,6 +33,8 @@ export const waitingQueueEntryLua = `
 
   local eventId = tonumber(ARGV[1])
   local sid = ARGV[2]
+  local expectedFrom = ARGV[3]
+  local nextTo = ARGV[4]
 
   local raw = redis.call('GET', sessionKey)
   if not raw then
@@ -37,7 +42,7 @@ export const waitingQueueEntryLua = `
   end
 
   local session = cjson.decode(raw)
-  if session.userStatus ~= '${USER_STATUS.LOGIN}' then
+  if session.userStatus ~= expectedFrom then
     return {'STATE_MISMATCH', session.userStatus}
   end
 
@@ -47,7 +52,7 @@ export const waitingQueueEntryLua = `
 
   local order = redis.call('INCR', waitingOrderKey)
 
-  session.userStatus = '${USER_STATUS.WAITING}'
+  session.userStatus = nextTo
   session.targetEvent = eventId
   session.waitingOrder = order
 
@@ -69,6 +74,8 @@ type RedisWithWaitingQueueEntryCommand = Redis & {
     waitingOrderKey: string,
     eventId: string,
     sid: string,
+    expectedFrom: string,
+    nextTo: string,
   ): Promise<LuaUserStateTransitionRawResult>;
 };
 
@@ -90,9 +97,9 @@ export function mapWaitingQueueEntryLuaResult(
   raw: LuaUserStateTransitionRawResult,
 ): WaitingQueueEntryLuaResult {
   const transition = mapLuaUserStateTransitionResult(raw, {
-    action: 'enterWaiting',
-    expectedFrom: USER_STATUS.LOGIN,
-    nextTo: USER_STATUS.WAITING,
+    action: ENTER_WAITING_TRANSITION.action,
+    expectedFrom: ENTER_WAITING_TRANSITION.from,
+    nextTo: ENTER_WAITING_TRANSITION.to,
   });
 
   if (!transition.ok) {
@@ -120,6 +127,8 @@ export async function runWaitingQueueEntryLua(
     input.waitingOrderKey,
     String(input.eventId),
     input.sid,
+    ENTER_WAITING_TRANSITION.from,
+    ENTER_WAITING_TRANSITION.to,
   );
 
   return mapWaitingQueueEntryLuaResult(rawResult);

--- a/back/src/domains/booking/service/booking-seats.service.ts
+++ b/back/src/domains/booking/service/booking-seats.service.ts
@@ -352,8 +352,7 @@ export class BookingSeatsService implements OnModuleDestroy {
     }
 
     // SSE 풀 조작 성공 후에만 세션의 subscribedSection 갱신 (D-01)
-    session.subscribedSection = sectionIndex;
-    await this.inBookingService.setSession(eventId, session);
+    await this.inBookingService.setSubscribedSection(eventId, sid, sectionIndex);
 
     return { sectionIndex, seatStatus: seats ?? [] };
   }

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -11,12 +11,23 @@ import {
   type WaitingHeadPromotionBusinessCode,
   type WaitingHeadPromotionLuaResult,
 } from '../luaScripts/admissionCapacityLua';
+import {
+  runMarkReconnectingLua,
+  runRestoreSelectingLua,
+  type MarkReconnectingLuaResult,
+  type RestoreSelectingLuaResult,
+} from '../luaScripts/reconnectingTransitionLua';
 
 import { BookingService } from './booking.service';
 
 jest.mock('../luaScripts/admissionCapacityLua', () => ({
   runImmediateAdmissionLua: jest.fn(),
   runWaitingHeadPromotionLua: jest.fn(),
+}));
+
+jest.mock('../luaScripts/reconnectingTransitionLua', () => ({
+  runMarkReconnectingLua: jest.fn(),
+  runRestoreSelectingLua: jest.fn(),
 }));
 
 type TransitionContextFixture = {
@@ -119,6 +130,7 @@ function createService() {
   };
   const logger = {
     error: jest.fn(),
+    warn: jest.fn(),
   };
 
   const service = new BookingService(
@@ -134,6 +146,7 @@ function createService() {
 
   return {
     authService,
+    logger,
     openBookingService,
     redis,
     service,
@@ -210,6 +223,59 @@ function promotionFailedResult(
   };
 }
 
+function extractMethodBody(source: string, startMarker: string, endMarker: string): string {
+  const methodStart = source.indexOf(startMarker);
+  const nextMethodStart = source.indexOf(endMarker, methodStart);
+
+  if (methodStart < 0 || nextMethodStart < 0) {
+    throw new Error(`${startMarker} 본문을 찾을 수 없음`);
+  }
+
+  return source.slice(methodStart, nextMethodStart);
+}
+
+function markOkResult(): MarkReconnectingLuaResult {
+  return {
+    ok: true,
+    code: 'OK',
+    action: 'markReconnectingSelection',
+    from: USER_STATUS.SELECTING_SEAT,
+    to: USER_STATUS.RECONNECTING_SELECTING,
+  };
+}
+
+function markFailedResult(code: 'STATE_MISMATCH' | 'SESSION_MISSING'): MarkReconnectingLuaResult {
+  return {
+    ok: false,
+    code,
+    action: 'markReconnectingSelection',
+    expectedFrom: USER_STATUS.SELECTING_SEAT,
+    nextTo: USER_STATUS.RECONNECTING_SELECTING,
+    details: [],
+  };
+}
+
+function restoreOkResult(): RestoreSelectingLuaResult {
+  return {
+    ok: true,
+    code: 'OK',
+    action: 'restoreSeatSelection',
+    from: USER_STATUS.RECONNECTING_SELECTING,
+    to: USER_STATUS.SELECTING_SEAT,
+  };
+}
+
+function restoreFailedResult(code: 'NOT_RECONNECTING' | 'STATE_MISMATCH'): RestoreSelectingLuaResult {
+  return {
+    ok: false,
+    code,
+    action: 'restoreSeatSelection',
+    expectedFrom: USER_STATUS.RECONNECTING_SELECTING,
+    nextTo: USER_STATUS.SELECTING_SEAT,
+    details: [],
+  };
+}
+
 async function callLetInNextWaiting(service: BookingService, eventId = 42) {
   await (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(
     eventId,
@@ -243,50 +309,78 @@ describe('BookingService transaction-local event ownership validation', () => {
     expect(multi.del).not.toHaveBeenCalled();
     expect(multi.hset).not.toHaveBeenCalled();
   });
+});
 
-  it('does not restore reconnecting state for a mismatched transaction targetEvent', async () => {
-    const { authService, service } = createService();
-    const transactionRedis = createRedisMock();
-    const multi = createMultiMock();
+describe('BookingService 재연결 전이 Lua 연동', () => {
+  const runMarkReconnectingLuaMock = jest.mocked(runMarkReconnectingLua);
+  const runRestoreSelectingLuaMock = jest.mocked(runRestoreSelectingLua);
 
-    authService.restoreSeatSelection.mockImplementation(
-      async (_sid: string, options: TransitionOptionsFixture) => {
-        const isValid = await options.validate?.(transactionRedis, createContext(2));
-        if (isValid === false) {
-          return null;
-        }
-
-        await options.mutate?.(multi, createContext(2));
-        return successfulTransition('restoreSeatSelection');
-      },
-    );
-
-    await expectInvalidState(() => service.restoreInBookingFromReconnecting(1, 'sid-1'));
-
-    expect(transactionRedis.zscore).not.toHaveBeenCalled();
-    expect(multi.zrem).not.toHaveBeenCalled();
+  beforeEach(() => {
+    runMarkReconnectingLuaMock.mockReset();
+    runRestoreSelectingLuaMock.mockReset();
   });
 
-  it('returns false without reconnecting zadd when transaction targetEvent changed', async () => {
-    const { authService, service } = createService();
-    const transactionRedis = createRedisMock();
-    const multi = createMultiMock();
+  it('재연결 표시는 세션 키와 재연결 풀 키를 Lua runner에 넘김', async () => {
+    const { redis, service } = createService();
+    runMarkReconnectingLuaMock.mockResolvedValue(markOkResult());
 
-    authService.markReconnectingSelection.mockImplementation(
-      async (_sid: string, options: TransitionOptionsFixture) => {
-        const isValid = await options.validate?.(transactionRedis, createContext(2));
-        if (isValid === false) {
-          return null;
-        }
+    await expect(service.markReconnectingFromSeat(42, 'sid-1')).resolves.toBe(true);
 
-        await options.mutate?.(multi, createContext(2));
-        return successfulTransition('markReconnectingSelection');
-      },
+    expect(runMarkReconnectingLuaMock).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      reconnectingKey: 'reconnecting:42',
+      eventId: 42,
+      sid: 'sid-1',
+      nowMs: expect.any(Number),
+    });
+  });
+
+  it('재연결 표시가 실패하면 슬롯 누수 가능성을 경고 로그로 남기고 false를 반환함', async () => {
+    const { logger, service } = createService();
+    runMarkReconnectingLuaMock.mockResolvedValue(markFailedResult('STATE_MISMATCH'));
+
+    await expect(service.markReconnectingFromSeat(42, 'sid-1')).resolves.toBe(false);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('STATE_MISMATCH'));
+  });
+
+  it('재연결 복원은 세션 키와 재연결 풀 키를 Lua runner에 넘김', async () => {
+    const { redis, service } = createService();
+    runRestoreSelectingLuaMock.mockResolvedValue(restoreOkResult());
+
+    await expect(service.restoreInBookingFromReconnecting(42, 'sid-1')).resolves.toBeUndefined();
+
+    expect(runRestoreSelectingLuaMock).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      reconnectingKey: 'reconnecting:42',
+      eventId: 42,
+      sid: 'sid-1',
+    });
+  });
+
+  it('재연결 풀 멤버가 아니면 INVALID_STATE로 변환함', async () => {
+    const { service } = createService();
+    runRestoreSelectingLuaMock.mockResolvedValue(restoreFailedResult('NOT_RECONNECTING'));
+
+    await expectInvalidState(() => service.restoreInBookingFromReconnecting(42, 'sid-1'));
+  });
+
+  it('재연결 경로는 WATCH 기반 AuthService 콜백으로 회귀하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+    const restoreBody = extractMethodBody(
+      source,
+      'async restoreInBookingFromReconnecting',
+      'async markReconnectingFromSeat',
     );
+    const markBody = extractMethodBody(source, 'async markReconnectingFromSeat', 'async isAdmission');
 
-    await expect(service.markReconnectingFromSeat(1, 'sid-1')).resolves.toBe(false);
-
-    expect(multi.zadd).not.toHaveBeenCalled();
+    expect(markBody).toContain('runMarkReconnectingLua(this.redis');
+    expect(restoreBody).toContain('runRestoreSelectingLua(this.redis');
+    for (const body of [markBody, restoreBody]) {
+      expect(body).not.toContain('watchKeys');
+      expect(body).not.toContain('this.authService.markReconnectingSelection');
+      expect(body).not.toContain('this.authService.restoreSeatSelection');
+    }
   });
 });
 

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -17,6 +17,7 @@ import {
   type MarkReconnectingLuaResult,
   type RestoreSelectingLuaResult,
 } from '../luaScripts/reconnectingTransitionLua';
+import { runWaitingQueueEntryLua, type WaitingQueueEntryLuaResult } from '../luaScripts/waitingQueueEntryLua';
 
 import { BookingService } from './booking.service';
 
@@ -28,6 +29,10 @@ jest.mock('../luaScripts/admissionCapacityLua', () => ({
 jest.mock('../luaScripts/reconnectingTransitionLua', () => ({
   runMarkReconnectingLua: jest.fn(),
   runRestoreSelectingLua: jest.fn(),
+}));
+
+jest.mock('../luaScripts/waitingQueueEntryLua', () => ({
+  runWaitingQueueEntryLua: jest.fn(),
 }));
 
 type TransitionContextFixture = {
@@ -276,6 +281,35 @@ function restoreFailedResult(code: 'NOT_RECONNECTING' | 'STATE_MISMATCH'): Resto
   };
 }
 
+function waitingEntryOkResult(order: number): WaitingQueueEntryLuaResult {
+  return {
+    transition: {
+      ok: true,
+      code: 'OK',
+      action: 'enterWaiting',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.WAITING,
+    },
+    order,
+  };
+}
+
+function waitingEntryFailedResult(
+  code: 'STATE_MISMATCH' | 'SESSION_MISSING' | 'TARGET_EVENT_MISMATCH',
+): WaitingQueueEntryLuaResult {
+  return {
+    transition: {
+      ok: false,
+      code,
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+      details: [],
+    },
+    order: null,
+  };
+}
+
 async function callLetInNextWaiting(service: BookingService, eventId = 42) {
   await (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(
     eventId,
@@ -386,9 +420,11 @@ describe('BookingService 재연결 전이 Lua 연동', () => {
 
 describe('BookingService immediate admission Lua integration', () => {
   const runImmediateAdmissionLuaMock = jest.mocked(runImmediateAdmissionLua);
+  const runWaitingQueueEntryLuaMock = jest.mocked(runWaitingQueueEntryLua);
 
   beforeEach(() => {
     runImmediateAdmissionLuaMock.mockReset();
+    runWaitingQueueEntryLuaMock.mockReset();
   });
 
   it('즉시 입장 Lua OK 결과를 기존 entering DTO로 반환하고 WATCH 경로를 호출하지 않음', async () => {
@@ -436,12 +472,7 @@ describe('BookingService immediate admission Lua integration', () => {
       nextTo: USER_STATUS.ENTERING,
       details: [],
     });
-    authService.enterWaiting.mockImplementation(
-      async (_sid: string, _eventId: number, options: TransitionOptionsFixture) => {
-        await options.validate?.(redis, createContext(null));
-        return { ok: true, action: 'enterWaiting' };
-      },
-    );
+    runWaitingQueueEntryLuaMock.mockResolvedValue(waitingEntryOkResult(1));
 
     await expect(service.isAdmission(42, 'sid-1')).resolves.toEqual({
       waitingStatus: true,
@@ -450,13 +481,13 @@ describe('BookingService immediate admission Lua integration', () => {
     });
 
     expect(authService.enterBookingGate).not.toHaveBeenCalled();
-    expect(authService.enterWaiting).toHaveBeenCalledWith(
-      'sid-1',
-      42,
-      expect.objectContaining({
-        watchKeys: ['waiting-queue:42', 'waiting-queue:42:order'],
-      }),
-    );
+    expect(runWaitingQueueEntryLuaMock).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      waitingQueueKey: 'waiting-queue:42',
+      waitingOrderKey: 'waiting-queue:42:order',
+      eventId: 42,
+      sid: 'sid-1',
+    });
   });
 
   it('즉시 입장 Lua stale 세션 결과는 기존 INVALID_STATE 예외로 유지함', async () => {
@@ -475,7 +506,34 @@ describe('BookingService immediate admission Lua integration', () => {
     await expectInvalidState(() => service.isAdmission(42, 'sid-1'));
 
     expect(authService.enterBookingGate).not.toHaveBeenCalled();
-    expect(authService.enterWaiting).not.toHaveBeenCalled();
+    expect(runWaitingQueueEntryLuaMock).not.toHaveBeenCalled();
+  });
+
+  it('대기열 진입 Lua가 거부하면 INVALID_STATE로 변환함', async () => {
+    const { openBookingService, authService, service } = createService();
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    authService.getUserSession.mockResolvedValue(loginSession());
+    runImmediateAdmissionLuaMock.mockResolvedValue({
+      ok: false,
+      code: 'CAPACITY_FULL',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.ENTERING,
+      details: [],
+    });
+    runWaitingQueueEntryLuaMock.mockResolvedValue(waitingEntryFailedResult('STATE_MISMATCH'));
+
+    await expectInvalidState(() => service.isAdmission(42, 'sid-1'));
+  });
+
+  it('대기열 진입 경로는 WATCH 기반 order 갱신으로 회귀하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+    const body = extractMethodBody(source, 'private async tryEnterWaitingQueue', 'private getEnteringKey');
+
+    expect(body).toContain('runWaitingQueueEntryLua(this.redis');
+    expect(body).not.toContain('watchKeys');
+    expect(body).not.toContain('this.authService.enterWaiting');
+    expect(body).not.toContain('parseInt');
   });
 });
 

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -112,7 +112,6 @@ function createService() {
   };
   const waitingQueueService = {
     getQueueSize: jest.fn(),
-    popQueue: jest.fn(),
   };
   const enterBookingService = {
     isEntering: jest.fn(),
@@ -289,7 +288,6 @@ describe('BookingService transaction-local event ownership validation', () => {
 
     expect(multi.zadd).not.toHaveBeenCalled();
   });
-
 });
 
 describe('BookingService immediate admission Lua integration', () => {
@@ -408,7 +406,7 @@ describe('BookingService waiting-head promotion Lua integration', () => {
   });
 
   it('대기열 head 승격 OK면 정원이 찰 때까지 Lua 호출을 반복함', async () => {
-    const { authService, redis, service, waitingQueueService } = createService();
+    const { authService, redis, service } = createService();
     runWaitingHeadPromotionLuaMock
       .mockResolvedValueOnce(promotionOkResult())
       .mockResolvedValueOnce(promotionOkResult())
@@ -432,11 +430,10 @@ describe('BookingService waiting-head promotion Lua integration', () => {
       nowMs: expect.any(Number),
     });
     expect(authService.enterBookingGate).not.toHaveBeenCalled();
-    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
   });
 
   it('stale head 결과면 다음 후보를 위해 Lua 호출을 계속함', async () => {
-    const { service, waitingQueueService } = createService();
+    const { service } = createService();
     runWaitingHeadPromotionLuaMock
       .mockResolvedValueOnce(promotionFailedResult('STALE_SESSION_MISSING', ['sid-1']))
       .mockResolvedValueOnce(promotionFailedResult('STALE_STATE_MISMATCH', [USER_STATUS.LOGIN]))
@@ -445,17 +442,15 @@ describe('BookingService waiting-head promotion Lua integration', () => {
     await callLetInNextWaiting(service);
 
     expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledTimes(3);
-    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
   });
 
-  it('CAPACITY_FULL이면 head 제거 없이 승격 loop를 멈춤', async () => {
-    const { service, waitingQueueService } = createService();
+  it('CAPACITY_FULL이면 승격 loop를 멈춤', async () => {
+    const { service } = createService();
     runWaitingHeadPromotionLuaMock.mockResolvedValue(promotionFailedResult('CAPACITY_FULL'));
 
     await callLetInNextWaiting(service);
 
     expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledTimes(1);
-    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
   });
 
   it('QUEUE_EMPTY이면 queue pre-read 없이 승격 loop를 멈춤', async () => {
@@ -469,16 +464,14 @@ describe('BookingService waiting-head promotion Lua integration', () => {
     expect(redis.lindex).not.toHaveBeenCalled();
   });
 
-  it('Lua 실패는 stale pop으로 변환하지 않고 caller로 throw함', async () => {
-    const { service, waitingQueueService } = createService();
+  it('Lua 실패는 삼키지 않고 caller로 throw함', async () => {
+    const { service } = createService();
     const failure = new Error('redis lua failure');
     runWaitingHeadPromotionLuaMock.mockRejectedValue(failure);
 
     await expect(
       (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(42),
     ).rejects.toThrow(failure);
-
-    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
   });
 
   it('대기열 head 승격 경로는 Lua runner를 사용하고 hot WATCH pre-read로 회귀하지 않음', () => {
@@ -488,7 +481,6 @@ describe('BookingService waiting-head promotion Lua integration', () => {
     expect(promotionBody).toContain('runWaitingHeadPromotionLua(this.redis');
     expect(promotionBody).not.toContain('this.authService.enterBookingGate');
     expect(promotionBody).not.toContain('getWaitingHead');
-    expect(promotionBody).not.toContain('waitingQueueService.popQueue');
     expect(promotionBody).not.toContain('getAdmissionWatchKeys');
   });
 });

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -68,13 +68,8 @@ function createService() {
   };
 
   const authService = {
-    enterWaiting: jest.fn(),
-    enterBookingGate: jest.fn(),
     getUserSession: jest.fn(),
     getUserEventTarget: jest.fn(),
-    markReconnectingSelection: jest.fn(),
-    restoreSeatSelection: jest.fn(),
-    startSeatSelection: jest.fn(),
   };
   const bookingSeatsService = {
     updateSeatDeleted: jest.fn().mockResolvedValue(undefined),
@@ -482,7 +477,6 @@ describe('BookingService immediate admission Lua integration', () => {
       defaultMaxSize: IN_BOOKING_DEFAULT_MAX_SIZE,
       nowMs: expect.any(Number),
     });
-    expect(authService.enterBookingGate).not.toHaveBeenCalled();
   });
 
   it('즉시 입장 Lua CAPACITY_FULL 결과는 INVALID_STATE가 아니라 기존 대기열 DTO로 이어짐', async () => {
@@ -505,7 +499,6 @@ describe('BookingService immediate admission Lua integration', () => {
       userOrder: 1,
     });
 
-    expect(authService.enterBookingGate).not.toHaveBeenCalled();
     expect(runWaitingQueueEntryLuaMock).toHaveBeenCalledWith(redis, {
       sessionKey: 'user:sid-1',
       waitingQueueKey: 'waiting-queue:42',
@@ -530,7 +523,6 @@ describe('BookingService immediate admission Lua integration', () => {
 
     await expectInvalidState(() => service.isAdmission(42, 'sid-1'));
 
-    expect(authService.enterBookingGate).not.toHaveBeenCalled();
     expect(runWaitingQueueEntryLuaMock).not.toHaveBeenCalled();
   });
 
@@ -583,7 +575,7 @@ describe('BookingService waiting-head promotion Lua integration', () => {
   });
 
   it('대기열 head 승격 OK면 정원이 찰 때까지 Lua 호출을 반복함', async () => {
-    const { authService, redis, service } = createService();
+    const { redis, service } = createService();
     runWaitingHeadPromotionLuaMock
       .mockResolvedValueOnce(promotionOkResult())
       .mockResolvedValueOnce(promotionOkResult())
@@ -606,7 +598,6 @@ describe('BookingService waiting-head promotion Lua integration', () => {
       defaultMaxSize: IN_BOOKING_DEFAULT_MAX_SIZE,
       nowMs: expect.any(Number),
     });
-    expect(authService.enterBookingGate).not.toHaveBeenCalled();
   });
 
   it('stale head 결과면 다음 후보를 위해 Lua 호출을 계속함', async () => {

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -17,6 +17,10 @@ import {
   type MarkReconnectingLuaResult,
   type RestoreSelectingLuaResult,
 } from '../luaScripts/reconnectingTransitionLua';
+import {
+  runStartSeatSelectionLua,
+  type StartSeatSelectionLuaResult,
+} from '../luaScripts/startSeatSelectionLua';
 import { runWaitingQueueEntryLua, type WaitingQueueEntryLuaResult } from '../luaScripts/waitingQueueEntryLua';
 
 import { BookingService } from './booking.service';
@@ -35,29 +39,11 @@ jest.mock('../luaScripts/waitingQueueEntryLua', () => ({
   runWaitingQueueEntryLua: jest.fn(),
 }));
 
-type TransitionContextFixture = {
-  session: { targetEvent: number | null };
-  sessionKey: string;
-  result: { ok: true; action: string; from: string; to: string };
-};
+jest.mock('../luaScripts/startSeatSelectionLua', () => ({
+  runStartSeatSelectionLua: jest.fn(),
+}));
 
 type RedisMock = Record<string, jest.Mock>;
-type MultiMock = Record<string, jest.Mock>;
-
-type TransitionOptionsFixture = {
-  validate?: (redis: RedisMock, context: TransitionContextFixture) => boolean | Promise<boolean>;
-  mutate?: (multi: MultiMock, context: TransitionContextFixture) => void | Promise<void>;
-};
-
-function createMultiMock(): MultiMock {
-  return {
-    del: jest.fn().mockReturnThis(),
-    hset: jest.fn().mockReturnThis(),
-    lpop: jest.fn().mockReturnThis(),
-    zadd: jest.fn().mockReturnThis(),
-    zrem: jest.fn().mockReturnThis(),
-  };
-}
 
 function createRedisMock(): RedisMock {
   return {
@@ -67,28 +53,6 @@ function createRedisMock(): RedisMock {
     lrange: jest.fn().mockResolvedValue([]),
     zcard: jest.fn().mockResolvedValue(0),
     zscore: jest.fn().mockResolvedValue('1'),
-  };
-}
-
-function createContext(targetEvent: number | null): TransitionContextFixture {
-  return {
-    session: { targetEvent },
-    sessionKey: 'user:sid-1',
-    result: {
-      ok: true,
-      action: 'transition',
-      from: USER_STATUS.ENTERING,
-      to: USER_STATUS.SELECTING_SEAT,
-    },
-  };
-}
-
-function successfulTransition(action: string) {
-  return {
-    ok: true,
-    action,
-    from: USER_STATUS.ENTERING,
-    to: USER_STATUS.SELECTING_SEAT,
   };
 }
 
@@ -310,38 +274,96 @@ function waitingEntryFailedResult(
   };
 }
 
+function startSeatSelectionOkResult(): StartSeatSelectionLuaResult {
+  return {
+    ok: true,
+    code: 'OK',
+    action: 'startSeatSelection',
+    from: USER_STATUS.ENTERING,
+    to: USER_STATUS.SELECTING_SEAT,
+  };
+}
+
+function startSeatSelectionFailedResult(
+  code: 'NOT_ENTERING' | 'STATE_MISMATCH' | 'TARGET_EVENT_MISMATCH',
+): StartSeatSelectionLuaResult {
+  return {
+    ok: false,
+    code,
+    action: 'startSeatSelection',
+    expectedFrom: USER_STATUS.ENTERING,
+    nextTo: USER_STATUS.SELECTING_SEAT,
+    details: [],
+  };
+}
+
 async function callLetInNextWaiting(service: BookingService, eventId = 42) {
   await (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(
     eventId,
   );
 }
 
-describe('BookingService transaction-local event ownership validation', () => {
-  it('does not move entering state into in-booking when transaction targetEvent changed', async () => {
+describe('BookingService 좌석 선택 진입 Lua 연동', () => {
+  const runStartSeatSelectionLuaMock = jest.mocked(runStartSeatSelectionLua);
+
+  beforeEach(() => {
+    runStartSeatSelectionLuaMock.mockReset();
+  });
+
+  it('세션에 대상 이벤트가 없으면 Lua를 호출하지 않고 SESSION_EVENT_NOT_FOUND를 던짐', async () => {
     const { authService, service } = createService();
-    const transactionRedis = createRedisMock();
-    const multi = createMultiMock();
+    authService.getUserEventTarget.mockResolvedValue(null);
 
-    authService.getUserEventTarget.mockResolvedValue(1);
-    authService.startSeatSelection.mockImplementation(
-      async (_sid: string, options: TransitionOptionsFixture) => {
-        const isValid = await options.validate?.(transactionRedis, createContext(2));
-        if (isValid === false) {
-          return null;
-        }
+    await expect(service.setInBookingFromEntering('sid-1')).rejects.toBeInstanceOf(AppException);
+    expect(runStartSeatSelectionLuaMock).not.toHaveBeenCalled();
+  });
 
-        await options.mutate?.(multi, createContext(2));
-        return successfulTransition('startSeatSelection');
-      },
-    );
+  it('entering 풀, in-booking 해시, 임시 예매 수량 키를 Lua runner에 넘김', async () => {
+    const { authService, redis, service } = createService();
+    authService.getUserEventTarget.mockResolvedValue(42);
+    runStartSeatSelectionLuaMock.mockResolvedValue(startSeatSelectionOkResult());
+
+    await expect(service.setInBookingFromEntering('sid-1')).resolves.toBeUndefined();
+
+    expect(runStartSeatSelectionLuaMock).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      enteringKey: 'entering:42',
+      inBookingSessionsKey: 'in-booking:42:sessions',
+      bookingAmountKey: 'entering:sid-1:temp-booking-amount',
+      eventId: 42,
+      sid: 'sid-1',
+    });
+  });
+
+  it('entering 멤버가 아니면 INVALID_STATE로 변환함', async () => {
+    const { authService, service } = createService();
+    authService.getUserEventTarget.mockResolvedValue(42);
+    runStartSeatSelectionLuaMock.mockResolvedValue(startSeatSelectionFailedResult('NOT_ENTERING'));
 
     await expectInvalidState(() => service.setInBookingFromEntering('sid-1'));
+  });
 
-    expect(transactionRedis.zscore).not.toHaveBeenCalled();
-    expect(transactionRedis.get).not.toHaveBeenCalled();
-    expect(multi.zrem).not.toHaveBeenCalled();
-    expect(multi.del).not.toHaveBeenCalled();
-    expect(multi.hset).not.toHaveBeenCalled();
+  it('좌석 선택 진입 경로는 WATCH 콜백으로 회귀하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+    const body = extractMethodBody(
+      source,
+      'async setInBookingFromEntering',
+      'async restoreInBookingFromReconnecting',
+    );
+
+    expect(body).toContain('runStartSeatSelectionLua(this.redis');
+    expect(body).not.toContain('watchKeys');
+    expect(body).not.toContain('this.authService.startSeatSelection');
+    expect(body).not.toContain('multi.hset');
+  });
+
+  it('BookingService에는 WATCH 기반 전이 옵션이 남아 있지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+
+    expect(source).not.toContain('watchKeys');
+    expect(source).not.toContain('validate:');
+    expect(source).not.toContain('mutate:');
+    expect(source).not.toContain('isSessionTargetingEvent');
   });
 });
 

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -77,11 +77,12 @@ function createService() {
     startSeatSelection: jest.fn(),
   };
   const bookingSeatsService = {
-    updateSeatDeleted: jest.fn(),
+    updateSeatDeleted: jest.fn().mockResolvedValue(undefined),
   };
   const inBookingService = {
     emitSession: jest.fn(),
     flushAndSetBookingAmount: jest.fn(),
+    flushUnsavedBookedSeats: jest.fn().mockResolvedValue([]),
     getSession: jest.fn(),
     isInBooking: jest.fn(),
     setSession: jest.fn(),
@@ -115,6 +116,8 @@ function createService() {
 
   return {
     authService,
+    bookingSeatsService,
+    inBookingService,
     logger,
     openBookingService,
     redis,
@@ -709,5 +712,68 @@ describe('BookingService 대기 순번 조회', () => {
     });
 
     expect(redis.lrange).toHaveBeenCalledWith('waiting-queue:42', 0, -1);
+  });
+});
+
+describe('BookingService 미확정 좌석 회수', () => {
+  const runWaitingHeadPromotionLuaMock = jest.mocked(runWaitingHeadPromotionLua);
+
+  beforeEach(() => {
+    runWaitingHeadPromotionLuaMock.mockReset();
+    // SSE 종료 정리는 대기열 승격까지 이어지므로 빈 큐로 고정함
+    runWaitingHeadPromotionLuaMock.mockResolvedValue(promotionFailedResult('QUEUE_EMPTY'));
+  });
+
+  it('한 번의 회수 연산이 돌려준 좌석만 반납하고 세션을 다시 쓰지 않음', async () => {
+    const { authService, bookingSeatsService, inBookingService, openBookingService, service } =
+      createService();
+    authService.getUserEventTarget.mockResolvedValue(42);
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    inBookingService.flushUnsavedBookedSeats.mockResolvedValue([
+      [0, 1],
+      [2, 3],
+    ]);
+
+    await service.onSeatsSseDisconnected({ sid: 'sid-1' });
+
+    expect(inBookingService.flushUnsavedBookedSeats).toHaveBeenCalledWith(42, 'sid-1');
+    expect(bookingSeatsService.updateSeatDeleted).toHaveBeenCalledTimes(2);
+    expect(bookingSeatsService.updateSeatDeleted).toHaveBeenCalledWith(42, [0, 1]);
+    expect(bookingSeatsService.updateSeatDeleted).toHaveBeenCalledWith(42, [2, 3]);
+    expect(inBookingService.setSession).not.toHaveBeenCalled();
+  });
+
+  it('회수할 좌석이 없으면 반납을 시도하지 않음', async () => {
+    const { authService, bookingSeatsService, inBookingService, openBookingService, service } =
+      createService();
+    authService.getUserEventTarget.mockResolvedValue(42);
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    inBookingService.flushUnsavedBookedSeats.mockResolvedValue([]);
+
+    await service.onSeatsSseDisconnected({ sid: 'sid-1' });
+
+    expect(bookingSeatsService.updateSeatDeleted).not.toHaveBeenCalled();
+  });
+
+  it('좌석 반납이 실패해도 나머지 정리를 계속하고 경고를 남김', async () => {
+    const { authService, bookingSeatsService, inBookingService, logger, openBookingService, service } =
+      createService();
+    authService.getUserEventTarget.mockResolvedValue(42);
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    inBookingService.flushUnsavedBookedSeats.mockResolvedValue([[0, 1]]);
+    bookingSeatsService.updateSeatDeleted.mockRejectedValue(new Error('이미 반납된 좌석'));
+
+    await expect(service.onSeatsSseDisconnected({ sid: 'sid-1' })).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('좌석 반납 실패'));
+    expect(inBookingService.emitSession).toHaveBeenCalledWith(42, 'sid-1');
+  });
+
+  it('좌석 회수 경로가 세션 전체 덮어쓰기로 회귀하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+
+    expect(source).toContain('flushUnsavedBookedSeats');
+    expect(source).not.toContain('inBookingService.setSession');
+    expect(source).not.toContain('bookedSeats.forEach');
   });
 });

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -649,3 +649,43 @@ describe('BookingService Phase 2 final static gates', () => {
     expect(source).not.toContain('authService.enterBookingGate');
   });
 });
+
+describe('BookingService 대기 순번 조회', () => {
+  it('세션에 순번이 있으면 대기열을 스캔하지 않고 그대로 반환함', async () => {
+    const { openBookingService, authService, redis, service } = createService();
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    authService.getUserSession.mockResolvedValue({
+      ...loginSession(),
+      targetEvent: 42,
+      userStatus: USER_STATUS.WAITING,
+      waitingOrder: 7,
+    });
+
+    await expect(service.isAdmission(42, 'sid-1')).resolves.toEqual({
+      waitingStatus: true,
+      enteringStatus: false,
+      userOrder: 7,
+    });
+
+    expect(redis.lrange).not.toHaveBeenCalled();
+  });
+
+  it('순번이 없는 이전 세션만 대기열 스캔으로 보정함', async () => {
+    const { openBookingService, authService, redis, service } = createService();
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    authService.getUserSession.mockResolvedValue({
+      ...loginSession(),
+      targetEvent: 42,
+      userStatus: USER_STATUS.WAITING,
+    });
+    redis.lrange.mockResolvedValue([JSON.stringify({ sid: 'sid-1', order: 3 })]);
+
+    await expect(service.isAdmission(42, 'sid-1')).resolves.toEqual({
+      waitingStatus: true,
+      enteringStatus: false,
+      userOrder: 3,
+    });
+
+    expect(redis.lrange).toHaveBeenCalledWith('waiting-queue:42', 0, -1);
+  });
+});

--- a/back/src/domains/booking/service/booking.service.spec.ts
+++ b/back/src/domains/booking/service/booking.service.spec.ts
@@ -1,8 +1,23 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 import { USER_STATUS } from '../../../auth/const/userStatus.const';
 import { AppException } from '../../../common/exception/app.exception';
+import { IN_BOOKING_DEFAULT_MAX_SIZE } from '../const/inBookingDefaultMaxSize.const';
 import { BookingErrorCode } from '../exception/booking-error-code';
+import {
+  runImmediateAdmissionLua,
+  runWaitingHeadPromotionLua,
+  type WaitingHeadPromotionBusinessCode,
+  type WaitingHeadPromotionLuaResult,
+} from '../luaScripts/admissionCapacityLua';
 
 import { BookingService } from './booking.service';
+
+jest.mock('../luaScripts/admissionCapacityLua', () => ({
+  runImmediateAdmissionLua: jest.fn(),
+  runWaitingHeadPromotionLua: jest.fn(),
+}));
 
 type TransitionContextFixture = {
   session: { targetEvent: number | null };
@@ -73,7 +88,9 @@ function createService() {
   };
 
   const authService = {
+    enterWaiting: jest.fn(),
     enterBookingGate: jest.fn(),
+    getUserSession: jest.fn(),
     getUserEventTarget: jest.fn(),
     markReconnectingSelection: jest.fn(),
     restoreSeatSelection: jest.fn(),
@@ -118,6 +135,7 @@ function createService() {
 
   return {
     authService,
+    openBookingService,
     redis,
     service,
     waitingQueueService,
@@ -135,6 +153,68 @@ async function expectInvalidState(action: () => Promise<unknown>) {
 
   expect(thrown).toBeInstanceOf(AppException);
   expect((thrown as AppException).getCode()).toBe(BookingErrorCode.INVALID_STATE);
+}
+
+function loginSession() {
+  return {
+    id: 1,
+    loginId: 'guest-1',
+    roles: ['USER'],
+    targetEvent: null,
+    userStatus: USER_STATUS.LOGIN,
+  };
+}
+
+function extractTryEnterBookingGateBody(source: string): string {
+  const methodStart = source.indexOf('private async tryEnterBookingGate');
+  const nextMethodStart = source.indexOf('private async tryEnterWaitingQueue', methodStart);
+
+  if (methodStart < 0 || nextMethodStart < 0) {
+    throw new Error('tryEnterBookingGate 본문을 찾을 수 없음');
+  }
+
+  return source.slice(methodStart, nextMethodStart);
+}
+
+function extractLetInNextWaitingBody(source: string): string {
+  const methodStart = source.indexOf('private async letInNextWaiting');
+  const nextMethodStart = source.indexOf('async setInBookingFromEntering', methodStart);
+
+  if (methodStart < 0 || nextMethodStart < 0) {
+    throw new Error('letInNextWaiting 본문을 찾을 수 없음');
+  }
+
+  return source.slice(methodStart, nextMethodStart);
+}
+
+function promotionOkResult(): WaitingHeadPromotionLuaResult {
+  return {
+    ok: true,
+    code: 'OK',
+    action: 'enterBookingGate',
+    from: USER_STATUS.WAITING,
+    to: USER_STATUS.ENTERING,
+  };
+}
+
+function promotionFailedResult(
+  code: WaitingHeadPromotionBusinessCode,
+  details: unknown[] = [],
+): WaitingHeadPromotionLuaResult {
+  return {
+    ok: false,
+    code,
+    action: 'enterBookingGate',
+    expectedFrom: USER_STATUS.WAITING,
+    nextTo: USER_STATUS.ENTERING,
+    details,
+  };
+}
+
+async function callLetInNextWaiting(service: BookingService, eventId = 42) {
+  await (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(
+    eventId,
+  );
 }
 
 describe('BookingService transaction-local event ownership validation', () => {
@@ -210,29 +290,218 @@ describe('BookingService transaction-local event ownership validation', () => {
     expect(multi.zadd).not.toHaveBeenCalled();
   });
 
-  it('does not promote waiting queue head when transaction targetEvent changed', async () => {
-    const { authService, redis, service, waitingQueueService } = createService();
-    const transactionRedis = createRedisMock();
-    const multi = createMultiMock();
+});
 
-    waitingQueueService.getQueueSize.mockResolvedValue(1);
-    redis.lindex.mockResolvedValue(JSON.stringify({ sid: 'sid-1', order: 1 }));
-    authService.enterBookingGate.mockImplementation(
+describe('BookingService immediate admission Lua integration', () => {
+  const runImmediateAdmissionLuaMock = jest.mocked(runImmediateAdmissionLua);
+
+  beforeEach(() => {
+    runImmediateAdmissionLuaMock.mockReset();
+  });
+
+  it('즉시 입장 Lua OK 결과를 기존 entering DTO로 반환하고 WATCH 경로를 호출하지 않음', async () => {
+    const { authService, openBookingService, redis, service } = createService();
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    authService.getUserSession.mockResolvedValue(loginSession());
+    runImmediateAdmissionLuaMock.mockResolvedValue({
+      ok: true,
+      code: 'OK',
+      action: 'enterBookingGate',
+      from: USER_STATUS.LOGIN,
+      to: USER_STATUS.ENTERING,
+    });
+
+    await expect(service.isAdmission(42, 'sid-1')).resolves.toEqual({
+      waitingStatus: false,
+      enteringStatus: true,
+    });
+
+    expect(runImmediateAdmissionLuaMock).toHaveBeenCalledWith(redis, {
+      sessionKey: 'user:sid-1',
+      eventId: 42,
+      keys: {
+        enteringKey: 'entering:42',
+        inBookingSessionsKey: 'in-booking:42:sessions',
+        reconnectingKey: 'reconnecting:42',
+        maxSizeKey: 'in-booking:42:max-size',
+        defaultMaxSizeKey: 'in-booking:default-max-size',
+      },
+      defaultMaxSize: IN_BOOKING_DEFAULT_MAX_SIZE,
+      nowMs: expect.any(Number),
+    });
+    expect(authService.enterBookingGate).not.toHaveBeenCalled();
+  });
+
+  it('즉시 입장 Lua CAPACITY_FULL 결과는 INVALID_STATE가 아니라 기존 대기열 DTO로 이어짐', async () => {
+    const { authService, openBookingService, redis, service } = createService();
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    authService.getUserSession.mockResolvedValue(loginSession());
+    runImmediateAdmissionLuaMock.mockResolvedValue({
+      ok: false,
+      code: 'CAPACITY_FULL',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.ENTERING,
+      details: [],
+    });
+    authService.enterWaiting.mockImplementation(
       async (_sid: string, _eventId: number, options: TransitionOptionsFixture) => {
-        const isValid = await options.validate?.(transactionRedis, createContext(2));
-        if (isValid === false) {
-          return null;
-        }
-
-        await options.mutate?.(multi, createContext(2));
-        return successfulTransition('enterBookingGate');
+        await options.validate?.(redis, createContext(null));
+        return { ok: true, action: 'enterWaiting' };
       },
     );
 
-    await (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(1);
+    await expect(service.isAdmission(42, 'sid-1')).resolves.toEqual({
+      waitingStatus: true,
+      enteringStatus: false,
+      userOrder: 1,
+    });
 
-    expect(transactionRedis.lindex).not.toHaveBeenCalled();
-    expect(multi.lpop).not.toHaveBeenCalled();
-    expect(multi.zadd).not.toHaveBeenCalled();
+    expect(authService.enterBookingGate).not.toHaveBeenCalled();
+    expect(authService.enterWaiting).toHaveBeenCalledWith(
+      'sid-1',
+      42,
+      expect.objectContaining({
+        watchKeys: ['waiting-queue:42', 'waiting-queue:42:order'],
+      }),
+    );
+  });
+
+  it('즉시 입장 Lua stale 세션 결과는 기존 INVALID_STATE 예외로 유지함', async () => {
+    const { authService, openBookingService, service } = createService();
+    openBookingService.isEventOpened.mockResolvedValue(true);
+    authService.getUserSession.mockResolvedValue(loginSession());
+    runImmediateAdmissionLuaMock.mockResolvedValue({
+      ok: false,
+      code: 'SESSION_MISSING',
+      action: 'enterBookingGate',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.ENTERING,
+      details: [],
+    });
+
+    await expectInvalidState(() => service.isAdmission(42, 'sid-1'));
+
+    expect(authService.enterBookingGate).not.toHaveBeenCalled();
+    expect(authService.enterWaiting).not.toHaveBeenCalled();
+  });
+});
+
+describe('BookingService immediate admission static regression gates', () => {
+  it('즉시 입장 경로는 Lua runner를 사용하고 hot admission WATCH로 회귀하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+    const immediateAdmissionBody = extractTryEnterBookingGateBody(source);
+
+    expect(immediateAdmissionBody).toContain('runImmediateAdmissionLua(this.redis');
+    expect(immediateAdmissionBody).not.toContain('this.authService.enterBookingGate');
+    expect(immediateAdmissionBody).not.toContain('getAdmissionWatchKeys');
+    expect(immediateAdmissionBody).not.toContain('watchKeys');
+    expect(immediateAdmissionBody).not.toContain('lost');
+  });
+});
+
+describe('BookingService waiting-head promotion Lua integration', () => {
+  const runWaitingHeadPromotionLuaMock = jest.mocked(runWaitingHeadPromotionLua);
+
+  beforeEach(() => {
+    runWaitingHeadPromotionLuaMock.mockReset();
+  });
+
+  it('대기열 head 승격 OK면 정원이 찰 때까지 Lua 호출을 반복함', async () => {
+    const { authService, redis, service, waitingQueueService } = createService();
+    runWaitingHeadPromotionLuaMock
+      .mockResolvedValueOnce(promotionOkResult())
+      .mockResolvedValueOnce(promotionOkResult())
+      .mockResolvedValueOnce(promotionFailedResult('CAPACITY_FULL'));
+
+    await callLetInNextWaiting(service);
+
+    expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledTimes(3);
+    expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledWith(redis, {
+      waitingQueueKey: 'waiting-queue:42',
+      userKeyPrefix: 'user:',
+      eventId: 42,
+      keys: {
+        enteringKey: 'entering:42',
+        inBookingSessionsKey: 'in-booking:42:sessions',
+        reconnectingKey: 'reconnecting:42',
+        maxSizeKey: 'in-booking:42:max-size',
+        defaultMaxSizeKey: 'in-booking:default-max-size',
+      },
+      defaultMaxSize: IN_BOOKING_DEFAULT_MAX_SIZE,
+      nowMs: expect.any(Number),
+    });
+    expect(authService.enterBookingGate).not.toHaveBeenCalled();
+    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
+  });
+
+  it('stale head 결과면 다음 후보를 위해 Lua 호출을 계속함', async () => {
+    const { service, waitingQueueService } = createService();
+    runWaitingHeadPromotionLuaMock
+      .mockResolvedValueOnce(promotionFailedResult('STALE_SESSION_MISSING', ['sid-1']))
+      .mockResolvedValueOnce(promotionFailedResult('STALE_STATE_MISMATCH', [USER_STATUS.LOGIN]))
+      .mockResolvedValueOnce(promotionFailedResult('QUEUE_EMPTY'));
+
+    await callLetInNextWaiting(service);
+
+    expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledTimes(3);
+    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
+  });
+
+  it('CAPACITY_FULL이면 head 제거 없이 승격 loop를 멈춤', async () => {
+    const { service, waitingQueueService } = createService();
+    runWaitingHeadPromotionLuaMock.mockResolvedValue(promotionFailedResult('CAPACITY_FULL'));
+
+    await callLetInNextWaiting(service);
+
+    expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledTimes(1);
+    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
+  });
+
+  it('QUEUE_EMPTY이면 queue pre-read 없이 승격 loop를 멈춤', async () => {
+    const { redis, service, waitingQueueService } = createService();
+    runWaitingHeadPromotionLuaMock.mockResolvedValue(promotionFailedResult('QUEUE_EMPTY'));
+
+    await callLetInNextWaiting(service);
+
+    expect(runWaitingHeadPromotionLuaMock).toHaveBeenCalledTimes(1);
+    expect(waitingQueueService.getQueueSize).not.toHaveBeenCalled();
+    expect(redis.lindex).not.toHaveBeenCalled();
+  });
+
+  it('Lua 실패는 stale pop으로 변환하지 않고 caller로 throw함', async () => {
+    const { service, waitingQueueService } = createService();
+    const failure = new Error('redis lua failure');
+    runWaitingHeadPromotionLuaMock.mockRejectedValue(failure);
+
+    await expect(
+      (service as unknown as { letInNextWaiting(eventId: number): Promise<void> }).letInNextWaiting(42),
+    ).rejects.toThrow(failure);
+
+    expect(waitingQueueService.popQueue).not.toHaveBeenCalled();
+  });
+
+  it('대기열 head 승격 경로는 Lua runner를 사용하고 hot WATCH pre-read로 회귀하지 않음', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+    const promotionBody = extractLetInNextWaitingBody(source);
+
+    expect(promotionBody).toContain('runWaitingHeadPromotionLua(this.redis');
+    expect(promotionBody).not.toContain('this.authService.enterBookingGate');
+    expect(promotionBody).not.toContain('getWaitingHead');
+    expect(promotionBody).not.toContain('waitingQueueService.popQueue');
+    expect(promotionBody).not.toContain('getAdmissionWatchKeys');
+  });
+});
+
+describe('BookingService Phase 2 final static gates', () => {
+  it('입장 대상 경로 전체에서 hot admission WATCH helper와 AuthService enterBookingGate를 제거함', () => {
+    const source = readFileSync(join(__dirname, 'booking.service.ts'), 'utf8');
+
+    expect(source).toContain('runImmediateAdmissionLua');
+    expect(source).toContain('runWaitingHeadPromotionLua');
+    expect(source).not.toMatch(
+      /getAdmissionWatchKeys|watchKeys: this\.getAdmissionWatchKeys|watchKeys: \[\.\.\.this\.getAdmissionWatchKeys/,
+    );
+    expect(source).not.toContain('authService.enterBookingGate');
   });
 });

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -97,17 +97,25 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async collectSeatsIfNotSaved(eventId: number, sid: string) {
-    const inBookingSession = await this.inBookingService.getSession(eventId, sid);
     if (process.env.BENCHMARK_MODE === 'true' && eventId === 1) {
       return;
     }
-    if (inBookingSession && !inBookingSession.saved) {
-      const bookedSeats = inBookingSession.bookedSeats;
-      bookedSeats.forEach((seat) => {
-        this.bookingSeatsService.updateSeatDeleted(eventId, seat);
-      });
-      inBookingSession.bookedSeats = [];
-      await this.inBookingService.setSession(eventId, inBookingSession);
+
+    const flushedSeats = await this.inBookingService.flushUnsavedBookedSeats(eventId, sid);
+
+    await Promise.all(flushedSeats.map((seat) => this.releaseSeatQuietly(eventId, sid, seat)));
+  }
+
+  private async releaseSeatQuietly(eventId: number, sid: string, seat: [number, number]) {
+    try {
+      await this.bookingSeatsService.updateSeatDeleted(eventId, seat);
+    } catch (error) {
+      // 반납 실패가 나머지 정리(세션 회수, 대기열 승격)를 막지 않도록 흡수하되 남겨 둠
+      this.logger.warn(
+        `좌석 반납 실패: eventId=${eventId} sid=${sid} seat=${JSON.stringify(seat)} — ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`,
+      );
     }
   }
 

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -14,6 +14,7 @@ import { ServerTimeDto } from '../dto/serverTime.dto';
 import { BookingErrorCode } from '../exception/booking-error-code';
 import { runImmediateAdmissionLua, runWaitingHeadPromotionLua } from '../luaScripts/admissionCapacityLua';
 import { runMarkReconnectingLua, runRestoreSelectingLua } from '../luaScripts/reconnectingTransitionLua';
+import { runStartSeatSelectionLua } from '../luaScripts/startSeatSelectionLua';
 import { runWaitingQueueEntryLua } from '../luaScripts/waitingQueueEntryLua';
 
 import { BookingSeatsService } from './booking-seats.service';
@@ -110,10 +111,6 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private isSessionTargetingEvent(context: { session: { targetEvent?: unknown } }, eventId: number) {
-    return context.session.targetEvent === eventId;
-  }
-
   private async letInNextWaiting(eventId: number) {
     while (true) {
       const result = await runWaitingHeadPromotionLua(this.redis, {
@@ -154,45 +151,16 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
       throw new AppException(BookingErrorCode.SESSION_EVENT_NOT_FOUND);
     }
 
-    const enteringKey = this.getEnteringKey(eventId);
-    const inBookingKey = this.getInBookingSessionsKey(eventId);
-    const bookingAmountKey = this.getEnteringBookingAmountKey(sid);
-    let bookingAmount = 0;
-
-    const result = await this.authService.startSeatSelection(sid, {
-      watchKeys: [enteringKey, inBookingKey, bookingAmountKey],
-      validate: async (redis, context) => {
-        if (!this.isSessionTargetingEvent(context, eventId)) {
-          return false;
-        }
-
-        const score = await redis.zscore(enteringKey, sid);
-        if (score === null) {
-          return false;
-        }
-
-        const bookingAmountData = await redis.get(bookingAmountKey);
-        bookingAmount = bookingAmountData ? parseInt(bookingAmountData) : 0;
-        return Number.isFinite(bookingAmount);
-      },
-      mutate: (multi) => {
-        multi.zrem(enteringKey, sid);
-        multi.del(bookingAmountKey);
-        multi.hset(
-          inBookingKey,
-          sid,
-          JSON.stringify({
-            sid,
-            bookingAmount,
-            bookedSeats: [],
-            saved: false,
-            subscribedSection: null,
-          }),
-        );
-      },
+    const result = await runStartSeatSelectionLua(this.redis, {
+      sessionKey: `user:${sid}`,
+      enteringKey: this.getEnteringKey(eventId),
+      inBookingSessionsKey: this.getInBookingSessionsKey(eventId),
+      bookingAmountKey: this.getEnteringBookingAmountKey(sid),
+      eventId,
+      sid,
     });
 
-    if (!result?.ok) {
+    if (!result.ok) {
       throw new AppException(BookingErrorCode.INVALID_STATE);
     }
   }

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -13,6 +13,7 @@ import { BookingAdmissionStatusDto } from '../dto/bookingAdmissionStatus.dto';
 import { ServerTimeDto } from '../dto/serverTime.dto';
 import { BookingErrorCode } from '../exception/booking-error-code';
 import { runImmediateAdmissionLua, runWaitingHeadPromotionLua } from '../luaScripts/admissionCapacityLua';
+import { runMarkReconnectingLua, runRestoreSelectingLua } from '../luaScripts/reconnectingTransitionLua';
 
 import { BookingSeatsService } from './booking-seats.service';
 import { EnterBookingService } from './enter-booking.service';
@@ -196,32 +197,34 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
   }
 
   async restoreInBookingFromReconnecting(eventId: number, sid: string) {
-    const reconnectingKey = this.getReconnectingKey(eventId);
-    const result = await this.authService.restoreSeatSelection(sid, {
-      watchKeys: [reconnectingKey],
-      validate: async (redis, context) =>
-        this.isSessionTargetingEvent(context, eventId) && (await redis.zscore(reconnectingKey, sid)) !== null,
-      mutate: (multi) => {
-        multi.zrem(reconnectingKey, sid);
-      },
+    const result = await runRestoreSelectingLua(this.redis, {
+      sessionKey: `user:${sid}`,
+      reconnectingKey: this.getReconnectingKey(eventId),
+      eventId,
+      sid,
     });
 
-    if (!result?.ok) {
+    if (!result.ok) {
       throw new AppException(BookingErrorCode.INVALID_STATE);
     }
   }
 
   async markReconnectingFromSeat(eventId: number, sid: string): Promise<boolean> {
-    const reconnectingKey = this.getReconnectingKey(eventId);
-    const result = await this.authService.markReconnectingSelection(sid, {
-      watchKeys: [reconnectingKey],
-      validate: (_redis, context) => this.isSessionTargetingEvent(context, eventId),
-      mutate: (multi) => {
-        multi.zadd(reconnectingKey, Date.now(), sid);
-      },
+    const result = await runMarkReconnectingLua(this.redis, {
+      sessionKey: `user:${sid}`,
+      reconnectingKey: this.getReconnectingKey(eventId),
+      eventId,
+      sid,
+      nowMs: Date.now(),
     });
 
-    return !!result?.ok;
+    if (!result.ok) {
+      this.logger.warn(
+        `재연결 표시 실패로 in-booking 슬롯이 남을 수 있음: eventId=${eventId} sid=${sid} code=${result.code}`,
+      );
+    }
+
+    return result.ok;
   }
 
   // 함수 이름 생각하기

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -12,6 +12,7 @@ import { IN_BOOKING_DEFAULT_MAX_SIZE } from '../const/inBookingDefaultMaxSize.co
 import { BookingAdmissionStatusDto } from '../dto/bookingAdmissionStatus.dto';
 import { ServerTimeDto } from '../dto/serverTime.dto';
 import { BookingErrorCode } from '../exception/booking-error-code';
+import { runImmediateAdmissionLua, runWaitingHeadPromotionLua } from '../luaScripts/admissionCapacityLua';
 
 import { BookingSeatsService } from './booking-seats.service';
 import { EnterBookingService } from './enter-booking.service';
@@ -112,41 +113,31 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async letInNextWaiting(eventId: number) {
-    const isQueueEmpty = async (eventId: number) =>
-      (await this.waitingQueueService.getQueueSize(eventId)) < 1;
-    while (!(await isQueueEmpty(eventId)) && (await this.isInsertableInBooking(eventId))) {
-      const item = await this.getWaitingHead(eventId);
-      if (!item) {
-        break;
-      }
-
-      const result = await this.authService.enterBookingGate(item.sid, eventId, {
-        watchKeys: [...this.getAdmissionWatchKeys(eventId), this.getWaitingQueueKey(eventId)],
-        validate: async (redis, context) => {
-          if (!this.isSessionTargetingEvent(context, eventId)) {
-            return false;
-          }
-
-          const head = await redis.lindex(this.getWaitingQueueKey(eventId), 0);
-          if (!head) {
-            return false;
-          }
-
-          const parsed = JSON.parse(head);
-          return parsed?.sid === item.sid && (await this.isInsertableInBookingWithRedis(redis, eventId));
+    while (true) {
+      const result = await runWaitingHeadPromotionLua(this.redis, {
+        waitingQueueKey: this.getWaitingQueueKey(eventId),
+        userKeyPrefix: 'user:',
+        eventId,
+        keys: {
+          enteringKey: this.getEnteringKey(eventId),
+          inBookingSessionsKey: this.getInBookingSessionsKey(eventId),
+          reconnectingKey: this.getReconnectingKey(eventId),
+          maxSizeKey: this.getInBookingMaxSizeKey(eventId),
+          defaultMaxSizeKey: 'in-booking:default-max-size',
         },
-        mutate: (multi) => {
-          multi.lpop(this.getWaitingQueueKey(eventId));
-          multi.zadd(this.getEnteringKey(eventId), Date.now(), item.sid);
-        },
+        defaultMaxSize: IN_BOOKING_DEFAULT_MAX_SIZE,
+        nowMs: Date.now(),
       });
 
-      if (result?.ok) {
+      if (result.ok) {
         continue;
       }
 
-      if (result && !result.ok) {
-        await this.waitingQueueService.popQueue(eventId);
+      if (
+        result.code === 'STALE_SESSION_MISSING' ||
+        result.code === 'STALE_STATE_MISMATCH' ||
+        result.code === 'STALE_TARGET_EVENT_MISMATCH'
+      ) {
         continue;
       }
 
@@ -279,7 +270,7 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
       };
     }
 
-    if (enteringResult === 'rejected' || enteringResult === 'lost') {
+    if (enteringResult === 'rejected') {
       throw new AppException(BookingErrorCode.INVALID_STATE);
     }
 
@@ -295,38 +286,30 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
     };
   }
 
-  private async isInsertableInBooking(eventId: number): Promise<boolean> {
-    return this.isInsertableInBookingWithRedis(this.redis, eventId);
-  }
-
-  private async tryEnterBookingGate(
-    eventId: number,
-    sid: string,
-  ): Promise<'entered' | 'full' | 'rejected' | 'lost'> {
-    let validationRan = false;
-    let capacityAvailable = false;
-
-    const result = await this.authService.enterBookingGate(sid, eventId, {
-      watchKeys: this.getAdmissionWatchKeys(eventId),
-      validate: async (redis) => {
-        validationRan = true;
-        capacityAvailable = await this.isInsertableInBookingWithRedis(redis, eventId);
-        return capacityAvailable;
+  private async tryEnterBookingGate(eventId: number, sid: string): Promise<'entered' | 'full' | 'rejected'> {
+    const result = await runImmediateAdmissionLua(this.redis, {
+      sessionKey: `user:${sid}`,
+      eventId,
+      keys: {
+        enteringKey: this.getEnteringKey(eventId),
+        inBookingSessionsKey: this.getInBookingSessionsKey(eventId),
+        reconnectingKey: this.getReconnectingKey(eventId),
+        maxSizeKey: this.getInBookingMaxSizeKey(eventId),
+        defaultMaxSizeKey: 'in-booking:default-max-size',
       },
-      mutate: (multi) => {
-        multi.zadd(this.getEnteringKey(eventId), Date.now(), sid);
-      },
+      defaultMaxSize: IN_BOOKING_DEFAULT_MAX_SIZE,
+      nowMs: Date.now(),
     });
 
-    if (result?.ok) {
+    if (result.ok) {
       return 'entered';
     }
 
-    if (result && !result.ok) {
-      return 'rejected';
+    if (result.code === 'CAPACITY_FULL') {
+      return 'full';
     }
 
-    return validationRan && !capacityAvailable ? 'full' : 'lost';
+    return 'rejected';
   }
 
   private async tryEnterWaitingQueue(eventId: number, sid: string): Promise<number | null> {
@@ -348,34 +331,6 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
     });
 
     return result?.ok ? nextOrder : null;
-  }
-
-  private async isInsertableInBookingWithRedis(redis: Redis, eventId: number): Promise<boolean> {
-    const inBookingCount = await redis.hlen(this.getInBookingSessionsKey(eventId));
-    const inBookingReconnectingCount = await redis.zcard(this.getReconnectingKey(eventId));
-    const enteringCount = await redis.zcard(this.getEnteringKey(eventId));
-    const maxSize = await this.getInBookingSessionsMaxSizeWithRedis(redis, eventId);
-    return inBookingCount + inBookingReconnectingCount + enteringCount < maxSize;
-  }
-
-  private async getInBookingSessionsMaxSizeWithRedis(redis: Redis, eventId: number): Promise<number> {
-    const raw = await redis.get(this.getInBookingMaxSizeKey(eventId));
-    if (raw) {
-      return parseInt(raw);
-    }
-
-    const defaultRaw = await redis.get('in-booking:default-max-size');
-    return defaultRaw ? parseInt(defaultRaw) : IN_BOOKING_DEFAULT_MAX_SIZE;
-  }
-
-  private getAdmissionWatchKeys(eventId: number): string[] {
-    return [
-      this.getEnteringKey(eventId),
-      this.getInBookingSessionsKey(eventId),
-      this.getReconnectingKey(eventId),
-      this.getInBookingMaxSizeKey(eventId),
-      'in-booking:default-max-size',
-    ];
   }
 
   private getEnteringKey(eventId: number): string {
@@ -404,11 +359,6 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
 
   private getWaitingOrderKey(eventId: number): string {
     return `waiting-queue:${eventId}:order`;
-  }
-
-  private async getWaitingHead(eventId: number): Promise<{ sid: string; order: number } | null> {
-    const item = await this.redis.lindex(this.getWaitingQueueKey(eventId), 0);
-    return item ? JSON.parse(item) : null;
   }
 
   private async getWaitingOrder(eventId: number, sid: string): Promise<number | null> {

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -252,7 +252,7 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
         const waitingResponse = {
           waitingStatus: true,
           enteringStatus: false,
-          userOrder: await this.getWaitingOrder(eventId, sid),
+          userOrder: await this.resolveWaitingOrder(eventId, sid, session),
         };
         return waitingResponse;
       }
@@ -356,7 +356,20 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
     return `waiting-queue:${eventId}:order`;
   }
 
-  private async getWaitingOrder(eventId: number, sid: string): Promise<number | null> {
+  private async resolveWaitingOrder(
+    eventId: number,
+    sid: string,
+    session: { waitingOrder?: unknown },
+  ): Promise<number | null> {
+    if (typeof session.waitingOrder === 'number') {
+      return session.waitingOrder;
+    }
+
+    // 순번을 세션에 남기기 이전에 대기열에 들어간 세션만 큐 스캔으로 보정함.
+    return this.scanWaitingOrder(eventId, sid);
+  }
+
+  private async scanWaitingOrder(eventId: number, sid: string): Promise<number | null> {
     const items = await this.redis.lrange(this.getWaitingQueueKey(eventId), 0, -1);
     for (const item of items) {
       const parsed = JSON.parse(item);

--- a/back/src/domains/booking/service/booking.service.ts
+++ b/back/src/domains/booking/service/booking.service.ts
@@ -14,6 +14,7 @@ import { ServerTimeDto } from '../dto/serverTime.dto';
 import { BookingErrorCode } from '../exception/booking-error-code';
 import { runImmediateAdmissionLua, runWaitingHeadPromotionLua } from '../luaScripts/admissionCapacityLua';
 import { runMarkReconnectingLua, runRestoreSelectingLua } from '../luaScripts/reconnectingTransitionLua';
+import { runWaitingQueueEntryLua } from '../luaScripts/waitingQueueEntryLua';
 
 import { BookingSeatsService } from './booking-seats.service';
 import { EnterBookingService } from './enter-booking.service';
@@ -316,24 +317,15 @@ export class BookingService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async tryEnterWaitingQueue(eventId: number, sid: string): Promise<number | null> {
-    const orderKey = this.getWaitingOrderKey(eventId);
-    const queueKey = this.getWaitingQueueKey(eventId);
-    let nextOrder: number | null = null;
-
-    const result = await this.authService.enterWaiting(sid, eventId, {
-      watchKeys: [queueKey, orderKey],
-      validate: async (redis) => {
-        const rawOrder = await redis.get(orderKey);
-        nextOrder = rawOrder ? parseInt(rawOrder) + 1 : 1;
-        return Number.isFinite(nextOrder);
-      },
-      mutate: (multi) => {
-        multi.set(orderKey, nextOrder);
-        multi.rpush(queueKey, JSON.stringify({ sid, order: nextOrder }));
-      },
+    const { order } = await runWaitingQueueEntryLua(this.redis, {
+      sessionKey: `user:${sid}`,
+      waitingQueueKey: this.getWaitingQueueKey(eventId),
+      waitingOrderKey: this.getWaitingOrderKey(eventId),
+      eventId,
+      sid,
     });
 
-    return result?.ok ? nextOrder : null;
+    return order;
   }
 
   private getEnteringKey(eventId: number): string {

--- a/back/src/domains/booking/service/enter-booking.service.ts
+++ b/back/src/domains/booking/service/enter-booking.service.ts
@@ -50,43 +50,14 @@ export class EnterBookingService {
     }
   }
 
-  async addEnteringSession(eventId: number, sid: string) {
-    const timestamp = Date.now();
-    await this.redis.zadd(`entering:${eventId}`, timestamp, sid);
-    return true;
-  }
-
-  async removeEnteringSession(eventId: number, sid: string) {
-    await this.redis.zrem(`entering:${eventId}`, sid);
-    await this.removeBookingAmount(sid);
-    return true;
-  }
-
   async isEntering(eventId: number, sid: string) {
     const isMember = await this.redis.zscore(`entering:${eventId}`, sid);
     return isMember !== null;
   }
 
-  async getEnteringSessionCount(eventId: number) {
-    return this.redis.zcard(`entering:${eventId}`);
-  }
-
   async setBookingAmount(sid: string, bookingAmount: number) {
     await this.redis.set(`entering:${sid}:temp-booking-amount`, bookingAmount);
     return bookingAmount;
-  }
-
-  async getBookingAmount(sid: string) {
-    const bookingAmountData = await this.redis.get(`entering:${sid}:temp-booking-amount`);
-    if (!bookingAmountData) {
-      return 0;
-    }
-    return parseInt(bookingAmountData);
-  }
-
-  async removeBookingAmount(sid: string) {
-    await this.redis.del(`entering:${sid}:temp-booking-amount`);
-    return true;
   }
 
   private async removeExpiredSessions(eventId: number) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -140,16 +140,6 @@ export class InBookingService {
     }
   }
 
-  async getInBookingSessionsMaxSize(eventId: number) {
-    const raw = await this.redis.get(`in-booking:${eventId}:max-size`);
-    if (!raw) return await this.getInBookingSessionsDefaultMaxSize();
-    return parseInt(raw);
-  }
-
-  async getInBookingSessionCount(eventId: number): Promise<number> {
-    return this.redis.hlen(this.getEventKey(eventId));
-  }
-
   private getEventKey(eventId: number) {
     return `in-booking:${eventId}:sessions`;
   }
@@ -260,19 +250,9 @@ export class InBookingService {
     }
   }
 
-  async addReconnectingSession(eventId: number, sid: string) {
-    const timestamp = Date.now();
-    await this.redis.zadd(`reconnecting:${eventId}`, timestamp, sid);
-    return true;
-  }
-
   async removeReconnectingSession(eventId: number, sid: string) {
     await this.redis.zrem(`reconnecting:${eventId}`, sid);
     return true;
-  }
-
-  async getReconnectingSessionCount(eventId: number) {
-    return this.redis.zcard(`reconnecting:${eventId}`);
   }
 
   private async removeExpiredReconnectingSessions(eventId: number) {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -14,6 +14,13 @@ import {
   RECONNECTING_SELECTING_GC_INTERVAL,
 } from '../const/seatsSseRetryTime.const';
 import { BookingErrorCode } from '../exception/booking-error-code';
+import {
+  runAddBookedSeatLua,
+  runFlushBookedSeatsLua,
+  runRemoveBookedSeatLua,
+  runSetInBookingSavedLua,
+  runSetSubscribedSectionLua,
+} from '../luaScripts/inBookingSessionLua';
 
 type InBookingSession = {
   sid: string;
@@ -97,9 +104,12 @@ export class InBookingService {
   }
 
   async addBookedSeat(eventId: number, sid: string, seat: [number, number]): Promise<void> {
-    const session = await this.getSession(eventId, sid);
-    session.bookedSeats.push(seat);
-    await this.setSession(eventId, session);
+    await runAddBookedSeatLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      seat,
+      enforceQuota: false,
+    });
   }
 
   async getBookedSeats(eventId: number, sid: string): Promise<[number, number][]> {
@@ -111,9 +121,12 @@ export class InBookingService {
   }
 
   async removeBookedSeat(eventId: number, sid: string, seat: [number, number]): Promise<void> {
-    const session = await this.getSession(eventId, sid);
-    session.bookedSeats = session.bookedSeats.filter((s) => s[0] !== seat[0] || s[1] !== seat[1]);
-    await this.setSession(eventId, session);
+    await runRemoveBookedSeatLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      seat,
+      requireBooked: false,
+    });
   }
 
   async removeBookedSeats(eventId: number, sid: string) {
@@ -128,9 +141,19 @@ export class InBookingService {
   }
 
   async setIsSaved(eventId: number, sid: string, saved: boolean) {
-    const session = await this.getSession(eventId, sid);
-    session.saved = saved;
-    await this.setSession(eventId, session);
+    await runSetInBookingSavedLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      saved,
+    });
+  }
+
+  async setSubscribedSection(eventId: number, sid: string, sectionIndex: number | null) {
+    await runSetSubscribedSectionLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      sectionIndex,
+    });
   }
 
   async emitSession(eventId: number, sid: string) {
@@ -170,27 +193,35 @@ export class InBookingService {
   }
 
   async validateAndAddBookedSeat(eventId: number, sid: string, target: [number, number]): Promise<void> {
-    const session = await this.getSession(eventId, sid);
-    if (!session) {
+    const { code } = await runAddBookedSeatLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      seat: target,
+      enforceQuota: true,
+    });
+
+    if (code === 'SESSION_NOT_FOUND') {
       throw new AppException(BookingErrorCode.SEAT_SESSION_NOT_FOUND);
     }
-    if (session.bookingAmount <= session.bookedSeats.length) {
+    if (code === 'QUOTA_EXCEEDED') {
       throw new AppException(BookingErrorCode.SEAT_QUOTA_EXCEEDED);
     }
-    session.bookedSeats.push(target);
-    await this.setSession(eventId, session);
   }
 
   async validateAndRemoveBookedSeat(eventId: number, sid: string, target: [number, number]): Promise<void> {
-    const session = await this.getSession(eventId, sid);
-    if (!session || session.bookedSeats.length === 0) {
+    const { code } = await runRemoveBookedSeatLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      seat: target,
+      requireBooked: true,
+    });
+
+    if (code === 'CANCEL_EMPTY') {
       throw new AppException(BookingErrorCode.SEAT_CANCEL_EMPTY);
     }
-    if (!session.bookedSeats.some((seat) => seat[0] === target[0] && seat[1] === target[1])) {
+    if (code === 'SEAT_NOT_BOOKED') {
       throw new AppException(BookingErrorCode.SEAT_NOT_BOOKED);
     }
-    session.bookedSeats = session.bookedSeats.filter((s) => s[0] !== target[0] || s[1] !== target[1]);
-    await this.setSession(eventId, session);
   }
 
   async flushAndSetBookingAmount(
@@ -198,15 +229,23 @@ export class InBookingService {
     sid: string,
     amount: number,
   ): Promise<{ flushedSeats: [number, number][] }> {
-    const session = await this.getSession(eventId, sid);
-    if (!session) {
-      return { flushedSeats: [] };
-    }
-    const flushedSeats = [...session.bookedSeats];
-    session.bookedSeats = [];
-    session.bookingAmount = amount;
-    await this.setSession(eventId, session);
-    return { flushedSeats };
+    const { seats } = await runFlushBookedSeatsLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      bookingAmount: amount,
+    });
+
+    return { flushedSeats: seats };
+  }
+
+  async flushUnsavedBookedSeats(eventId: number, sid: string): Promise<[number, number][]> {
+    const { seats } = await runFlushBookedSeatsLua(this.redis, {
+      inBookingSessionsKey: this.getEventKey(eventId),
+      sid,
+      onlyWhenUnsaved: true,
+    });
+
+    return seats;
   }
 
   async getAllInBookingSids(eventId: number): Promise<string[]> {

--- a/back/src/domains/booking/service/in-booking.service.ts
+++ b/back/src/domains/booking/service/in-booking.service.ts
@@ -89,20 +89,6 @@ export class InBookingService {
     return true;
   }
 
-  async setBookingAmount(eventId: number, sid: string, amount: number): Promise<number> {
-    const session = await this.getSession(eventId, sid);
-
-    session.bookingAmount = amount;
-    await this.setSession(eventId, session);
-
-    return amount;
-  }
-
-  async getBookingAmount(eventId: number, sid: string): Promise<number> {
-    const session = await this.getSession(eventId, sid);
-    return session.bookingAmount;
-  }
-
   async addBookedSeat(eventId: number, sid: string, seat: [number, number]): Promise<void> {
     await runAddBookedSeatLua(this.redis, {
       inBookingSessionsKey: this.getEventKey(eventId),
@@ -112,14 +98,6 @@ export class InBookingService {
     });
   }
 
-  async getBookedSeats(eventId: number, sid: string): Promise<[number, number][]> {
-    const session = await this.getSession(eventId, sid);
-    if (!session) {
-      return [];
-    }
-    return session.bookedSeats;
-  }
-
   async removeBookedSeat(eventId: number, sid: string, seat: [number, number]): Promise<void> {
     await runRemoveBookedSeatLua(this.redis, {
       inBookingSessionsKey: this.getEventKey(eventId),
@@ -127,17 +105,6 @@ export class InBookingService {
       seat,
       requireBooked: false,
     });
-  }
-
-  async removeBookedSeats(eventId: number, sid: string) {
-    const session = await this.getSession(eventId, sid);
-    session.bookedSeats = [];
-    await this.setSession(eventId, session);
-  }
-
-  async getIsSaved(eventId: number, sid: string) {
-    const session = await this.getSession(eventId, sid);
-    return session.saved;
   }
 
   async setIsSaved(eventId: number, sid: string, saved: boolean) {

--- a/back/src/domains/booking/service/waiting-queue.service.ts
+++ b/back/src/domains/booking/service/waiting-queue.service.ts
@@ -48,24 +48,6 @@ export class WaitingQueueService implements OnModuleDestroy {
     this.sseBroadcaster.removeClient(String(eventId), res);
   }
 
-  async pushQueue(eventId: number, sid: string) {
-    if (!this.queueSubscriptionMap.has(eventId)) {
-      await this.createQueueSubscription(eventId);
-    }
-    const order = await this.redis.incr(`waiting-queue:${eventId}:order`);
-    const item = JSON.stringify({ sid, order });
-    await this.redis.rpush(`waiting-queue:${eventId}`, item);
-    return order;
-  }
-
-  async popQueue(eventId: number) {
-    const item = await this.redis.lpop(`waiting-queue:${eventId}`);
-    if (!item) {
-      return null;
-    }
-    return JSON.parse(item);
-  }
-
   async getQueueSize(eventId: number) {
     const size = await this.redis.llen(`waiting-queue:${eventId}`);
     return size;

--- a/back/src/testing/redis/admission-capacity-command-mock.ts
+++ b/back/src/testing/redis/admission-capacity-command-mock.ts
@@ -1,0 +1,222 @@
+import Redis from 'ioredis';
+
+import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
+
+type AdmissionRawResult = Array<string | number | null>;
+
+type RedisWithAdmissionCommands = Redis & {
+  admitBookingGateImmediate?: (
+    sessionKey: string,
+    enteringKey: string,
+    inBookingSessionsKey: string,
+    reconnectingKey: string,
+    maxSizeKey: string,
+    eventId: string,
+    defaultMaxSizeKey: string,
+    defaultMaxSize: string,
+    nowMs: string,
+  ) => Promise<AdmissionRawResult>;
+  promoteWaitingQueueHead?: (
+    waitingQueueKey: string,
+    enteringKey: string,
+    inBookingSessionsKey: string,
+    reconnectingKey: string,
+    maxSizeKey: string,
+    defaultMaxSizeKey: string,
+    eventId: string,
+    userKeyPrefix: string,
+    defaultMaxSize: string,
+    nowMs: string,
+  ) => Promise<AdmissionRawResult>;
+};
+
+async function getAdmissionMaxSize(
+  redis: Redis,
+  maxSizeKey: string,
+  defaultMaxSizeKey: string,
+  defaultMaxSize: string,
+): Promise<number> {
+  const eventMaxSize = await redis.get(maxSizeKey);
+  if (eventMaxSize) {
+    return Number(eventMaxSize);
+  }
+
+  const redisDefaultMaxSize = await redis.get(defaultMaxSizeKey);
+  return redisDefaultMaxSize ? Number(redisDefaultMaxSize) : Number(defaultMaxSize);
+}
+
+async function hasAdmissionCapacity(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  reconnectingKey: string,
+  enteringKey: string,
+  maxSizeKey: string,
+  defaultMaxSizeKey: string,
+  defaultMaxSize: string,
+): Promise<boolean> {
+  const inBookingCount = await redis.hlen(inBookingSessionsKey);
+  const reconnectingCount = await redis.zcard(reconnectingKey);
+  const enteringCount = await redis.zcard(enteringKey);
+  const maxSize = await getAdmissionMaxSize(redis, maxSizeKey, defaultMaxSizeKey, defaultMaxSize);
+
+  return inBookingCount + reconnectingCount + enteringCount < maxSize;
+}
+
+async function writePreparedSession(
+  redis: Redis,
+  sessionKey: string,
+  encodedSession: string,
+  ttl: number,
+): Promise<void> {
+  if (ttl > 0) {
+    await redis.set(sessionKey, encodedSession, 'PX', ttl);
+    return;
+  }
+
+  await redis.set(sessionKey, encodedSession);
+}
+
+async function emulateImmediateAdmission(
+  redis: Redis,
+  sessionKey: string,
+  enteringKey: string,
+  inBookingSessionsKey: string,
+  reconnectingKey: string,
+  maxSizeKey: string,
+  eventId: string,
+  defaultMaxSizeKey: string,
+  defaultMaxSize: string,
+  nowMs: string,
+): Promise<AdmissionRawResult> {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return ['SESSION_MISSING'];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+  if (session.userStatus !== USER_STATUS.LOGIN) {
+    return ['STATE_MISMATCH', session.userStatus as string];
+  }
+
+  if (session.targetEvent !== null) {
+    return ['TARGET_EVENT_MISMATCH', session.targetEvent as number | string];
+  }
+
+  if (
+    !(await hasAdmissionCapacity(
+      redis,
+      inBookingSessionsKey,
+      reconnectingKey,
+      enteringKey,
+      maxSizeKey,
+      defaultMaxSizeKey,
+      defaultMaxSize,
+    ))
+  ) {
+    return ['CAPACITY_FULL'];
+  }
+
+  session.userStatus = USER_STATUS.ENTERING;
+  session.targetEvent = Number(eventId);
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+  if (ttl < -1) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  const encodedSession = JSON.stringify(session);
+  const sid = sessionKey.replace(/^user:/, '');
+  await redis.zadd(enteringKey, nowMs, sid);
+  await writePreparedSession(redis, sessionKey, encodedSession, ttl);
+  return ['OK'];
+}
+
+async function emulateWaitingHeadPromotion(
+  redis: Redis,
+  waitingQueueKey: string,
+  enteringKey: string,
+  inBookingSessionsKey: string,
+  reconnectingKey: string,
+  maxSizeKey: string,
+  defaultMaxSizeKey: string,
+  eventId: string,
+  userKeyPrefix: string,
+  defaultMaxSize: string,
+  nowMs: string,
+): Promise<AdmissionRawResult> {
+  const head = await redis.lindex(waitingQueueKey, 0);
+  if (!head) {
+    return ['QUEUE_EMPTY'];
+  }
+
+  const item = JSON.parse(head) as Record<string, unknown>;
+  const sid = item.sid as string;
+
+  if (
+    !(await hasAdmissionCapacity(
+      redis,
+      inBookingSessionsKey,
+      reconnectingKey,
+      enteringKey,
+      maxSizeKey,
+      defaultMaxSizeKey,
+      defaultMaxSize,
+    ))
+  ) {
+    return ['CAPACITY_FULL'];
+  }
+
+  const sessionKey = `${userKeyPrefix}${sid}`;
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    await redis.lpop(waitingQueueKey);
+    return ['STALE_SESSION_MISSING', sid];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+  if (session.userStatus !== USER_STATUS.WAITING) {
+    await redis.lpop(waitingQueueKey);
+    return ['STALE_STATE_MISMATCH', session.userStatus as string];
+  }
+
+  if (session.targetEvent !== Number(eventId)) {
+    await redis.lpop(waitingQueueKey);
+    return ['STALE_TARGET_EVENT_MISMATCH', session.targetEvent as number | string];
+  }
+
+  session.userStatus = USER_STATUS.ENTERING;
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+  if (ttl < -1) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  const encodedSession = JSON.stringify(session);
+  await redis.zadd(enteringKey, nowMs, sid);
+  await redis.lpop(waitingQueueKey);
+  await writePreparedSession(redis, sessionKey, encodedSession, ttl);
+  return ['OK'];
+}
+
+export function installAdmissionCapacityCommandMock(redis: Redis): void {
+  const commandRedis = redis as RedisWithAdmissionCommands;
+  const originalDefineCommand = redis.defineCommand.bind(redis);
+
+  redis.defineCommand = function defineCommand(name: string, options: unknown) {
+    if (name === 'admitBookingGateImmediate') {
+      commandRedis.admitBookingGateImmediate = (...args) => emulateImmediateAdmission(redis, ...args);
+      return redis;
+    }
+
+    if (name === 'promoteWaitingQueueHead') {
+      commandRedis.promoteWaitingQueueHead = (...args) => emulateWaitingHeadPromotion(redis, ...args);
+      return redis;
+    }
+
+    return originalDefineCommand(name, options as never);
+  } as typeof redis.defineCommand;
+}

--- a/back/src/testing/redis/admission-capacity-command-mock.ts
+++ b/back/src/testing/redis/admission-capacity-command-mock.ts
@@ -1,7 +1,5 @@
 import Redis from 'ioredis';
 
-import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
-
 type AdmissionRawResult = Array<string | number | null>;
 
 type RedisWithAdmissionCommands = Redis & {
@@ -15,6 +13,8 @@ type RedisWithAdmissionCommands = Redis & {
     defaultMaxSizeKey: string,
     defaultMaxSize: string,
     nowMs: string,
+    expectedFrom: string,
+    nextTo: string,
   ) => Promise<AdmissionRawResult>;
   promoteWaitingQueueHead?: (
     waitingQueueKey: string,
@@ -27,6 +27,8 @@ type RedisWithAdmissionCommands = Redis & {
     userKeyPrefix: string,
     defaultMaxSize: string,
     nowMs: string,
+    expectedFrom: string,
+    nextTo: string,
   ) => Promise<AdmissionRawResult>;
 };
 
@@ -87,6 +89,8 @@ async function emulateImmediateAdmission(
   defaultMaxSizeKey: string,
   defaultMaxSize: string,
   nowMs: string,
+  expectedFrom: string,
+  nextTo: string,
 ): Promise<AdmissionRawResult> {
   const raw = await redis.get(sessionKey);
   if (!raw) {
@@ -94,7 +98,7 @@ async function emulateImmediateAdmission(
   }
 
   const session = JSON.parse(raw) as Record<string, unknown>;
-  if (session.userStatus !== USER_STATUS.LOGIN) {
+  if (session.userStatus !== expectedFrom) {
     return ['STATE_MISMATCH', session.userStatus as string];
   }
 
@@ -116,7 +120,7 @@ async function emulateImmediateAdmission(
     return ['CAPACITY_FULL'];
   }
 
-  session.userStatus = USER_STATUS.ENTERING;
+  session.userStatus = nextTo;
   session.targetEvent = Number(eventId);
   const ttl = await redis.pttl(sessionKey);
   if (ttl === -2 || ttl === 0) {
@@ -145,6 +149,8 @@ async function emulateWaitingHeadPromotion(
   userKeyPrefix: string,
   defaultMaxSize: string,
   nowMs: string,
+  expectedFrom: string,
+  nextTo: string,
 ): Promise<AdmissionRawResult> {
   const head = await redis.lindex(waitingQueueKey, 0);
   if (!head) {
@@ -176,7 +182,7 @@ async function emulateWaitingHeadPromotion(
   }
 
   const session = JSON.parse(raw) as Record<string, unknown>;
-  if (session.userStatus !== USER_STATUS.WAITING) {
+  if (session.userStatus !== expectedFrom) {
     await redis.lpop(waitingQueueKey);
     return ['STALE_STATE_MISMATCH', session.userStatus as string];
   }
@@ -186,7 +192,7 @@ async function emulateWaitingHeadPromotion(
     return ['STALE_TARGET_EVENT_MISMATCH', session.targetEvent as number | string];
   }
 
-  session.userStatus = USER_STATUS.ENTERING;
+  session.userStatus = nextTo;
   const ttl = await redis.pttl(sessionKey);
   if (ttl === -2 || ttl === 0) {
     return ['SESSION_EXPIRED_DURING_WRITE'];

--- a/back/src/testing/redis/in-booking-session-command-mock.ts
+++ b/back/src/testing/redis/in-booking-session-command-mock.ts
@@ -1,0 +1,218 @@
+import Redis from 'ioredis';
+
+type InBookingSessionRawResult = Array<string>;
+
+type InBookingSessionRecord = {
+  sid: string;
+  bookingAmount: number;
+  bookedSeats: [number, number][];
+  saved: boolean;
+  subscribedSection: number | null;
+};
+
+type RedisWithInBookingSessionCommands = Redis & {
+  addInBookingBookedSeat?: (
+    inBookingSessionsKey: string,
+    sid: string,
+    sectionIndex: string,
+    seatIndex: string,
+    enforceQuota: string,
+  ) => Promise<InBookingSessionRawResult>;
+  removeInBookingBookedSeat?: (
+    inBookingSessionsKey: string,
+    sid: string,
+    sectionIndex: string,
+    seatIndex: string,
+    requireBooked: string,
+  ) => Promise<InBookingSessionRawResult>;
+  flushInBookingBookedSeats?: (
+    inBookingSessionsKey: string,
+    sid: string,
+    setBookingAmount: string,
+    bookingAmount: string,
+    onlyWhenUnsaved: string,
+  ) => Promise<InBookingSessionRawResult>;
+  setInBookingSaved?: (
+    inBookingSessionsKey: string,
+    sid: string,
+    saved: string,
+  ) => Promise<InBookingSessionRawResult>;
+  setInBookingSubscribedSection?: (
+    inBookingSessionsKey: string,
+    sid: string,
+    hasSection: string,
+    sectionIndex: string,
+  ) => Promise<InBookingSessionRawResult>;
+};
+
+async function readSession(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+): Promise<InBookingSessionRecord | null> {
+  const raw = await redis.hget(inBookingSessionsKey, sid);
+  return raw ? (JSON.parse(raw) as InBookingSessionRecord) : null;
+}
+
+async function writeSession(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+  session: InBookingSessionRecord,
+): Promise<void> {
+  await redis.hset(inBookingSessionsKey, sid, JSON.stringify(session));
+}
+
+function findSeatIndex(seats: [number, number][], sectionIndex: number, seatIndex: number): number {
+  return seats.findIndex((seat) => seat[0] === sectionIndex && seat[1] === seatIndex);
+}
+
+async function emulateAddBookedSeat(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+  sectionIndex: string,
+  seatIndex: string,
+  enforceQuota: string,
+): Promise<InBookingSessionRawResult> {
+  const session = await readSession(redis, inBookingSessionsKey, sid);
+  if (!session) {
+    return ['SESSION_NOT_FOUND'];
+  }
+
+  if (enforceQuota === '1' && session.bookingAmount <= session.bookedSeats.length) {
+    return ['QUOTA_EXCEEDED'];
+  }
+
+  session.bookedSeats.push([Number(sectionIndex), Number(seatIndex)]);
+  await writeSession(redis, inBookingSessionsKey, sid, session);
+
+  return ['OK'];
+}
+
+async function emulateRemoveBookedSeat(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+  sectionIndex: string,
+  seatIndex: string,
+  requireBooked: string,
+): Promise<InBookingSessionRawResult> {
+  const mustBeBooked = requireBooked === '1';
+  const session = await readSession(redis, inBookingSessionsKey, sid);
+  if (!session) {
+    return mustBeBooked ? ['CANCEL_EMPTY'] : ['SESSION_NOT_FOUND'];
+  }
+
+  if (mustBeBooked && session.bookedSeats.length === 0) {
+    return ['CANCEL_EMPTY'];
+  }
+
+  const foundIndex = findSeatIndex(session.bookedSeats, Number(sectionIndex), Number(seatIndex));
+  if (foundIndex < 0) {
+    return mustBeBooked ? ['SEAT_NOT_BOOKED'] : ['OK'];
+  }
+
+  session.bookedSeats.splice(foundIndex, 1);
+  await writeSession(redis, inBookingSessionsKey, sid, session);
+
+  return ['OK'];
+}
+
+async function emulateFlushBookedSeats(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+  setBookingAmount: string,
+  bookingAmount: string,
+  onlyWhenUnsaved: string,
+): Promise<InBookingSessionRawResult> {
+  const session = await readSession(redis, inBookingSessionsKey, sid);
+  if (!session) {
+    return ['SESSION_NOT_FOUND', '[]'];
+  }
+
+  if (onlyWhenUnsaved === '1' && session.saved) {
+    return ['OK', '[]'];
+  }
+
+  const flushedSeats = JSON.stringify(session.bookedSeats);
+  session.bookedSeats = [];
+
+  if (setBookingAmount === '1') {
+    session.bookingAmount = Number(bookingAmount);
+  }
+
+  await writeSession(redis, inBookingSessionsKey, sid, session);
+
+  return ['OK', flushedSeats];
+}
+
+async function emulateSetInBookingSaved(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+  saved: string,
+): Promise<InBookingSessionRawResult> {
+  const session = await readSession(redis, inBookingSessionsKey, sid);
+  if (!session) {
+    return ['SESSION_NOT_FOUND'];
+  }
+
+  session.saved = saved === '1';
+  await writeSession(redis, inBookingSessionsKey, sid, session);
+
+  return ['OK'];
+}
+
+async function emulateSetSubscribedSection(
+  redis: Redis,
+  inBookingSessionsKey: string,
+  sid: string,
+  hasSection: string,
+  sectionIndex: string,
+): Promise<InBookingSessionRawResult> {
+  const session = await readSession(redis, inBookingSessionsKey, sid);
+  if (!session) {
+    return ['SESSION_NOT_FOUND'];
+  }
+
+  session.subscribedSection = hasSection === '1' ? Number(sectionIndex) : null;
+  await writeSession(redis, inBookingSessionsKey, sid, session);
+
+  return ['OK'];
+}
+
+export function installInBookingSessionCommandMock(redis: Redis): void {
+  const commandRedis = redis as RedisWithInBookingSessionCommands;
+  const originalDefineCommand = redis.defineCommand.bind(redis);
+
+  redis.defineCommand = function defineCommand(name: string, options: unknown) {
+    if (name === 'addInBookingBookedSeat') {
+      commandRedis.addInBookingBookedSeat = (...args) => emulateAddBookedSeat(redis, ...args);
+      return redis;
+    }
+
+    if (name === 'removeInBookingBookedSeat') {
+      commandRedis.removeInBookingBookedSeat = (...args) => emulateRemoveBookedSeat(redis, ...args);
+      return redis;
+    }
+
+    if (name === 'flushInBookingBookedSeats') {
+      commandRedis.flushInBookingBookedSeats = (...args) => emulateFlushBookedSeats(redis, ...args);
+      return redis;
+    }
+
+    if (name === 'setInBookingSaved') {
+      commandRedis.setInBookingSaved = (...args) => emulateSetInBookingSaved(redis, ...args);
+      return redis;
+    }
+
+    if (name === 'setInBookingSubscribedSection') {
+      commandRedis.setInBookingSubscribedSection = (...args) => emulateSetSubscribedSection(redis, ...args);
+      return redis;
+    }
+
+    return originalDefineCommand(name, options as never);
+  } as typeof redis.defineCommand;
+}

--- a/back/src/testing/redis/luaScripts.real-spec.ts
+++ b/back/src/testing/redis/luaScripts.real-spec.ts
@@ -1,0 +1,511 @@
+import Redis from 'ioredis';
+
+import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
+import { runUserStateTransitionLua } from '../../auth/luaScripts/userStateTransitionLua';
+import {
+  runImmediateAdmissionLua,
+  runWaitingHeadPromotionLua,
+} from '../../domains/booking/luaScripts/admissionCapacityLua';
+import {
+  runAddBookedSeatLua,
+  runFlushBookedSeatsLua,
+  runRemoveBookedSeatLua,
+  runSetInBookingSavedLua,
+  runSetSubscribedSectionLua,
+} from '../../domains/booking/luaScripts/inBookingSessionLua';
+import {
+  runMarkReconnectingLua,
+  runRestoreSelectingLua,
+} from '../../domains/booking/luaScripts/reconnectingTransitionLua';
+import { runStartSeatSelectionLua } from '../../domains/booking/luaScripts/startSeatSelectionLua';
+import { runWaitingQueueEntryLua } from '../../domains/booking/luaScripts/waitingQueueEntryLua';
+
+/**
+ * 실제 Redis에서 Lua 스크립트 본문을 실행해 검증한다.
+ * `ioredis-mock`에는 cjson이 없어 다른 테스트는 계약을 흉내 낸 command mock으로만 검증하므로,
+ * 스크립트가 실제로 도는지는 이 파일에서만 확인된다.
+ *
+ * 실행: npm --prefix back run test:lua   (VM Redis가 켜져 있어야 함)
+ */
+const REDIS_HOST = process.env.LUA_TEST_REDIS_HOST ?? '192.168.138.2';
+const REDIS_PORT = Number(process.env.LUA_TEST_REDIS_PORT ?? 6379);
+const REDIS_DB = Number(process.env.LUA_TEST_REDIS_DB ?? 15);
+
+const EVENT_ID = 42;
+const SID = 'sid-1';
+const SESSION_KEY = `user:${SID}`;
+const ENTERING_KEY = `entering:${EVENT_ID}`;
+const IN_BOOKING_KEY = `in-booking:${EVENT_ID}:sessions`;
+const RECONNECTING_KEY = `reconnecting:${EVENT_ID}`;
+const MAX_SIZE_KEY = `in-booking:${EVENT_ID}:max-size`;
+const DEFAULT_MAX_SIZE_KEY = 'in-booking:default-max-size';
+const QUEUE_KEY = `waiting-queue:${EVENT_ID}`;
+const ORDER_KEY = `waiting-queue:${EVENT_ID}:order`;
+const AMOUNT_KEY = `entering:${SID}:temp-booking-amount`;
+
+const admissionKeys = {
+  enteringKey: ENTERING_KEY,
+  inBookingSessionsKey: IN_BOOKING_KEY,
+  reconnectingKey: RECONNECTING_KEY,
+  maxSizeKey: MAX_SIZE_KEY,
+  defaultMaxSizeKey: DEFAULT_MAX_SIZE_KEY,
+};
+
+let redis: Redis;
+
+function userSession(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    id: 1,
+    loginId: 'guest-1',
+    roles: ['USER'],
+    targetEvent: null,
+    userStatus: USER_STATUS.LOGIN,
+    ...overrides,
+  });
+}
+
+async function readJson(key: string): Promise<Record<string, unknown> | null> {
+  const raw = await redis.get(key);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+async function readInBooking(): Promise<Record<string, unknown> | null> {
+  const raw = await redis.hget(IN_BOOKING_KEY, SID);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+beforeAll(async () => {
+  redis = new Redis({ host: REDIS_HOST, port: REDIS_PORT, db: REDIS_DB, lazyConnect: true });
+  await redis.connect();
+});
+
+afterAll(async () => {
+  await redis.flushdb();
+  redis.disconnect();
+});
+
+beforeEach(async () => {
+  await redis.flushdb();
+});
+
+describe('실제 Redis - 기반 세션 전이 Lua', () => {
+  it('상태를 바꾸면서 남은 TTL을 보존함', async () => {
+    await redis.set(SESSION_KEY, userSession(), 'PX', 60_000);
+
+    const result = await runUserStateTransitionLua(redis, {
+      sessionKey: SESSION_KEY,
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+      targetEventPatch: { mode: 'set', eventId: EVENT_ID },
+      expectedTargetEvent: null,
+    });
+
+    expect(result).toMatchObject({ ok: true, code: 'OK' });
+    expect(await readJson(SESSION_KEY)).toMatchObject({
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: EVENT_ID,
+    });
+
+    const ttl = await redis.pttl(SESSION_KEY);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(60_000);
+  });
+
+  it('현재 상태가 다르면 쓰지 않고 STATE_MISMATCH를 반환함', async () => {
+    const stored = userSession({ userStatus: USER_STATUS.ENTERING });
+    await redis.set(SESSION_KEY, stored);
+
+    const result = await runUserStateTransitionLua(redis, {
+      sessionKey: SESSION_KEY,
+      action: 'enterWaiting',
+      expectedFrom: USER_STATUS.LOGIN,
+      nextTo: USER_STATUS.WAITING,
+      targetEventPatch: { mode: 'set', eventId: EVENT_ID },
+      expectedTargetEvent: null,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'STATE_MISMATCH' });
+    expect(await redis.get(SESSION_KEY)).toBe(stored);
+  });
+
+  it('targetEvent clear는 null로 저장되고 roles 배열이 유지됨', async () => {
+    await redis.set(SESSION_KEY, userSession({ userStatus: USER_STATUS.WAITING, targetEvent: 7 }));
+
+    await runUserStateTransitionLua(redis, {
+      sessionKey: SESSION_KEY,
+      action: 'resetToLogin',
+      expectedFrom: USER_STATUS.WAITING,
+      nextTo: USER_STATUS.LOGIN,
+      targetEventPatch: { mode: 'clear' },
+      expectedTargetEvent: 7,
+    });
+
+    const session = await readJson(SESSION_KEY);
+    expect(session).toMatchObject({ userStatus: USER_STATUS.LOGIN, targetEvent: null });
+    expect(Array.isArray(session?.roles)).toBe(true);
+  });
+});
+
+describe('실제 Redis - 입장 capacity Lua', () => {
+  it('즉시 입장은 entering 등록과 상태 전이를 함께 반영함', async () => {
+    await redis.set(SESSION_KEY, userSession());
+
+    const result = await runImmediateAdmissionLua(redis, {
+      sessionKey: SESSION_KEY,
+      eventId: EVENT_ID,
+      keys: admissionKeys,
+      defaultMaxSize: 10,
+      nowMs: 1_700_000_000_000,
+    });
+
+    expect(result).toMatchObject({ ok: true, code: 'OK' });
+    expect(await redis.zscore(ENTERING_KEY, SID)).toBe('1700000000000');
+    expect(await readJson(SESSION_KEY)).toMatchObject({
+      userStatus: USER_STATUS.ENTERING,
+      targetEvent: EVENT_ID,
+    });
+  });
+
+  it('정원이 차면 CAPACITY_FULL을 반환하고 아무것도 쓰지 않음', async () => {
+    await redis.set(SESSION_KEY, userSession());
+    await redis.set(MAX_SIZE_KEY, '1');
+    await redis.zadd(ENTERING_KEY, 1, 'other');
+
+    const result = await runImmediateAdmissionLua(redis, {
+      sessionKey: SESSION_KEY,
+      eventId: EVENT_ID,
+      keys: admissionKeys,
+      defaultMaxSize: 10,
+      nowMs: 1,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'CAPACITY_FULL' });
+    expect(await redis.zscore(ENTERING_KEY, SID)).toBeNull();
+  });
+
+  it('대기열 head 승격은 head를 pop하고 상태를 ENTERING으로 바꿈', async () => {
+    await redis.set(SESSION_KEY, userSession({ userStatus: USER_STATUS.WAITING, targetEvent: EVENT_ID }));
+    await redis.rpush(QUEUE_KEY, JSON.stringify({ sid: SID, order: 1 }));
+
+    const result = await runWaitingHeadPromotionLua(redis, {
+      waitingQueueKey: QUEUE_KEY,
+      userKeyPrefix: 'user:',
+      eventId: EVENT_ID,
+      keys: admissionKeys,
+      defaultMaxSize: 10,
+      nowMs: 1,
+    });
+
+    expect(result).toMatchObject({ ok: true, code: 'OK' });
+    expect(await redis.llen(QUEUE_KEY)).toBe(0);
+    expect(await readJson(SESSION_KEY)).toMatchObject({ userStatus: USER_STATUS.ENTERING });
+  });
+
+  it('세션 없는 stale head는 pop만 하고 다음으로 넘어감', async () => {
+    await redis.rpush(QUEUE_KEY, JSON.stringify({ sid: 'ghost', order: 1 }));
+
+    const result = await runWaitingHeadPromotionLua(redis, {
+      waitingQueueKey: QUEUE_KEY,
+      userKeyPrefix: 'user:',
+      eventId: EVENT_ID,
+      keys: admissionKeys,
+      defaultMaxSize: 10,
+      nowMs: 1,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'STALE_SESSION_MISSING' });
+    expect(await redis.llen(QUEUE_KEY)).toBe(0);
+  });
+});
+
+describe('실제 Redis - 대기열 진입 Lua', () => {
+  it('순번을 INCR로 발급하고 큐와 세션에 함께 반영함', async () => {
+    await redis.set(SESSION_KEY, userSession());
+
+    const { transition, order } = await runWaitingQueueEntryLua(redis, {
+      sessionKey: SESSION_KEY,
+      waitingQueueKey: QUEUE_KEY,
+      waitingOrderKey: ORDER_KEY,
+      eventId: EVENT_ID,
+      sid: SID,
+    });
+
+    expect(transition).toMatchObject({ ok: true, code: 'OK' });
+    expect(order).toBe(1);
+    expect(JSON.parse((await redis.lindex(QUEUE_KEY, 0)) ?? '{}')).toEqual({ sid: SID, order: 1 });
+    expect(await readJson(SESSION_KEY)).toMatchObject({
+      userStatus: USER_STATUS.WAITING,
+      targetEvent: EVENT_ID,
+      waitingOrder: 1,
+    });
+  });
+
+  it('여러 사용자가 진입해도 순번이 겹치지 않음', async () => {
+    const orders: Array<number | null> = [];
+
+    for (const sid of ['a', 'b', 'c']) {
+      await redis.set(`user:${sid}`, userSession());
+      const { order } = await runWaitingQueueEntryLua(redis, {
+        sessionKey: `user:${sid}`,
+        waitingQueueKey: QUEUE_KEY,
+        waitingOrderKey: ORDER_KEY,
+        eventId: EVENT_ID,
+        sid,
+      });
+      orders.push(order);
+    }
+
+    expect(orders).toEqual([1, 2, 3]);
+  });
+});
+
+describe('실제 Redis - 좌석 선택 진입 Lua', () => {
+  it('생성된 in-booking 세션의 bookedSeats가 객체가 아니라 배열임', async () => {
+    await redis.set(SESSION_KEY, userSession({ userStatus: USER_STATUS.ENTERING, targetEvent: EVENT_ID }));
+    await redis.zadd(ENTERING_KEY, 1, SID);
+    await redis.set(AMOUNT_KEY, '3');
+
+    const result = await runStartSeatSelectionLua(redis, {
+      sessionKey: SESSION_KEY,
+      enteringKey: ENTERING_KEY,
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      bookingAmountKey: AMOUNT_KEY,
+      eventId: EVENT_ID,
+      sid: SID,
+    });
+
+    expect(result).toMatchObject({ ok: true, code: 'OK' });
+    expect(await readInBooking()).toEqual({
+      sid: SID,
+      bookingAmount: 3,
+      bookedSeats: [],
+      saved: false,
+      subscribedSection: null,
+    });
+    expect(Array.isArray((await readInBooking())?.bookedSeats)).toBe(true);
+    expect(await redis.zscore(ENTERING_KEY, SID)).toBeNull();
+    expect(await redis.get(AMOUNT_KEY)).toBeNull();
+  });
+
+  it('entering 멤버가 아니면 아무것도 쓰지 않음', async () => {
+    await redis.set(SESSION_KEY, userSession({ userStatus: USER_STATUS.ENTERING, targetEvent: EVENT_ID }));
+    await redis.set(AMOUNT_KEY, '3');
+
+    const result = await runStartSeatSelectionLua(redis, {
+      sessionKey: SESSION_KEY,
+      enteringKey: ENTERING_KEY,
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      bookingAmountKey: AMOUNT_KEY,
+      eventId: EVENT_ID,
+      sid: SID,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'NOT_ENTERING' });
+    expect(await readInBooking()).toBeNull();
+    expect(await redis.get(AMOUNT_KEY)).toBe('3');
+    expect(await readJson(SESSION_KEY)).toMatchObject({ userStatus: USER_STATUS.ENTERING });
+  });
+});
+
+describe('실제 Redis - 재연결 전이 Lua', () => {
+  it('표시는 재연결 풀 등록과 상태 전이를 함께 반영함', async () => {
+    await redis.set(
+      SESSION_KEY,
+      userSession({ userStatus: USER_STATUS.SELECTING_SEAT, targetEvent: EVENT_ID }),
+    );
+
+    const result = await runMarkReconnectingLua(redis, {
+      sessionKey: SESSION_KEY,
+      reconnectingKey: RECONNECTING_KEY,
+      eventId: EVENT_ID,
+      sid: SID,
+      nowMs: 1_700_000_000_000,
+    });
+
+    expect(result).toMatchObject({ ok: true, code: 'OK' });
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).toBe('1700000000000');
+    expect(await readJson(SESSION_KEY)).toMatchObject({
+      userStatus: USER_STATUS.RECONNECTING_SELECTING,
+    });
+  });
+
+  it('재연결 풀에 없으면 상태를 전이하지 않음', async () => {
+    const stored = userSession({
+      userStatus: USER_STATUS.RECONNECTING_SELECTING,
+      targetEvent: EVENT_ID,
+    });
+    await redis.set(SESSION_KEY, stored);
+
+    const result = await runRestoreSelectingLua(redis, {
+      sessionKey: SESSION_KEY,
+      reconnectingKey: RECONNECTING_KEY,
+      eventId: EVENT_ID,
+      sid: SID,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'NOT_RECONNECTING' });
+    expect(await redis.get(SESSION_KEY)).toBe(stored);
+  });
+
+  it('재연결 풀 멤버면 제거하고 좌석 선택으로 되돌림', async () => {
+    await redis.set(
+      SESSION_KEY,
+      userSession({ userStatus: USER_STATUS.RECONNECTING_SELECTING, targetEvent: EVENT_ID }),
+    );
+    await redis.zadd(RECONNECTING_KEY, 1, SID);
+
+    const result = await runRestoreSelectingLua(redis, {
+      sessionKey: SESSION_KEY,
+      reconnectingKey: RECONNECTING_KEY,
+      eventId: EVENT_ID,
+      sid: SID,
+    });
+
+    expect(result).toMatchObject({ ok: true, code: 'OK' });
+    expect(await redis.zscore(RECONNECTING_KEY, SID)).toBeNull();
+    expect(await readJson(SESSION_KEY)).toMatchObject({ userStatus: USER_STATUS.SELECTING_SEAT });
+  });
+});
+
+describe('실제 Redis - in-booking 세션 필드 Lua', () => {
+  async function seedInBooking(overrides: Record<string, unknown> = {}) {
+    await redis.hset(
+      IN_BOOKING_KEY,
+      SID,
+      JSON.stringify({
+        sid: SID,
+        bookingAmount: 2,
+        bookedSeats: [],
+        saved: false,
+        subscribedSection: null,
+        ...overrides,
+      }),
+    );
+  }
+
+  it('좌석을 추가하면 중첩 배열 형태가 유지됨', async () => {
+    await seedInBooking();
+
+    const result = await runAddBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      enforceQuota: true,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(await readInBooking()).toEqual({
+      sid: SID,
+      bookingAmount: 2,
+      bookedSeats: [[1, 2]],
+      saved: false,
+      subscribedSection: null,
+    });
+  });
+
+  it('마지막 좌석을 빼도 빈 배열로 남고 객체가 되지 않음', async () => {
+    await seedInBooking({ bookedSeats: [[1, 2]] });
+
+    await runRemoveBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      requireBooked: true,
+    });
+
+    const session = await readInBooking();
+    expect(Array.isArray(session?.bookedSeats)).toBe(true);
+    expect(session?.bookedSeats).toEqual([]);
+  });
+
+  it('예매 수량을 넘으면 QUOTA_EXCEEDED로 막음', async () => {
+    await seedInBooking({
+      bookingAmount: 1,
+      bookedSeats: [[0, 0]],
+    });
+
+    const result = await runAddBookedSeatLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      seat: [1, 2],
+      enforceQuota: true,
+    });
+
+    expect(result.code).toBe('QUOTA_EXCEEDED');
+    expect(await readInBooking()).toMatchObject({ bookedSeats: [[0, 0]] });
+  });
+
+  it('좌석 회수는 목록을 돌려주면서 배열로 비움', async () => {
+    await seedInBooking({
+      bookedSeats: [
+        [0, 1],
+        [2, 3],
+      ],
+    });
+
+    const result = await runFlushBookedSeatsLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      onlyWhenUnsaved: true,
+    });
+
+    expect(result.code).toBe('OK');
+    expect(result.seats).toEqual([
+      [0, 1],
+      [2, 3],
+    ]);
+
+    const session = await readInBooking();
+    expect(Array.isArray(session?.bookedSeats)).toBe(true);
+    expect(session?.bookedSeats).toEqual([]);
+  });
+
+  it('이미 확정된 세션은 좌석을 회수하지 않음', async () => {
+    await seedInBooking({ bookedSeats: [[0, 1]], saved: true });
+
+    const result = await runFlushBookedSeatsLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      onlyWhenUnsaved: true,
+    });
+
+    expect(result.seats).toEqual([]);
+    expect(await readInBooking()).toMatchObject({ bookedSeats: [[0, 1]] });
+  });
+
+  it('확정 표시와 섹션 갱신이 좌석 목록을 건드리지 않음', async () => {
+    await seedInBooking({ bookedSeats: [[0, 1]] });
+
+    await runSetInBookingSavedLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      saved: true,
+    });
+    await runSetSubscribedSectionLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      sectionIndex: 3,
+    });
+
+    expect(await readInBooking()).toEqual({
+      sid: SID,
+      bookingAmount: 2,
+      bookedSeats: [[0, 1]],
+      saved: true,
+      subscribedSection: 3,
+    });
+  });
+
+  it('섹션을 비우면 null로 저장됨', async () => {
+    await seedInBooking({ subscribedSection: 3 });
+
+    await runSetSubscribedSectionLua(redis, {
+      inBookingSessionsKey: IN_BOOKING_KEY,
+      sid: SID,
+      sectionIndex: null,
+    });
+
+    expect(await readInBooking()).toMatchObject({ subscribedSection: null });
+  });
+});

--- a/back/src/testing/redis/reconnecting-transition-command-mock.ts
+++ b/back/src/testing/redis/reconnecting-transition-command-mock.ts
@@ -1,7 +1,5 @@
 import Redis from 'ioredis';
 
-import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
-
 type ReconnectingRawResult = Array<string | number | null>;
 
 type RedisWithReconnectingTransitionCommands = Redis & {
@@ -11,12 +9,16 @@ type RedisWithReconnectingTransitionCommands = Redis & {
     eventId: string,
     sid: string,
     nowMs: string,
+    expectedFrom: string,
+    nextTo: string,
   ) => Promise<ReconnectingRawResult>;
   restoreSelectingSeat?: (
     sessionKey: string,
     reconnectingKey: string,
     eventId: string,
     sid: string,
+    expectedFrom: string,
+    nextTo: string,
   ) => Promise<ReconnectingRawResult>;
 };
 
@@ -82,13 +84,15 @@ async function emulateMarkReconnectingSelecting(
   eventId: string,
   sid: string,
   nowMs: string,
+  expectedFrom: string,
+  nextTo: string,
 ): Promise<ReconnectingRawResult> {
-  const read = await readTransitionableSession(redis, sessionKey, USER_STATUS.SELECTING_SEAT, eventId);
+  const read = await readTransitionableSession(redis, sessionKey, expectedFrom, eventId);
   if ('denial' in read) {
     return read.denial;
   }
 
-  read.session.userStatus = USER_STATUS.RECONNECTING_SELECTING;
+  read.session.userStatus = nextTo;
 
   const prepared = await prepareSessionWrite(redis, sessionKey, read.session);
   if (prepared.code !== 'OK') {
@@ -107,18 +111,15 @@ async function emulateRestoreSelectingSeat(
   reconnectingKey: string,
   eventId: string,
   sid: string,
+  expectedFrom: string,
+  nextTo: string,
 ): Promise<ReconnectingRawResult> {
-  const read = await readTransitionableSession(
-    redis,
-    sessionKey,
-    USER_STATUS.RECONNECTING_SELECTING,
-    eventId,
-  );
+  const read = await readTransitionableSession(redis, sessionKey, expectedFrom, eventId);
   if ('denial' in read) {
     return read.denial;
   }
 
-  read.session.userStatus = USER_STATUS.SELECTING_SEAT;
+  read.session.userStatus = nextTo;
 
   const prepared = await prepareSessionWrite(redis, sessionKey, read.session);
   if (prepared.code !== 'OK') {

--- a/back/src/testing/redis/reconnecting-transition-command-mock.ts
+++ b/back/src/testing/redis/reconnecting-transition-command-mock.ts
@@ -1,0 +1,154 @@
+import Redis from 'ioredis';
+
+import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
+
+type ReconnectingRawResult = Array<string | number | null>;
+
+type RedisWithReconnectingTransitionCommands = Redis & {
+  markReconnectingSelecting?: (
+    sessionKey: string,
+    reconnectingKey: string,
+    eventId: string,
+    sid: string,
+    nowMs: string,
+  ) => Promise<ReconnectingRawResult>;
+  restoreSelectingSeat?: (
+    sessionKey: string,
+    reconnectingKey: string,
+    eventId: string,
+    sid: string,
+  ) => Promise<ReconnectingRawResult>;
+};
+
+type PreparedSessionWrite =
+  | { code: 'OK'; encodedSession: string; ttl: number }
+  | { code: 'SESSION_EXPIRED_DURING_WRITE' };
+
+async function prepareSessionWrite(
+  redis: Redis,
+  sessionKey: string,
+  session: Record<string, unknown>,
+): Promise<PreparedSessionWrite> {
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0 || ttl < -1) {
+    return { code: 'SESSION_EXPIRED_DURING_WRITE' };
+  }
+
+  return { code: 'OK', encodedSession: JSON.stringify(session), ttl };
+}
+
+async function writePreparedSessionPreservingTtl(
+  redis: Redis,
+  sessionKey: string,
+  encodedSession: string,
+  ttl: number,
+): Promise<void> {
+  if (ttl > 0) {
+    await redis.set(sessionKey, encodedSession, 'PX', ttl);
+    return;
+  }
+
+  await redis.set(sessionKey, encodedSession);
+}
+
+async function readTransitionableSession(
+  redis: Redis,
+  sessionKey: string,
+  expectedFrom: string,
+  eventId: string,
+): Promise<{ session: Record<string, unknown> } | { denial: ReconnectingRawResult }> {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return { denial: ['SESSION_MISSING'] };
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+
+  if (session.userStatus !== expectedFrom) {
+    return { denial: ['STATE_MISMATCH', session.userStatus as string] };
+  }
+
+  if (session.targetEvent !== Number(eventId)) {
+    return { denial: ['TARGET_EVENT_MISMATCH', session.targetEvent as number | string | null] };
+  }
+
+  return { session };
+}
+
+async function emulateMarkReconnectingSelecting(
+  redis: Redis,
+  sessionKey: string,
+  reconnectingKey: string,
+  eventId: string,
+  sid: string,
+  nowMs: string,
+): Promise<ReconnectingRawResult> {
+  const read = await readTransitionableSession(redis, sessionKey, USER_STATUS.SELECTING_SEAT, eventId);
+  if ('denial' in read) {
+    return read.denial;
+  }
+
+  read.session.userStatus = USER_STATUS.RECONNECTING_SELECTING;
+
+  const prepared = await prepareSessionWrite(redis, sessionKey, read.session);
+  if (prepared.code !== 'OK') {
+    return [prepared.code];
+  }
+
+  await redis.zadd(reconnectingKey, Number(nowMs), sid);
+  await writePreparedSessionPreservingTtl(redis, sessionKey, prepared.encodedSession, prepared.ttl);
+
+  return ['OK'];
+}
+
+async function emulateRestoreSelectingSeat(
+  redis: Redis,
+  sessionKey: string,
+  reconnectingKey: string,
+  eventId: string,
+  sid: string,
+): Promise<ReconnectingRawResult> {
+  const read = await readTransitionableSession(
+    redis,
+    sessionKey,
+    USER_STATUS.RECONNECTING_SELECTING,
+    eventId,
+  );
+  if ('denial' in read) {
+    return read.denial;
+  }
+
+  read.session.userStatus = USER_STATUS.SELECTING_SEAT;
+
+  const prepared = await prepareSessionWrite(redis, sessionKey, read.session);
+  if (prepared.code !== 'OK') {
+    return [prepared.code];
+  }
+
+  if ((await redis.zrem(reconnectingKey, sid)) !== 1) {
+    return ['NOT_RECONNECTING'];
+  }
+
+  await writePreparedSessionPreservingTtl(redis, sessionKey, prepared.encodedSession, prepared.ttl);
+
+  return ['OK'];
+}
+
+export function installReconnectingTransitionCommandMock(redis: Redis): void {
+  const commandRedis = redis as RedisWithReconnectingTransitionCommands;
+  const originalDefineCommand = redis.defineCommand.bind(redis);
+
+  redis.defineCommand = function defineCommand(name: string, options: unknown) {
+    if (name === 'markReconnectingSelecting') {
+      commandRedis.markReconnectingSelecting = (...args) => emulateMarkReconnectingSelecting(redis, ...args);
+      return redis;
+    }
+
+    if (name === 'restoreSelectingSeat') {
+      commandRedis.restoreSelectingSeat = (...args) => emulateRestoreSelectingSeat(redis, ...args);
+      return redis;
+    }
+
+    return originalDefineCommand(name, options as never);
+  } as typeof redis.defineCommand;
+}

--- a/back/src/testing/redis/start-seat-selection-command-mock.ts
+++ b/back/src/testing/redis/start-seat-selection-command-mock.ts
@@ -1,7 +1,5 @@
 import Redis from 'ioredis';
 
-import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
-
 type StartSeatSelectionRawResult = Array<string | number | null>;
 
 type RedisWithStartSeatSelectionCommand = Redis & {
@@ -14,6 +12,8 @@ type RedisWithStartSeatSelectionCommand = Redis & {
     sid: string,
     inBookingSessionPrefix: string,
     inBookingSessionSuffix: string,
+    expectedFrom: string,
+    nextTo: string,
   ) => Promise<StartSeatSelectionRawResult>;
 };
 
@@ -27,6 +27,8 @@ async function emulateStartSeatSelectionFromEntering(
   sid: string,
   inBookingSessionPrefix: string,
   inBookingSessionSuffix: string,
+  expectedFrom: string,
+  nextTo: string,
 ): Promise<StartSeatSelectionRawResult> {
   const raw = await redis.get(sessionKey);
   if (!raw) {
@@ -35,7 +37,7 @@ async function emulateStartSeatSelectionFromEntering(
 
   const session = JSON.parse(raw) as Record<string, unknown>;
 
-  if (session.userStatus !== USER_STATUS.ENTERING) {
+  if (session.userStatus !== expectedFrom) {
     return ['STATE_MISMATCH', session.userStatus as string];
   }
 
@@ -53,7 +55,7 @@ async function emulateStartSeatSelectionFromEntering(
     bookingAmount = Math.floor(parsedBookingAmount);
   }
 
-  session.userStatus = USER_STATUS.SELECTING_SEAT;
+  session.userStatus = nextTo;
 
   const ttl = await redis.pttl(sessionKey);
   if (ttl === -2 || ttl === 0 || ttl < -1) {

--- a/back/src/testing/redis/start-seat-selection-command-mock.ts
+++ b/back/src/testing/redis/start-seat-selection-command-mock.ts
@@ -1,0 +1,97 @@
+import Redis from 'ioredis';
+
+import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
+
+type StartSeatSelectionRawResult = Array<string | number | null>;
+
+type RedisWithStartSeatSelectionCommand = Redis & {
+  startSeatSelectionFromEntering?: (
+    sessionKey: string,
+    enteringKey: string,
+    inBookingSessionsKey: string,
+    bookingAmountKey: string,
+    eventId: string,
+    sid: string,
+    inBookingSessionPrefix: string,
+    inBookingSessionSuffix: string,
+  ) => Promise<StartSeatSelectionRawResult>;
+};
+
+async function emulateStartSeatSelectionFromEntering(
+  redis: Redis,
+  sessionKey: string,
+  enteringKey: string,
+  inBookingSessionsKey: string,
+  bookingAmountKey: string,
+  eventId: string,
+  sid: string,
+  inBookingSessionPrefix: string,
+  inBookingSessionSuffix: string,
+): Promise<StartSeatSelectionRawResult> {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return ['SESSION_MISSING'];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+
+  if (session.userStatus !== USER_STATUS.ENTERING) {
+    return ['STATE_MISMATCH', session.userStatus as string];
+  }
+
+  if (session.targetEvent !== Number(eventId)) {
+    return ['TARGET_EVENT_MISMATCH', session.targetEvent as number | string | null];
+  }
+
+  let bookingAmount = 0;
+  const rawBookingAmount = await redis.get(bookingAmountKey);
+  if (rawBookingAmount !== null) {
+    const parsedBookingAmount = Number(rawBookingAmount);
+    if (!Number.isFinite(parsedBookingAmount)) {
+      return ['CORRUPTED_BOOKING_AMOUNT'];
+    }
+    bookingAmount = Math.floor(parsedBookingAmount);
+  }
+
+  session.userStatus = USER_STATUS.SELECTING_SEAT;
+
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0 || ttl < -1) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+  const encodedSession = JSON.stringify(session);
+
+  if ((await redis.zrem(enteringKey, sid)) !== 1) {
+    return ['NOT_ENTERING'];
+  }
+
+  await redis.del(bookingAmountKey);
+  await redis.hset(
+    inBookingSessionsKey,
+    sid,
+    `${inBookingSessionPrefix}${bookingAmount}${inBookingSessionSuffix}`,
+  );
+
+  if (ttl > 0) {
+    await redis.set(sessionKey, encodedSession, 'PX', ttl);
+  } else {
+    await redis.set(sessionKey, encodedSession);
+  }
+
+  return ['OK'];
+}
+
+export function installStartSeatSelectionCommandMock(redis: Redis): void {
+  const commandRedis = redis as RedisWithStartSeatSelectionCommand;
+  const originalDefineCommand = redis.defineCommand.bind(redis);
+
+  redis.defineCommand = function defineCommand(name: string, options: unknown) {
+    if (name === 'startSeatSelectionFromEntering') {
+      commandRedis.startSeatSelectionFromEntering = (...args) =>
+        emulateStartSeatSelectionFromEntering(redis, ...args);
+      return redis;
+    }
+
+    return originalDefineCommand(name, options as never);
+  } as typeof redis.defineCommand;
+}

--- a/back/src/testing/redis/test-redis.service.ts
+++ b/back/src/testing/redis/test-redis.service.ts
@@ -3,6 +3,7 @@ import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
 import { installAdmissionCapacityCommandMock } from './admission-capacity-command-mock';
+import { installInBookingSessionCommandMock } from './in-booking-session-command-mock';
 import { installReconnectingTransitionCommandMock } from './reconnecting-transition-command-mock';
 import { installStartSeatSelectionCommandMock } from './start-seat-selection-command-mock';
 import { installUserStateTransitionCommandMock } from './user-state-transition-command-mock';
@@ -17,6 +18,7 @@ export class TestRedisService {
     this.redisClient = new RedisMock() as unknown as Redis;
     this.pubsubClient = new RedisMock() as unknown as Redis;
     installAdmissionCapacityCommandMock(this.redisClient);
+    installInBookingSessionCommandMock(this.redisClient);
     installReconnectingTransitionCommandMock(this.redisClient);
     installStartSeatSelectionCommandMock(this.redisClient);
     installUserStateTransitionCommandMock(this.redisClient);

--- a/back/src/testing/redis/test-redis.service.ts
+++ b/back/src/testing/redis/test-redis.service.ts
@@ -4,6 +4,7 @@ import RedisMock from 'ioredis-mock';
 
 import { installAdmissionCapacityCommandMock } from './admission-capacity-command-mock';
 import { installReconnectingTransitionCommandMock } from './reconnecting-transition-command-mock';
+import { installStartSeatSelectionCommandMock } from './start-seat-selection-command-mock';
 import { installUserStateTransitionCommandMock } from './user-state-transition-command-mock';
 import { installWaitingQueueEntryCommandMock } from './waiting-queue-entry-command-mock';
 
@@ -17,6 +18,7 @@ export class TestRedisService {
     this.pubsubClient = new RedisMock() as unknown as Redis;
     installAdmissionCapacityCommandMock(this.redisClient);
     installReconnectingTransitionCommandMock(this.redisClient);
+    installStartSeatSelectionCommandMock(this.redisClient);
     installUserStateTransitionCommandMock(this.redisClient);
     installWaitingQueueEntryCommandMock(this.redisClient);
   }

--- a/back/src/testing/redis/test-redis.service.ts
+++ b/back/src/testing/redis/test-redis.service.ts
@@ -5,6 +5,7 @@ import RedisMock from 'ioredis-mock';
 import { installAdmissionCapacityCommandMock } from './admission-capacity-command-mock';
 import { installReconnectingTransitionCommandMock } from './reconnecting-transition-command-mock';
 import { installUserStateTransitionCommandMock } from './user-state-transition-command-mock';
+import { installWaitingQueueEntryCommandMock } from './waiting-queue-entry-command-mock';
 
 @Injectable()
 export class TestRedisService {
@@ -17,6 +18,7 @@ export class TestRedisService {
     installAdmissionCapacityCommandMock(this.redisClient);
     installReconnectingTransitionCommandMock(this.redisClient);
     installUserStateTransitionCommandMock(this.redisClient);
+    installWaitingQueueEntryCommandMock(this.redisClient);
   }
 
   getOrThrow(namespace?: string): Redis {

--- a/back/src/testing/redis/test-redis.service.ts
+++ b/back/src/testing/redis/test-redis.service.ts
@@ -3,6 +3,7 @@ import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
 import { installAdmissionCapacityCommandMock } from './admission-capacity-command-mock';
+import { installReconnectingTransitionCommandMock } from './reconnecting-transition-command-mock';
 import { installUserStateTransitionCommandMock } from './user-state-transition-command-mock';
 
 @Injectable()
@@ -14,6 +15,7 @@ export class TestRedisService {
     this.redisClient = new RedisMock() as unknown as Redis;
     this.pubsubClient = new RedisMock() as unknown as Redis;
     installAdmissionCapacityCommandMock(this.redisClient);
+    installReconnectingTransitionCommandMock(this.redisClient);
     installUserStateTransitionCommandMock(this.redisClient);
   }
 

--- a/back/src/testing/redis/test-redis.service.ts
+++ b/back/src/testing/redis/test-redis.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 
+import { installAdmissionCapacityCommandMock } from './admission-capacity-command-mock';
+import { installUserStateTransitionCommandMock } from './user-state-transition-command-mock';
+
 @Injectable()
 export class TestRedisService {
   private redisClient: Redis;
@@ -10,6 +13,8 @@ export class TestRedisService {
   constructor() {
     this.redisClient = new RedisMock() as unknown as Redis;
     this.pubsubClient = new RedisMock() as unknown as Redis;
+    installAdmissionCapacityCommandMock(this.redisClient);
+    installUserStateTransitionCommandMock(this.redisClient);
   }
 
   getOrThrow(namespace?: string): Redis {

--- a/back/src/testing/redis/user-state-transition-command-mock.ts
+++ b/back/src/testing/redis/user-state-transition-command-mock.ts
@@ -1,0 +1,82 @@
+import Redis from 'ioredis';
+
+type UserStateRawResult = Array<string | number | null>;
+
+type RedisWithUserStateTransitionCommand = Redis & {
+  userStateTransition?: (
+    sessionKey: string,
+    expectedFromMode: string,
+    expectedFromValue: string,
+    nextTo: string,
+    targetEventPatchMode: string,
+    targetEventPatchValue: string,
+    expectedTargetEventMode: string,
+    expectedTargetEventValue: string,
+  ) => Promise<UserStateRawResult>;
+};
+
+async function emulateUserStateTransition(
+  redis: Redis,
+  sessionKey: string,
+  expectedFromMode: string,
+  expectedFromValue: string,
+  nextTo: string,
+  targetEventPatchMode: string,
+  targetEventPatchValue: string,
+  expectedTargetEventMode: string,
+  expectedTargetEventValue: string,
+): Promise<UserStateRawResult> {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return ['SESSION_MISSING'];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+
+  if (expectedFromMode === 'value' && session.userStatus !== expectedFromValue) {
+    return ['STATE_MISMATCH', session.userStatus as string];
+  }
+
+  if (expectedTargetEventMode !== 'none') {
+    const expectedTargetEvent = expectedTargetEventMode === 'null' ? null : Number(expectedTargetEventValue);
+    if (session.targetEvent !== expectedTargetEvent) {
+      return ['TARGET_EVENT_MISMATCH', session.targetEvent as number | string | null];
+    }
+  }
+
+  session.userStatus = nextTo;
+
+  if (targetEventPatchMode === 'set') {
+    session.targetEvent = Number(targetEventPatchValue);
+  } else if (targetEventPatchMode === 'clear') {
+    session.targetEvent = null;
+  }
+
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0 || ttl < -1) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  const encodedSession = JSON.stringify(session);
+  if (ttl > 0) {
+    await redis.set(sessionKey, encodedSession, 'PX', ttl);
+  } else {
+    await redis.set(sessionKey, encodedSession);
+  }
+
+  return ['OK'];
+}
+
+export function installUserStateTransitionCommandMock(redis: Redis): void {
+  const commandRedis = redis as RedisWithUserStateTransitionCommand;
+  const originalDefineCommand = redis.defineCommand.bind(redis);
+
+  redis.defineCommand = function defineCommand(name: string, options: unknown) {
+    if (name === 'userStateTransition') {
+      commandRedis.userStateTransition = (...args) => emulateUserStateTransition(redis, ...args);
+      return redis;
+    }
+
+    return originalDefineCommand(name, options as never);
+  } as typeof redis.defineCommand;
+}

--- a/back/src/testing/redis/waiting-queue-entry-command-mock.ts
+++ b/back/src/testing/redis/waiting-queue-entry-command-mock.ts
@@ -1,0 +1,75 @@
+import Redis from 'ioredis';
+
+import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
+
+type WaitingQueueEntryRawResult = Array<string | number | null>;
+
+type RedisWithWaitingQueueEntryCommand = Redis & {
+  enterWaitingQueue?: (
+    sessionKey: string,
+    waitingQueueKey: string,
+    waitingOrderKey: string,
+    eventId: string,
+    sid: string,
+  ) => Promise<WaitingQueueEntryRawResult>;
+};
+
+async function emulateEnterWaitingQueue(
+  redis: Redis,
+  sessionKey: string,
+  waitingQueueKey: string,
+  waitingOrderKey: string,
+  eventId: string,
+  sid: string,
+): Promise<WaitingQueueEntryRawResult> {
+  const raw = await redis.get(sessionKey);
+  if (!raw) {
+    return ['SESSION_MISSING'];
+  }
+
+  const session = JSON.parse(raw) as Record<string, unknown>;
+
+  if (session.userStatus !== USER_STATUS.LOGIN) {
+    return ['STATE_MISMATCH', session.userStatus as string];
+  }
+
+  if (session.targetEvent !== null) {
+    return ['TARGET_EVENT_MISMATCH', session.targetEvent as number | string | null];
+  }
+
+  const order = await redis.incr(waitingOrderKey);
+
+  session.userStatus = USER_STATUS.WAITING;
+  session.targetEvent = Number(eventId);
+  session.waitingOrder = order;
+
+  const ttl = await redis.pttl(sessionKey);
+  if (ttl === -2 || ttl === 0 || ttl < -1) {
+    return ['SESSION_EXPIRED_DURING_WRITE'];
+  }
+
+  const encodedSession = JSON.stringify(session);
+  await redis.rpush(waitingQueueKey, JSON.stringify({ sid, order }));
+
+  if (ttl > 0) {
+    await redis.set(sessionKey, encodedSession, 'PX', ttl);
+  } else {
+    await redis.set(sessionKey, encodedSession);
+  }
+
+  return ['OK', order];
+}
+
+export function installWaitingQueueEntryCommandMock(redis: Redis): void {
+  const commandRedis = redis as RedisWithWaitingQueueEntryCommand;
+  const originalDefineCommand = redis.defineCommand.bind(redis);
+
+  redis.defineCommand = function defineCommand(name: string, options: unknown) {
+    if (name === 'enterWaitingQueue') {
+      commandRedis.enterWaitingQueue = (...args) => emulateEnterWaitingQueue(redis, ...args);
+      return redis;
+    }
+
+    return originalDefineCommand(name, options as never);
+  } as typeof redis.defineCommand;
+}

--- a/back/src/testing/redis/waiting-queue-entry-command-mock.ts
+++ b/back/src/testing/redis/waiting-queue-entry-command-mock.ts
@@ -1,7 +1,5 @@
 import Redis from 'ioredis';
 
-import { USER_STATUS } from '../../auth/fsm/user-state.fsm';
-
 type WaitingQueueEntryRawResult = Array<string | number | null>;
 
 type RedisWithWaitingQueueEntryCommand = Redis & {
@@ -11,6 +9,8 @@ type RedisWithWaitingQueueEntryCommand = Redis & {
     waitingOrderKey: string,
     eventId: string,
     sid: string,
+    expectedFrom: string,
+    nextTo: string,
   ) => Promise<WaitingQueueEntryRawResult>;
 };
 
@@ -21,6 +21,8 @@ async function emulateEnterWaitingQueue(
   waitingOrderKey: string,
   eventId: string,
   sid: string,
+  expectedFrom: string,
+  nextTo: string,
 ): Promise<WaitingQueueEntryRawResult> {
   const raw = await redis.get(sessionKey);
   if (!raw) {
@@ -29,7 +31,7 @@ async function emulateEnterWaitingQueue(
 
   const session = JSON.parse(raw) as Record<string, unknown>;
 
-  if (session.userStatus !== USER_STATUS.LOGIN) {
+  if (session.userStatus !== expectedFrom) {
     return ['STATE_MISMATCH', session.userStatus as string];
   }
 
@@ -39,7 +41,7 @@ async function emulateEnterWaitingQueue(
 
   const order = await redis.incr(waitingOrderKey);
 
-  session.userStatus = USER_STATUS.WAITING;
+  session.userStatus = nextTo;
   session.targetEvent = Number(eventId);
   session.waitingOrder = order;
 

--- a/back/test/booking-abnormal.e2e-spec.ts
+++ b/back/test/booking-abnormal.e2e-spec.ts
@@ -88,22 +88,20 @@ describe('booking abnormal flows', () => {
       expect(sessionAfter.targetEvent).toBe(eventId);
     });
 
-    it('ABN-01b: admission CAS loss does not leak targetEvent or entering slot', async () => {
+    it('ABN-01b: admission Lua write failure does not leak targetEvent or entering slot', async () => {
       await openEventReservation(app, adminSid, eventId).expect(201);
       const userSid = await loginAsUser(app, 'abn01buser1', 'pass1234');
-      const enterSpy = jest.spyOn(authService, 'enterBookingGate').mockResolvedValueOnce(null);
+      const redis = getRedisService(app).getOrThrow();
+      await redis.set(`entering:${eventId}`, 'wrong-type');
 
       const res = await requestPermission(app, userSid, eventId);
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(500);
       const sessionAfter = await authService.getUserSession(userSid);
       expect(sessionAfter.userStatus).toBe('LOGIN');
       expect(sessionAfter.targetEvent).toBeNull();
 
-      const redis = getRedisService(app).getOrThrow();
-      expect(await redis.zscore(`entering:${eventId}`, userSid)).toBeNull();
-
-      enterSpy.mockRestore();
+      expect(await redis.get(`entering:${eventId}`)).toBe('wrong-type');
     });
 
     it('ABN-02: SELECTING_SEAT cross-event permission returns 400 without mutation', async () => {

--- a/back/test/booking-abnormal.e2e-spec.ts
+++ b/back/test/booking-abnormal.e2e-spec.ts
@@ -284,15 +284,15 @@ describe('booking abnormal flows', () => {
       await requestPermission(app, userSid, eventId).expect(200);
       await setBookingCount(app, userSid, 1).expect(201);
 
-      const startSpy = jest.spyOn(authService, 'startSeatSelection').mockResolvedValueOnce(null);
+      // entering 풀에서 사라진 상태(예: GC 회수)를 만들어 전이가 fail-closed 되는지 확인함
+      const redis = getRedisService(app).getOrThrow();
+      await redis.zrem(`entering:${eventId}`, userSid);
 
       await expect(bookingService.setInBookingFromEntering(userSid)).rejects.toThrow();
 
       const sessionAfter = await authService.getUserSession(userSid);
       expect(sessionAfter.userStatus).toBe('ENTERING');
       expect(await inBookingService.getSession(eventId, userSid)).toBeNull();
-
-      startSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## 📌 이슈 번호
- close #423

## 🚀 구현 내용
- 각 전이 구현이 모듈 로드 시점에 전이 테이블을 조회해 시작/도착 상태를 얻도록 바꿈. 테이블이 금지하는 전이면 요청을 받기 전에 실패함
- 스크립트 본문에 박아두던 상태 문자열을 인자로 옮김. 스크립트 안에 상태 하드코딩이 남지 않음
- 호출부가 없어진 `AuthService` 전이 메서드 5개를 제거함

## 테스트
```
npm run greenlight
npm --prefix back run test:unit
npm --prefix back run test:lua   # 실제 Redis 대상 필요
```

테이블과 구현이 어긋나면 실제로 막히는지 확인함.

| 시나리오 | 결과 |
|---|---|
| `markReconnectingSelection` 행 삭제 | 모듈 로드 시점에 throw (`INVALID_TRANSITION`) — 부팅 실패 |
| 경로별 행의 `from` 변경 | 같은 지점에서 throw |
| 테이블 행 추가·삭제·`to` 변경 | `user-state.fsm.spec.ts`의 테이블 고정이 실패 |

## 특이사항
- 전이 테이블 10행과 구현 6곳의 대응은 다음과 같음. 각 모듈이 로드 시점에 테이블에서 from/to를 유도하므로 **구현이 테이블에 없는 전이를 주장하면 부팅이 실패**함. 아래 표는 그 결과를 읽기 좋게 정리한 참고용이며, 표 자체를 검사하는 장치는 두지 않음.

  | 테이블 행 | 구현 |
  |---|---|
  | `enterWaiting` LOGIN→WAITING | `waitingQueueEntryLua` |
  | `enterBookingGate` LOGIN→ENTERING | `admissionCapacityLua` (즉시 입장) |
  | `enterBookingGate` WAITING→ENTERING | `admissionCapacityLua` (대기열 head 승격) |
  | `startSeatSelection` ENTERING→SELECTING_SEAT | `startSeatSelectionLua` |
  | `markReconnectingSelection` | `reconnectingTransitionLua` (재연결 표시) |
  | `restoreSeatSelection` | `reconnectingTransitionLua` (재연결 복원) |
  | `resetToLogin` ×4행 | `userStateTransitionLua` (기반 runner) |

- **`from`과 `to`의 검증 위치가 다름.** `from`은 Lua 안에서 저장된 세션 상태와 대조해 어긋나면 `STATE_MISMATCH`로 실패함(런타임 매 요청). `to`는 핫패스에서 되읽지 않고 스크립트의 `OK` 응답을 신뢰해 `nextTo`를 그대로 결과로 돌려줌 — 확인용 왕복을 한 번 더 하지 않기 위함. 그 신뢰의 근거는 `npm --prefix back run test:lua`가 댐: 실제 Redis에 스크립트를 돌린 뒤 세션을 되읽어 `userStatus`가 실제로 `to`인지 직접 확인함. 요약하면 **`from`은 런타임에서, `to`는 실물 스크립트 테스트에서** 지켜짐.

- 반대 방향(테이블에 행이 있는데 구현이 없음)은 강제하지 않음. 경로별 행이면 호출자가 없어 런타임 영향이 없고, `resetToLogin` 행이면 기반 runner가 세션의 실제 상태를 테이블에 대조하므로(`auth.service.ts`) 행 추가가 곧 권한 확대임. 이 경우는 `user-state.fsm.spec.ts`의 테이블 고정을 함께 고쳐야 하므로 리뷰를 거치게 됨.
